### PR TITLE
Implement uncompressed audio file size calculation from S3 and refactor audio processing logic

### DIFF
--- a/echo/server/dembrane/audio_lightrag/pipelines/audio_etl_pipeline.py
+++ b/echo/server/dembrane/audio_lightrag/pipelines/audio_etl_pipeline.py
@@ -27,7 +27,6 @@ class AudioETLPipeline:
 
         Args:
         - process_tracker (ProcessTracker): Instance to track the process.
-        - config_path (str): Path to the configuration file.
 
         Returns:
         - None

--- a/echo/server/dembrane/audio_lightrag/pipelines/audio_etl_pipeline.py
+++ b/echo/server/dembrane/audio_lightrag/pipelines/audio_etl_pipeline.py
@@ -20,10 +20,8 @@ logger = logging.getLogger(__name__)
 class AudioETLPipeline:
     def __init__(
         self,
-        process_tracker: ProcessTracker,
-        # config_path: str = "server/dembrane/audio_lightrag/configs/audio_etl_pipeline_config.yaml",
-        # config_path: str = os.path.join(BASE_DIR, "dembrane/audio_lightrag/configs/audio_etl_pipeline_config.yaml"),
-    ) -> None:
+        process_tracker: ProcessTracker
+        ) -> None:
         """
         Initialize the AudioETLPipeline.
 
@@ -74,6 +72,7 @@ class AudioETLPipeline:
                         configid=self.configid,
                         max_size_mb=float(self.max_size_mb),
                         counter=counter,
+                        process_tracker_df=transform_audio_process_tracker_df
                     )
                     
                     for chunk_id, segment_id in chunk_id_2_segment_temp:

--- a/echo/server/dembrane/audio_lightrag/utils/audio_utils.py
+++ b/echo/server/dembrane/audio_lightrag/utils/audio_utils.py
@@ -41,7 +41,7 @@ def _read_mp3_from_s3_and_get_wav_file_size(uri: str, format: str = "mp3") -> fl
         return wav_size_mb
 
     except Exception as e:
-        raise e
+        raise Exception(f"Error calculating WAV size for {uri}: {str(e)}") from e
 
 def get_audio_file_size(path: str) -> float:
     size_mb = os.path.getsize(path) / (1024 * 1024)  # Convert bytes to MB

--- a/echo/server/dembrane/audio_lightrag/utils/audio_utils.py
+++ b/echo/server/dembrane/audio_lightrag/utils/audio_utils.py
@@ -1,3 +1,4 @@
+import io
 import os
 import base64
 from io import BytesIO
@@ -8,10 +9,39 @@ from pydub import AudioSegment
 from dembrane.s3 import (
     save_audio_to_s3,
     get_stream_from_s3,
-    get_uncompressed_audio_file_size_from_s3_mb,
 )
 from dembrane.directus import directus
 
+
+def _read_mp3_from_s3_and_get_wav_file_size(uri: str, format: str = "mp3") -> float:
+    """
+    Calculate the size of an audio file stored in S3 when converted to WAV format.
+    This is useful for estimating the memory usage when loading audio files for processing.
+    
+    Args:
+        uri (str): The URI of the audio file in S3
+        format (str): The format of the stored audio file (default: "mp3")
+        
+    Returns:
+        float: The size of the audio in WAV format in MB
+    """
+    audio_stream = get_stream_from_s3(uri)
+    
+    try:
+        # Load the audio file from S3 into an AudioSegment
+        audio = AudioSegment.from_file(io.BytesIO(audio_stream.read()), format=format)
+        
+        # Export to WAV to calculate uncompressed size
+        wav_buffer = io.BytesIO()
+        audio.export(wav_buffer, format="wav")
+
+        # Calculate size in MB
+        wav_size_mb = len(wav_buffer.getvalue()) / (1024 * 1024)
+
+        return wav_size_mb
+
+    except Exception as e:
+        raise e
 
 def get_audio_file_size(path: str) -> float:
     size_mb = os.path.getsize(path) / (1024 * 1024)  # Convert bytes to MB
@@ -35,6 +65,19 @@ def process_audio_files(
     A segment is maximum mb permitted in the model being used.
     Ensures all files are segmented close to max_size_mb.
     **** File might be a little larger than max_size_mb
+    Args:
+        unprocessed_chunk_file_uri_li (list[str]):
+            List of unprocessed chunk file uris in order of processing
+        max_size_mb (float):
+            Maximum size of a segment in MB
+        configid (str):
+            The config id of the segment
+        counter (int):
+            The counter for the next segment id
+        process_tracker_df (pd.DataFrame):
+            The process tracker dataframe
+        format (str):
+            The format of the audio file
     Returns:
         unprocessed_chunk_file_uri_li: list[str]:
             List of unprocessed chunk file uris
@@ -42,11 +85,12 @@ def process_audio_files(
             List of chunk ids and segment ids
         counter: int:
             Counter for the next segment id
+
     """
     process_tracker_df = process_tracker_df[process_tracker_df['path'].isin(unprocessed_chunk_file_uri_li)]
     process_tracker_df = process_tracker_df.sort_values(by='timestamp')
     chunk_id_2_uri = dict(process_tracker_df[['chunk_id', 'path']].values)
