### PR TITLE
ECHO-370 update loading state for create library button

### DIFF
--- a/echo/frontend/src/routes/project/library/ProjectLibrary.tsx
+++ b/echo/frontend/src/routes/project/library/ProjectLibrary.tsx
@@ -181,7 +181,10 @@ export const ProjectLibraryRoute = () => {
               <Button
                 leftSection={!isLibraryEnabled ? <IconLock /> : <IconPlus />}
                 onClick={handleCreateLibrary}
-                loading={requestProjectLibraryMutation.isPending}
+                loading={
+                  requestProjectLibraryMutation.isPending ||
+                  requestProjectLibraryMutation.isSuccess
+                }
                 disabled={
                   // TODO: this should really be a server-side check
                   requestProjectLibraryMutation.isPending ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the loading indicator for the "Create Library" button to remain active during both the request and immediately after a successful creation, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->