### PR TITLE
ECHO-245 Add deep chunks configuration to ConversationAccordion component

### DIFF
--- a/echo/frontend/src/components/conversation/ConversationAccordion.tsx
+++ b/echo/frontend/src/components/conversation/ConversationAccordion.tsx
@@ -593,6 +593,12 @@ export const ConversationAccordion = ({ projectId }: { projectId: string }) => {
     false,
     {
       limit: 1,
+      deep: {
+        // @ts-expect-error chunks is not typed
+        chunks: {
+          _limit: 25,
+        },
+      },
     },
   );
 
@@ -642,6 +648,12 @@ export const ConversationAccordion = ({ projectId }: { projectId: string }) => {
     {
       search: debouncedConversationSearchValue,
       sort: sortBy,
+      deep: {
+        // @ts-expect-error chunks is not typed
+        chunks: {
+          _limit: 25,
+        },
+      },
     },
     // Temporarily disabled source filters
     // filterBySource,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation loading by ensuring up to 25 related chunks are fetched for each conversation in the conversation list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->