### PR TITLE
ECHO-366-Update-default-library-generation-prompt-to-recurring-themes

### DIFF
--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -23,6 +23,7 @@ from dembrane.config import (
     RUNPOD_TOPIC_MODELER_API_KEY,
 )
 from dembrane.sentry import init_sentry
+from dembrane.prompts import render_message
 from dembrane.directus import (
     DirectusBadRequest,
     DirectusServerError,
@@ -610,61 +611,17 @@ def task_create_project_library(project_id: str, language: str) -> None:
             logger.error(f"Can retry. Failed to create project analysis run: {e}")
             raise e from e
 
-        DEFAULT_PROMPTS = {
-            "en": [
-                {
-                    "user_query": "Power Plays",
-                    "user_query_context": "Identify who drives conversations, influences decisions, and shapes outcomes. Focus on detecting authority patterns, persuasion dynamics, and organizational hierarchy signals. Analyze speaking time distribution, interruption patterns, and whose ideas get adopted or dismissed. Map the power architecture of decision-making processes. Expected aspects: 3-7 for small datasets, 5-12 for medium datasets, 8-15 for large datasets. Processing hint: Look for distinct power centers, influence networks, and decision-making bottlenecks. Quality threshold: Each aspect should represent a unique power dynamic with clear behavioral evidence.",
-                },
-                {
-                    "user_query": "Smart vs. Loud",
-                    "user_query_context": "Distinguish between evidence-backed arguments and opinion-based statements. Identify participants who support claims with data, examples, and logical reasoning versus those relying on volume, authority, or emotional appeals. Measure argument quality, source credibility, and reasoning depth across different speakers. Expected aspects: 2-5 for small datasets, 4-8 for medium datasets, 6-12 for large datasets. Processing hint: Focus on argument structure, evidence types, and persuasion mechanisms. Quality threshold: Each aspect should demonstrate clear qualitative differences in reasoning approaches.",
-                },
-                {
-                    "user_query": "Mind Changes",
-                    "user_query_context": "Track position shifts, consensus formation, and persuasion effectiveness throughout conversations. Identify moments where participants change their stance, what triggers these shifts, and which arguments successfully influence others. Map the evolution from initial disagreement to final alignment or persistent division. Expected aspects: 2-6 for small datasets, 4-10 for medium datasets, 6-14 for large datasets. Processing hint: Identify temporal patterns, trigger events, and persuasion pathways. Quality threshold: Each aspect should show distinct change mechanisms with clear before/after states.",
-                },
-                {
-                    "user_query": "Trust Signals",
-                    "user_query_context": "Analyze what evidence types, sources, and expertise different participants find credible and compelling. Identify which data sources carry weight, whose opinions influence others, and how different groups validate information. Reveal the implicit credibility hierarchy that drives decision-making. Expected aspects: 3-6 for small datasets, 5-10 for medium datasets, 7-13 for large datasets. Processing hint: Map credibility networks, authority recognition patterns, and validation processes. Quality threshold: Each aspect should represent distinct credibility criteria with supporting behavioral evidence.",
-                },
-                {
-                    "user_query": "Getting Stuff Done",
-                    "user_query_context": "Measure conversation momentum toward actionable outcomes. Track progression from problem identification to concrete solutions, next steps, and ownership assignment. Identify which discussions generate accountability versus those that circle without resolution. Focus on decision-making effectiveness and implementation planning. Expected aspects: 2-5 for small datasets, 3-8 for medium datasets, 5-11 for large datasets. Processing hint: Focus on resolution patterns, accountability mechanisms, and implementation pathways. Quality threshold: Each aspect should demonstrate measurable progress toward concrete outcomes.",
-                },
-            ],
-            "nl": [
-                {
-                    "user_query": "Wie heeft de touwtjes in handen",
-                    "user_query_context": "Kijk wie de gesprekken stuurt, beslissingen beïnvloedt en de uitkomsten bepaalt. Let op wie het meeste spreekt, wie anderen onderbreekt en wiens ideeën worden opgepakt. Breng in kaart hoe de machtsbalans werkt en wie echt de lakens uitdeelt. Verwachte aspecten: 3-7 voor kleine datasets, 5-12 voor middelgrote datasets, 8-15 voor grote datasets. Verwerkingstip: Zoek naar duidelijke machtscentra, invloedsnetwerken en besluitvormingsknelpunten. Kwaliteitsdrempel: Elk aspect moet een unieke machtsdynamiek tonen met duidelijk gedragsbewijs.",
-                },
-                {
-                    "user_query": "Slim praten vs. hard praten",
-                    "user_query_context": "Onderscheid tussen argumenten met bewijs en loze praatjes. Wie ondersteunt hun punt met data en voorbeelden? Wie vertrouwt vooral op volume, status of emoties? Ontdek het verschil tussen echte inhoud en veel lawaai maken. Verwachte aspecten: 2-5 voor kleine datasets, 4-8 voor middelgrote datasets, 6-12 voor grote datasets. Verwerkingstip: Focus op argumentstructuur, bewijstypen en overtuigingsmechanismen. Kwaliteitsdrempel: Elk aspect moet duidelijke kwaliteitsverschillen in redeneerbenaderingen tonen.",
-                },
-                {
-                    "user_query": "Van mening veranderen",
-                    "user_query_context": "Volg wie van standpunt wisselt tijdens gesprekken. Wat zorgt ervoor dat mensen hun mening bijstellen? Welke argumenten werken echt? Zie hoe discussies evoleren van onenigheid naar overeenstemming (of juist niet). Verwachte aspecten: 2-6 voor kleine datasets, 4-10 voor middelgrote datasets, 6-14 voor grote datasets. Verwerkingstip: Identificeer tijdspatronen, trigger events en overtuigingstrajecten. Kwaliteitsdrempel: Elk aspect moet duidelijke veranderingsmechanismen tonen met voor/na situaties.",
-                },
-                {
-                    "user_query": "Wat mensen geloven",
-                    "user_query_context": "Analyseer waar verschillende mensen op vertrouwen. Welke bronnen vinden ze geloofwaardig? Wiens mening telt? Hoe valideren verschillende groepen informatie? Ontdek de onzichtbare geloofwaardigheidshiërarchie die beslissingen stuurt. Verwachte aspecten: 3-6 voor kleine datasets, 5-10 voor middelgrote datasets, 7-13 voor grote datasets. Verwerkingstip: Breng geloofwaardigheidsnetwerken, autoriteitsherkenning en validatieprocessen in kaart. Kwaliteitsdrempel: Elk aspect moet verschillende geloofwaardigheidscriteria tonen met gedragsbewijs.",
-                },
-                {
-                    "user_query": "Shit voor elkaar krijgen",
-                    "user_query_context": "Meet hoe gesprekken leiden tot echte actie. Gaan discussies van probleem naar oplossing? Wie pakt wat op? Welke gesprekken leiden tot resultaat en welke draaien maar rond zonder uitkomst? Focus op wat er daadwerkelijk gebeurt na het praten. Verwachte aspecten: 2-5 voor kleine datasets, 3-8 voor middelgrote datasets, 5-11 voor grote datasets. Verwerkingstip: Focus op oplossingspatronen, verantwoordelijkheidsmechanismen en implementatietrajecten. Kwaliteitsdrempel: Elk aspect moet meetbare vooruitgang naar concrete resultaten tonen.",
-                },
-            ],
-        }
-
+        default_view_name_list = ["default_view_reccuring_themes"]
         messages = []
 
-        for prompt in DEFAULT_PROMPTS[language]:
+        for view_name in default_view_name_list:
+            message = render_message(view_name, language, {}, ["user_query", "user_query_context"])
+            logger.info(f"Message: {message}")
             messages.append(
                 task_create_view.message(
                     project_analysis_run_id=new_run_id,
-                    user_query=prompt["user_query"],
-                    user_query_context=prompt["user_query_context"],
+                    user_query=message["user_query"],
+                    user_query_context=message["user_query_context"],
                     language=language,
                 )
             )

--- a/echo/server/prompt_templates/default_view_reccuring_themes.de.jinja
+++ b/echo/server/prompt_templates/default_view_reccuring_themes.de.jinja
@@ -1,0 +1,4 @@
+{
+    "user_query": "Geben Sie einen Überblick über die Hauptthemen und wiederkehrenden Themen",
+    "user_query_context": "Identifizieren Sie wiederkehrende Themen, Themen und Argumente, die konsistent in den Gesprächen auftreten. Analysieren Sie deren Häufigkeit, Intensität und Konsistenz. Erwartete Ausgabe: 3-7 Aspekte für kleine Datensätze, 5-12 für mittlere Datensätze, 8-15 für große Datensätze. Verarbeitungsrichtlinien: Konzentrieren Sie sich auf eindeutige Muster, die in mehreren Gesprächen auftreten. Qualitätsschwelle: Jeder Aspekt muss ein einzigartiges, konsistent auftretendes Thema mit klaren Belegen für Wiederholung darstellen."
+} 

--- a/echo/server/prompt_templates/default_view_reccuring_themes.en.jinja
+++ b/echo/server/prompt_templates/default_view_reccuring_themes.en.jinja
@@ -1,0 +1,4 @@
+{
+    "user_query": "Provide an overview of the main topics and recurring themes",
+    "user_query_context": "Identify recurring themes, topics, and arguments that appear consistently across conversations. Analyze their frequency, intensity, and consistency. Expected output: 3-7 aspects for small datasets, 5-12 for medium datasets, 8-15 for large datasets. Processing guidance: Focus on distinct patterns that emerge across multiple conversations. Quality threshold: Each aspect must represent a unique, consistently appearing theme with clear evidence of recurrence."
+}

--- a/echo/server/prompt_templates/default_view_reccuring_themes.es.jinja
+++ b/echo/server/prompt_templates/default_view_reccuring_themes.es.jinja
@@ -1,0 +1,4 @@
+{
+    "user_query": "Proporcione una visión general de los temas principales y temas recurrentes",
+    "user_query_context": "Identifique temas recurrentes, tópicos y argumentos que aparecen consistentemente a través de las conversaciones. Analice su frecuencia, intensidad y consistencia. Salida esperada: 3-7 aspectos para conjuntos de datos pequeños, 5-12 para conjuntos de datos medianos, 8-15 para conjuntos de datos grandes. Guía de procesamiento: Enfóquese en patrones distintos que emergen a través de múltiples conversaciones. Umbral de calidad: Cada aspecto debe representar un tema único y consistentemente presente con evidencia clara de recurrencia."
+} 

--- a/echo/server/prompt_templates/default_view_reccuring_themes.fr.jinja
+++ b/echo/server/prompt_templates/default_view_reccuring_themes.fr.jinja
@@ -1,0 +1,4 @@
+{
+    "user_query": "Fournissez un aperçu des sujets principaux et des thèmes récurrents",
+    "user_query_context": "Identifiez les thèmes récurrents, sujets et arguments qui apparaissent de manière cohérente à travers les conversations. Analysez leur fréquence, intensité et cohérence. Sortie attendue : 3-7 aspects pour les petits ensembles de données, 5-12 pour les ensembles moyens, 8-15 pour les grands ensembles. Guidance de traitement : Concentrez-vous sur les modèles distincts qui émergent à travers plusieurs conversations. Seuil de qualité : Chaque aspect doit représenter un thème unique et cohérent avec des preuves claires de récurrence."
+} 

--- a/echo/server/prompt_templates/default_view_reccuring_themes.nl.jinja
+++ b/echo/server/prompt_templates/default_view_reccuring_themes.nl.jinja
@@ -1,0 +1,4 @@
+{
+    "user_query": "Geef een overzicht van de hoofdonderwerpen en terugkerende thema's",
+    "user_query_context": "Identificeer terugkerende thema's, onderwerpen en argumenten die consistent voorkomen in gesprekken. Analyseer hun frequentie, intensiteit en consistentie. Verwachte uitvoer: 3-7 aspecten voor kleine datasets, 5-12 voor middelgrote datasets, 8-15 voor grote datasets. Verwerkingsrichtlijnen: Focus op onderscheidende patronen die opkomen in meerdere gesprekken. Kwaliteitsdrempel: Elk aspect moet een uniek, consistent voorkomend thema vertegenwoordigen met duidelijk bewijs van herhaling."
+} 


### PR DESCRIPTION
Add render_message function and new prompt templates for recurring themes

- Introduced a new function `render_message` in prompts.py to render message templates and validate keys.
- Added default prompt templates for recurring themes in multiple languages (English, Dutch, German, Spanish, French) to enhance conversation analysis capabilities.
- Updated tasks.py to utilize the new `render_message` function for generating messages based on the recurring themes template.