### PR TITLE
Disable mode selection when Dembrane Echo is disabled

### DIFF
--- a/echo/frontend/src/components/project/ProjectPortalEditor.tsx
+++ b/echo/frontend/src/components/project/ProjectPortalEditor.tsx
@@ -181,6 +181,11 @@ const ProjectPortalEditorComponent: React.FC<{ project: Project }> = ({
     name: "get_reply_mode",
   });
 
+  const watchedReplyEnabled = useWatch({
+    control,
+    name: "is_get_reply_enabled",
+  });
+
   const updateProjectMutation = useUpdateProjectByIdMutation();
 
   const onSave = useCallback(
@@ -436,37 +441,46 @@ const ProjectPortalEditorComponent: React.FC<{ project: Project }> = ({
                         </Text>
                         <Group gap="xs">
                           <Badge
-                            className="cursor-pointer capitalize"
+                            className={watchedReplyEnabled ? "cursor-pointer capitalize" : "capitalize"}
                             variant={
                               field.value === "summarize" ? "filled" : "default"
                             }
                             size="lg"
-                            style={{ cursor: "pointer" }}
-                            onClick={() => field.onChange("summarize")}
+                            style={{ 
+                              cursor: watchedReplyEnabled ? "pointer" : "not-allowed",
+                              opacity: watchedReplyEnabled ? 1 : 0.6
+                            }}
+                            onClick={() => watchedReplyEnabled && field.onChange("summarize")}
                           >
                             <Trans>Summarize</Trans>
                           </Badge>
                           <Badge
-                            className="cursor-pointer capitalize"
+                            className={watchedReplyEnabled ? "cursor-pointer capitalize" : "capitalize"}
                             variant={
                               field.value === "brainstorm"
                                 ? "filled"
                                 : "default"
                             }
                             size="lg"
-                            style={{ cursor: "pointer" }}
-                            onClick={() => field.onChange("brainstorm")}
+                            style={{ 
+                              cursor: watchedReplyEnabled ? "pointer" : "not-allowed",
+                              opacity: watchedReplyEnabled ? 1 : 0.6
+                            }}
+                            onClick={() => watchedReplyEnabled && field.onChange("brainstorm")}
                           >
                             <Trans>Brainstorm Ideas</Trans>
                           </Badge>
                           <Badge
-                            className="cursor-pointer capitalize"
+                            className={watchedReplyEnabled ? "cursor-pointer capitalize" : "capitalize"}
                             variant={
                               field.value === "custom" ? "filled" : "default"
                             }
                             size="lg"
-                            style={{ cursor: "pointer" }}
-                            onClick={() => field.onChange("custom")}
+                            style={{ 
+                              cursor: watchedReplyEnabled ? "pointer" : "not-allowed",
+                              opacity: watchedReplyEnabled ? 1 : 0.6
+                            }}
+                            onClick={() => watchedReplyEnabled && field.onChange("custom")}
                           >
                             <Trans>Custom</Trans>
                           </Badge>
@@ -499,6 +513,7 @@ const ProjectPortalEditorComponent: React.FC<{ project: Project }> = ({
                           }
                           autosize
                           minRows={5}
+                          disabled={!watchedReplyEnabled}
                           {...field}
                         />
                       )}


### PR DESCRIPTION
## Summary
- Disables the mode selection badges when the "Enable Dembrane Echo" switch is turned off
- Provides clear visual feedback with reduced opacity and disabled cursor states
- Prevents users from changing modes when Echo functionality is not enabled

## Changes
- Added watcher for `is_get_reply_enabled` field to monitor Echo toggle state
- Updated mode selection badges to be disabled when Echo is disabled
- Applied visual feedback (60% opacity, not-allowed cursor) to disabled states
- Disabled custom prompt textarea when Echo is disabled
- Improved UX by clearly indicating when mode selection is unavailable

## Test plan
- [ ] Navigate to Portal Editor for any project
- [ ] Verify mode selection works when "Enable Dembrane Echo" is ON
- [ ] Toggle "Enable Dembrane Echo" to OFF
- [ ] Verify mode badges become disabled with visual feedback
- [ ] Verify custom prompt textarea is disabled when Echo is off
- [ ] Confirm badges are not clickable when disabled

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to enable or disable reply mode selection and prompt editing based on a new setting.
- **Style**
  - Updated the appearance and interactivity of reply mode badges and prompt fields when the reply feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->