### PR TITLE
Hide settings icon participant portal finish page

### DIFF
--- a/echo/frontend/src/components/layout/ParticipantLayout.tsx
+++ b/echo/frontend/src/components/layout/ParticipantLayout.tsx
@@ -57,6 +57,7 @@ export const ParticipantLayout = () => {
                 variant="transparent"
                 onClick={open}
                 title={t`Settings`}
+                aria-label={t`Settings`}
               >
                 <IconSettings size={24} color="gray" />
               </ActionIcon>

--- a/echo/frontend/src/components/layout/ParticipantLayout.tsx
+++ b/echo/frontend/src/components/layout/ParticipantLayout.tsx
@@ -30,7 +30,7 @@ const ParticipantHeader = () => {
 export const ParticipantLayout = () => {
   const { pathname } = useLocation();
   const isReportPage = pathname.includes("report");
-  const isOnboardingPage = pathname.includes("start");
+  const hideSettingsButton = pathname.includes("start") || pathname.includes("finish");
   const [opened, { open, close }] = useDisclosure(false);
 
   if (isReportPage) {
@@ -50,7 +50,7 @@ export const ParticipantLayout = () => {
       <main className="relative !h-dvh overflow-y-auto">
         <div className="flex h-full flex-col">
           <ParticipantHeader />
-          {!isOnboardingPage && (
+          {!hideSettingsButton  && (
             <Box className="absolute right-4 top-5 z-20">
               <ActionIcon
                 size="lg"


### PR DESCRIPTION
Hide settings icon in participant portal on finish page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the logic controlling the visibility of the settings button so it is now hidden on both "start" and "finish" pages, instead of only on "start" pages.
  * Improved accessibility by adding an aria-label to the settings button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->