### PR TITLE
add load testing for runpod

### DIFF
--- a/echo/server/tests/k6_load_testing/.gitignore
+++ b/echo/server/tests/k6_load_testing/.gitignore
@@ -1,0 +1,21 @@
+# Environment files
+.env
+
+# Results directory
+results/
+*.json
+
+# Logs
+*.log
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Docker volumes
+docker-data/ 

--- a/echo/server/tests/k6_load_testing/env.example
+++ b/echo/server/tests/k6_load_testing/env.example
@@ -1,0 +1,9 @@
+# RunPod API Configuration
+RUNPOD_API_KEY=your_api_key_here
+RUNPOD_ENDPOINT_ID=your_endpoint_id_here
+
+# Test Configuration
+AUDIO_URL=https://github.com/runpod-workers/sample-inputs/raw/refs/heads/main/audio/Arthur.mp3
+BASE_URL=https://api.runpod.ai/v2
+WHISPER_MODEL=large-v3
+INITIAL_PROMPT=This is a test transcription. 

--- a/echo/server/tests/k6_load_testing/run-tests.sh
+++ b/echo/server/tests/k6_load_testing/run-tests.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+# K6 Load Testing Runner for RunPod API (Unified Script)
+# Usage: ./run-tests.sh [test-type] [options]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+TEST_TYPE="smoke"
+RESULTS_DIR="./results"
+DOCKER_IMAGE="grafana/k6:latest"
+K6_SCRIPT="scripts/k6_runpod_transcribe.js"
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 [test-type] [options]"
+    echo ""
+    echo "Test Types:"
+    echo "  smoke     - Basic functionality test (default)"
+    echo "  load      - Standard load test"
+    echo "  stress    - Stress test to find breaking points"
+    echo "  spike     - Spike test for sudden load increases"
+    echo "  all       - Run all test types sequentially"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help     Show this help message"
+    echo "  -c, --clean    Clean results directory before running"
+    echo "  -v, --verbose  Verbose output"
+    echo ""
+    echo "Examples:"
+    echo "  $0 smoke"
+    echo "  $0 load --clean"
+    echo "  $0 stress -v"
+    echo "  $0 all"
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+    
+    # Check if Docker is installed and running
+    if ! command -v docker &> /dev/null; then
+        print_error "Docker is not installed. Please install Docker first."
+        exit 1
+    fi
+    
+    if ! docker info &> /dev/null; then
+        print_error "Docker is not running. Please start Docker first."
+        exit 1
+    fi
+    
+    # Check if .env file exists
+    if [ ! -f ".env" ]; then
+        print_error ".env file not found. Please create it from env.example"
+        print_status "Run: cp env.example .env"
+        print_status "Then edit .env with your RunPod API key and config."
+        exit 1
+    fi
+    
+    # Check if API key is set
+    if ! grep -q "RUNPOD_API_KEY=.*[^[:space:]]" .env; then
+        print_error "RUNPOD_API_KEY is not set in .env file"
+        exit 1
+    fi
+    print_success "Prerequisites check passed"
+}
+
+# Function to create results directory
+setup_results_dir() {
+    if [ "$CLEAN_RESULTS" = true ]; then
+        print_status "Cleaning results directory..."
+        rm -rf "$RESULTS_DIR"
+    fi
+    
+    mkdir -p "$RESULTS_DIR"
+    print_status "Results will be saved to: $RESULTS_DIR"
+}
+
+# Function to run the test
+run_test() {
+    print_status "Running $TEST_TYPE test..."
+    print_status "Script: $K6_SCRIPT"
+
+    # Compose docker run command
+    local docker_cmd="docker run --rm"
+    docker_cmd="$docker_cmd -v $(pwd)/scripts:/scripts"
+    docker_cmd="$docker_cmd -v $(pwd)/$RESULTS_DIR:/results"
+    docker_cmd="$docker_cmd --env-file .env"
+    docker_cmd="$docker_cmd -e TEST_TYPE=$TEST_TYPE"
+    if [ "$VERBOSE" = true ]; then
+        docker_cmd="$docker_cmd -e K6_LOG_LEVEL=debug"
+    fi
+    docker_cmd="$docker_cmd $DOCKER_IMAGE run"
+    docker_cmd="$docker_cmd --out json=/results/${TEST_TYPE}-test-results.json"
+    docker_cmd="$docker_cmd /$K6_SCRIPT"
+
+    print_status "Executing: $docker_cmd"
+
+    # Run the test
+    if eval $docker_cmd; then
+        print_success "$TEST_TYPE test completed successfully"
+        print_status "Results saved to: $RESULTS_DIR/${TEST_TYPE}-test-results.json"
+    else
+        print_error "$TEST_TYPE test failed"
+        exit 1
+    fi
+}
+
+# Function to run all tests
+run_all_tests() {
+    local tests=("smoke" "load" "stress" "spike")
+    print_status "Running all test types..."
+    for test in "${tests[@]}"; do
+        TEST_TYPE="$test"
+        print_status "Starting $test test..."
+        run_test
+        print_success "$test test completed"
+        echo ""
+    done
+    print_success "All tests completed!"
+}
+
+# Parse command line arguments
+CLEAN_RESULTS=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        smoke|load|stress|spike)
+            TEST_TYPE="$1"
+            shift
+            ;;
+        all)
+            TEST_TYPE="all"
+            shift
+            ;;
+        -c|--clean)
+            CLEAN_RESULTS=true
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            show_usage
+            exit 1
+            ;;
+    esac
+    done
+
+# Main execution
+main() {
+    print_status "K6 Load Testing for RunPod API (Unified Script)"
+    print_status "Test type: $TEST_TYPE"
+    echo ""
+    check_prerequisites
+    setup_results_dir
+    if [ "$TEST_TYPE" = "all" ]; then
+        run_all_tests
+    else
+        run_test
+    fi
+    print_success "Testing completed!"
+}
+
+# Run main function
+main 

