### PR TITLE
ECHO-233 Refactor base URL constants in App and config files to hostname

### DIFF
--- a/echo/frontend/src/App.tsx
+++ b/echo/frontend/src/App.tsx
@@ -8,8 +8,8 @@ import { RouterProvider } from "react-router-dom";
 import { I18nProvider } from "./components/layout/I18nProvider";
 import { mainRouter, participantRouter } from "./Router";
 import {
-  ADMIN_BASE_URL,
-  PARTICIPANT_BASE_URL,
+  ADMIN_HOSTNAME,
+  PARTICIPANT_HOSTNAME,
   PLAUSIBLE_API_HOST,
   USE_PARTICIPANT_ROUTER,
 } from "./config";
@@ -24,7 +24,7 @@ const router = USE_PARTICIPANT_ROUTER ? participantRouter : mainRouter;
 export const App = () => {
   useEffect(() => {
     const { enableAutoPageviews } = Plausible({
-      domain: USE_PARTICIPANT_ROUTER ? PARTICIPANT_BASE_URL : ADMIN_BASE_URL,
+      domain: USE_PARTICIPANT_ROUTER ? PARTICIPANT_HOSTNAME : ADMIN_HOSTNAME,
       apiHost: PLAUSIBLE_API_HOST,
     });
 

--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -2,8 +2,12 @@ export const USE_PARTICIPANT_ROUTER =
   import.meta.env.VITE_USE_PARTICIPANT_ROUTER === "1";
 export const ADMIN_BASE_URL =
   import.meta.env.VITE_ADMIN_BASE_URL ?? window.location.origin;
+export const ADMIN_HOSTNAME =
+  import.meta.env.VITE_ADMIN_HOSTNAME ?? window.location.hostname;
 export const PARTICIPANT_BASE_URL =
   import.meta.env.VITE_PARTICIPANT_BASE_URL ?? window.location.origin;
+export const PARTICIPANT_HOSTNAME =
+  import.meta.env.VITE_PARTICIPANT_HOSTNAME ?? window.location.hostname;
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
 
 export const DIRECTUS_PUBLIC_URL =


### PR DESCRIPTION
- Updated App.tsx to use ADMIN_HOSTNAME and PARTICIPANT_HOSTNAME instead of ADMIN_BASE_URL and PARTICIPANT_BASE_URL for Plausible tracking.
- Added ADMIN_HOSTNAME and PARTICIPANT_HOSTNAME constants in config.ts to retrieve values from environment variables, enhancing clarity and consistency in URL handling.