### PR TITLE
fix webhooks

### DIFF
--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -275,6 +275,7 @@ async def delete_conversation(payload: DeleteConversationRequest,
 async def transcribe_webhook(payload: dict) -> None:
     logger = getLogger("stateless.webhook.transcribe")
     logger.debug(f"Transcribe webhook received: {payload}")
+    logger.info(f"Transcribe webhook received: {payload['output']['conversation_chunk_id']}")
     try:
         directus.update_item(
             collection_name="conversation_chunk",

--- a/echo/server/dembrane/transcribe.py
+++ b/echo/server/dembrane/transcribe.py
@@ -38,6 +38,7 @@ def queue_transcribe_audio_runpod(
     language: Optional[str],
     whisper_prompt: Optional[str],
     is_priority: bool = False,
+    conversation_chunk_id: Optional[str] = "",
 ) -> str:
     """Transcribe audio using RunPod"""
     logger = logging.getLogger("transcribe.transcribe_audio_runpod")
@@ -52,6 +53,7 @@ def queue_transcribe_audio_runpod(
         input_payload = {
             "audio": signed_url,
             "initial_prompt": whisper_prompt,
+            "conversation_chunk_id": conversation_chunk_id,
         }
 
         if language:
@@ -272,6 +274,7 @@ def _process_runpod_transcription(
         language=language,
         whisper_prompt=whisper_prompt,
         is_priority=is_priority,
+        conversation_chunk_id=conversation_chunk_id,
     )
 
     directus.update_item(


### PR DESCRIPTION
- Introduced conversation_chunk_id as an optional parameter in queue_transcribe_audio_runpod function to improve audio transcription context.
- Updated payload structure to include conversation_chunk_id for better tracking during transcription.
- Enhanced logging in transcribe_webhook to include conversation_chunk_id for improved debugging and monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved logging to include conversation chunk identifiers for better traceability during transcription.
- **Enhancements**
  - Transcription requests now support passing a conversation chunk identifier, enabling more precise tracking of audio segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->