### PR TITLE
Add Content-Type and X-Accel-Buffering headers in get_reply_for_conversation

### DIFF
--- a/echo/server/dembrane/api/conversation.py
+++ b/echo/server/dembrane/api/conversation.py
@@ -448,6 +448,8 @@ async def get_reply_for_conversation(
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
+            "Content-Type": "text/event-stream",
+            "X-Accel-Buffering": "no",
         },
     )
 


### PR DESCRIPTION
- Updated the headers in the get_reply_for_conversation function to include "Content-Type" set to "text/event-stream" and "X-Accel-Buffering" set to "no", improving the handling of server-sent events.