--- a/echo/server/tests/k6_load_testing/scripts/k6_runpod_transcribe.js
+++ b/echo/server/tests/k6_load_testing/scripts/k6_runpod_transcribe.js
@@ -1,0 +1,125 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Read config from environment variables
+const RUNPOD_API_KEY = __ENV.RUNPOD_API_KEY;
+const RUNPOD_ENDPOINT_ID = __ENV.RUNPOD_ENDPOINT_ID;
+const AUDIO_URL = __ENV.AUDIO_URL;
+const BASE_URL = __ENV.BASE_URL || 'https://api.runpod.ai/v2';
+const WHISPER_MODEL = __ENV.WHISPER_MODEL || 'large-v3';
+const INITIAL_PROMPT = __ENV.INITIAL_PROMPT || '';
+const POLL_INTERVAL = parseInt(__ENV.POLL_INTERVAL || '10', 10); // seconds
+const POLL_TIMEOUT = parseInt(__ENV.POLL_TIMEOUT || '1000', 10); // seconds
+
+if (!RUNPOD_API_KEY || !RUNPOD_ENDPOINT_ID || !AUDIO_URL) {
+  throw new Error(
+    'Missing required environment variables: RUNPOD_API_KEY, RUNPOD_ENDPOINT_ID, AUDIO_URL'
+  );
+}
+
+// Choose scenario via TEST_TYPE env var: 'smoke', 'load', 'spike', 'stress'
+const TEST_TYPE = (__ENV.TEST_TYPE || 'smoke').toLowerCase();
+
+let options = {};
+switch (TEST_TYPE) {
+  case 'smoke':
+    options = {
+      vus: 1,
+      iterations: 1,
+    };
+    break;
+  case 'load':
+    options = {
+      vus: 500,
+      duration: '10m',
+    };
+    break;
+  case 'spike':
+    options = {
+      stages: [
+        { duration: '30s', target: 1 },
+        { duration: '5m', target: 500 },
+        { duration: '30s', target: 1 },
+      ],
+    };
+    break;
+  case 'stress':
+    options = {
+      stages: [
+        { duration: '2m', target: 1500 },
+        { duration: '4m', target: 0 },
+      ],
+    };
+    break;
+  default:
+    options = { vus: 1, iterations: 1 };
+}
+
+export { options };
+
+// Parse AUDIO_URL for multiple files
+let audioFiles = [AUDIO_URL];
+if (AUDIO_URL.includes(',')) {
+  audioFiles = AUDIO_URL.split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+}
+
+function submitTranscriptionJob() {
+  // Randomly select an audio file if multiple are provided
+  const selectedAudio =
+    audioFiles.length > 1
+      ? audioFiles[Math.floor(Math.random() * audioFiles.length)]
+      : audioFiles[0];
+  const url = `${BASE_URL}/${RUNPOD_ENDPOINT_ID}/run`;
+  const headers = {
+    Authorization: `Bearer ${RUNPOD_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+  const payload = JSON.stringify({
+    input: {
+      audio: selectedAudio,
+      model: WHISPER_MODEL,
+      initial_prompt: INITIAL_PROMPT,
+      language: 'en',
+    },
+  });
+  const res = http.post(url, payload, { headers });
+  check(res, {
+    'job submitted': (r) => r.status === 200 && r.json('id'),
+  });
+  return res.json('id');
+}
+
+function pollStatus(jobId) {
+  const statusUrl = `${BASE_URL}/${RUNPOD_ENDPOINT_ID}/status/${jobId}`;
+  const headers = {
+    Authorization: `Bearer ${RUNPOD_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+  let waited = 0;
+  while (waited < POLL_TIMEOUT) {
+    const res = http.get(statusUrl, { headers });
+    const status = res.json('status');
+    if (status === 'COMPLETED') {
+      check(res, {
+        'transcription completed': (r) => !!r.json('output.transcription'),
+      });
+      return res.json('output.transcription');
+    } else if (status === 'FAILED') {
+      check(res, { 'transcription failed': () => false });
+      return null;
+    }
+    sleep(POLL_INTERVAL);
+    waited += POLL_INTERVAL;
+  }
+  check(null, { 'timeout waiting for transcription': () => false });
+  return null;
+}
+
+export default function () {
+  const jobId = submitTranscriptionJob();
+  if (jobId) {
+    pollStatus(jobId);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a load testing suite for the RunPod API, including a shell script to orchestrate different test types and a k6 script for transcription endpoint testing.
  - Added an example environment configuration file to simplify setup for load testing.
- **Chores**
  - Added a `.gitignore` to exclude sensitive and generated files from version control in the load testing directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->