### PR TITLE
implement audio URL fetching and configuration updates

### DIFF
--- a/echo/.cursor/mcp.json
+++ b/echo/.cursor/mcp.json
@@ -1,0 +1,17 @@
+{
+	"mcpServers": {
+		"playwright": {
+			"command": "npx",
+			"args": [
+				"-y",
+				"@executeautomation/playwright-mcp-server"
+			]
+		},
+		"fetch": {
+			"command": "uvx",
+			"args": [
+				"mcp-server-fetch"
+			]
+		}
+	}
+}

--- a/echo/frontend/src/components/conversation/ConversationChunkAudioTranscript.tsx
+++ b/echo/frontend/src/components/conversation/ConversationChunkAudioTranscript.tsx
@@ -1,8 +1,8 @@
 import { t } from "@lingui/core/macro";
-import { Text, Divider } from "@mantine/core";
+import { Text, Divider, Skeleton } from "@mantine/core";
 
 import { BaseMessage } from "../chat/BaseMessage";
-import { getConversationChunkContentLink } from "@/lib/api";
+import { useConversationChunkContentUrl } from "@/lib/query";
 
 export const ConversationChunkAudioTranscript = ({
   chunk,
@@ -11,10 +11,13 @@ export const ConversationChunkAudioTranscript = ({
   chunk: ConversationChunk;
   showAudioPlayer?: boolean;
 }) => {
-  const src = getConversationChunkContentLink(
+  // Fetch the direct audio URL instead of using a redirect
+  const audioUrlQuery = useConversationChunkContentUrl(
     chunk.conversation_id as string,
     chunk.id,
+    showAudioPlayer, // Only fetch if we need to show the player
   );
+
   return (
     <BaseMessage
       title={t`Speaker`}
@@ -27,13 +30,20 @@ export const ConversationChunkAudioTranscript = ({
         showAudioPlayer ? (
           <>
             <Divider />
-            <audio
-              src={src}
-              className="h-6 w-full p-0"
-              preload=""
-              crossOrigin="use-credentials"
-              controls
-            />
+            {audioUrlQuery.isLoading ? (
+              <Skeleton height={36} width="100%" />
+            ) : audioUrlQuery.isError ? (
+              <Text size="xs" color="red">
+                Failed to load audio
+              </Text>
+            ) : (
+              <audio
+                src={audioUrlQuery.data}
+                className="h-6 w-full p-0"
+                preload="none"
+                controls
+              />
+            )}
           </>
         ) : (
           <> </>

--- a/echo/frontend/src/lib/api.ts
+++ b/echo/frontend/src/lib/api.ts
@@ -422,8 +422,9 @@ export const getConversationContentLink = (conversationId: string) =>
 export const getConversationChunkContentLink = (
   conversationId: string,
   chunkId: string,
+  returnUrl: boolean = false,
 ) =>
-  `${apiCommonConfig.baseURL}/conversations/${conversationId}/chunks/${chunkId}/content`;
+  `${apiCommonConfig.baseURL}/conversations/${conversationId}/chunks/${chunkId}/content${returnUrl ? "?return_url=true" : ""}`;
 
 export const generateProjectLibrary = async (payload: {
   projectId: string;

--- a/echo/frontend/src/lib/query.ts
+++ b/echo/frontend/src/lib/query.ts
@@ -12,12 +12,14 @@ import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import {
   addChatContext,
   api,
+  apiNoAuth,
   createProjectReport,
   deleteChatContext,
   deleteResourceById,
   generateProjectLibrary as generateProjectLibrary,
   generateProjectView,
   getChatHistory,
+  getConversationChunkContentLink,
   getConversationTranscriptString,
   getLatestProjectAnalysisRunByProjectId,
   getProjectChatContext,
@@ -1739,5 +1741,26 @@ export const useProjectReportTimelineData = (projectReportId: string) => {
         projectReportMetrics,
       };
     },
+  });
+};
+
+export const useConversationChunkContentUrl = (
+  conversationId: string,
+  chunkId: string,
+  enabled: boolean = true,
+) => {
+  return useQuery({
+    queryKey: ["conversation", conversationId, "chunk", chunkId, "audio-url"],
+    queryFn: async () => {
+      const url = getConversationChunkContentLink(
+        conversationId,
+        chunkId,
+        true,
+      );
+      return apiNoAuth.get<unknown, string>(url);
+    },
+    enabled,
+    staleTime: 1000 * 60 * 30, // 30 minutes
+    gcTime: 1000 * 60 * 60, // 1 hour
   });
 };


### PR DESCRIPTION
- Add new mcp.json configuration for MCP servers.
- Refactor audio transcript component to use `useConversationChunkContentUrl` for fetching audio URLs.
- Update API functions to support returning direct audio URLs.
- Enhance server-side conversation content retrieval to optionally return signed URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced conversation audio playback: users now see dynamic loading indicators and clear error notifications when audio content is being fetched.
  - Optimized media streaming for faster, more reliable audio delivery through improved asynchronous retrieval and caching mechanisms.
  - Refined content delivery provides a smoother and more responsive audio experience during conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->