-    chunk_id_2_size = {chunk_id: get_uncompressed_audio_file_size_from_s3_mb(uri) for chunk_id, uri in chunk_id_2_uri.items()}
+    chunk_id_2_size = {chunk_id: _read_mp3_from_s3_and_get_wav_file_size(uri) for chunk_id, uri in chunk_id_2_uri.items()}
     chunk_id = list(chunk_id_2_size.keys())[0]
     chunk_id_2_segment = []
     segment_2_path = {}

--- a/echo/server/dembrane/s3.py
+++ b/echo/server/dembrane/s3.py
@@ -212,35 +212,3 @@ def save_audio_to_s3(audio: AudioSegment, file_name: str, public: bool = False) 
     s3_url = save_to_s3_from_file_like(file_like, file_name, public)
     return s3_url
 
-def get_uncompressed_audio_file_size_from_s3_mb(uri: str, format: str = "mp3") -> float:
-    """
-    Calculate the size of an audio file stored in S3 when converted to MP3 format.
-    This is useful for estimating the memory usage when loading audio files for processing.
-    
-    Args:
-        uri (str): The URI of the audio file in S3
-        format (str): The format of the stored audio file (default: "mp3")
-        
-    Returns:
-        float: The size of the audio in MP3 format in MB
-    """
-    audio_stream = get_stream_from_s3(uri)
-    
-    try:
-        # Load the audio file from S3 into an AudioSegment
-        audio = AudioSegment.from_file(io.BytesIO(audio_stream.read()), format=format)
-        
-        # Export to WAV to calculate uncompressed size
-        wav_buffer = io.BytesIO()
-        audio.export(wav_buffer, format="wav")
-
-        # Calculate size in MB
-        wav_size_mb = len(wav_buffer.getvalue()) / (1024 * 1024)
-
-        return wav_size_mb
-
-    except Exception as e:
-        logger.warning(f"Error calculating MP3 audio size for {uri}: {str(e)}")
-        # Fallback to the compressed size with a small multiplier as estimation
-        return get_file_size_from_s3_mb(uri) * 1.5
-


### PR DESCRIPTION
- Added a new function get_uncompressed_audio_file_size_from_s3_mb to calculate the size of audio files in uncompressed WAV format, improving memory usage estimation for audio processing.
- Updated process_audio_files to utilize the new function for determining file sizes, enhancing accuracy in segmenting audio files.
- Refactored imports in audio_utils.py to include the new size calculation function and removed unused imports for better code clarity.
- Minor adjustments in AudioETLPipeline initialization to streamline the process tracker integration.

ECHO-198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to calculate and use uncompressed audio file sizes when processing audio files from S3, improving accuracy in file size handling.
  - Enhanced audio processing by explicitly passing updated process tracking information during transformations.

- **Bug Fixes**
  - Improved the process for tracking and updating the state of audio file processing, ensuring more reliable management of processing steps.

- **Chores**
  - Removed redundant comments and simplified code for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->