### PR TITLE
ECHO-322 Hide "share" button on desktop 

### DIFF
--- a/echo/frontend/src/components/project/ProjectQRCode.tsx
+++ b/echo/frontend/src/components/project/ProjectQRCode.tsx
@@ -90,6 +90,7 @@ export const ProjectQRCode = ({ project }: ProjectQRCodeProps) => {
           <div className="flex flex-col flex-wrap gap-2">
             {canShare && (
               <Button
+                className="lg:hidden"
                 size="sm"
                 rightSection={<IconShare style={{ width: rem(16) }} />}
                 variant="outline"

--- a/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
+++ b/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
@@ -191,6 +191,7 @@ export const ProjectReportRoute = () => {
                     variant="transparent"
                     color="gray.9"
                     size={24}
+                    className="lg:hidden"
                   >
                     <IconShare2 />
                   </ActionIcon>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated share button and share icon to be hidden on large screens and above, making them visible only on smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->