### PR TITLE
ECHO-172 Bottom chat menu made sticky on medium screens and larger

### DIFF
--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -407,7 +407,7 @@ export const ProjectChatRoute = () => {
         </Stack>
       </Box>
       {/* Footer */}
-      <Box className="bottom-0 w-full border-t bg-white py-4 lg:sticky">
+      <Box className="bottom-0 w-full border-t bg-white py-4 md:sticky">
         <Stack>
           {(!ENABLE_CHAT_AUTO_SELECT
             ? noConversationsSelected


### PR DESCRIPTION
- Update ProjectChatRoute to change footer positioning from 'lg:sticky' to 'md:sticky'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the chat footer to become sticky starting at medium screen sizes instead of large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->