### PR TITLE
ECHO-33 Add duration and date to chat context for conversations

### DIFF
--- a/echo/server/dembrane/chat_utils.py
+++ b/echo/server/dembrane/chat_utils.py
@@ -122,6 +122,10 @@ async def create_system_messages_for_chat(
             {
                 "name": conversation.participant_name,
                 "tags": ", ".join([tag.text for tag in conversation.tags]),
+                "created_at": conversation.created_at.isoformat()
+                if conversation.created_at
+                else None,
+                "duration": conversation.duration,
                 "transcript": get_conversation_transcript(
                     conversation.id,
                     # fake auth to get this fn call

--- a/echo/server/dembrane/database.py
+++ b/echo/server/dembrane/database.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from fastapi import Depends
 from sqlalchemy import (
     Text,
+    Float,
     Table,
     Column,
     String,
@@ -353,6 +354,7 @@ class ConversationModel(Base):
 
     summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     source: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    duration: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     chunks: Mapped[List["ConversationChunkModel"]] = relationship(
         "ConversationChunkModel",

--- a/echo/server/dembrane/schemas.py
+++ b/echo/server/dembrane/schemas.py
@@ -77,6 +77,7 @@ class ConversationSchema(BaseModel):
 
     participant_email: Optional[str] = None
     participant_name: Optional[str] = None
+    duration: Optional[float] = None
 
     tags: Optional[List[ProjectTagSchema]] = None
     chunks: Optional[List[ConversationChunkSchema]] = None

--- a/echo/server/prompt_templates/context_conversations.de.jinja
+++ b/echo/server/prompt_templates/context_conversations.de.jinja
@@ -6,6 +6,8 @@ Noch keine Gespräche vom Benutzer hinzugefügt. Ermutigen Sie sie vorsichtig, e
 <conversation>
    <name>{{ conversation.name }}</name>
    <tags>{{ conversation.tags }}</tags>
+   <date>{{ conversation.created_at }}</date>
+   <duration>{{ conversation.duration }}</duration>
    <transcript>
    {{ conversation.transcript }}
    </transcript>

--- a/echo/server/prompt_templates/context_conversations.en.jinja
+++ b/echo/server/prompt_templates/context_conversations.en.jinja
@@ -6,6 +6,8 @@ No conversations added by the user yet. Gently nudge them to add some by selecti
 <conversation>
    <name>{{ conversation.name }}</name>
    <tags>{{ conversation.tags }}</tags>
+   <date>{{ conversation.created_at }}</date>
+   <duration>{{ conversation.duration }}</duration>
    <transcript>
    {{ conversation.transcript }}
    </transcript>

--- a/echo/server/prompt_templates/context_conversations.es.jinja
+++ b/echo/server/prompt_templates/context_conversations.es.jinja
@@ -6,6 +6,8 @@ No hay conversaciones añadidas por el usuario todavía. Anímelos suavemente a 
 <conversation>
    <name>{{ conversation.name }}</name>
    <tags>{{ conversation.tags }}</tags>
+   <date>{{ conversation.created_at }}</date>
+   <duration>{{ conversation.duration }}</duration>
    <transcript>
    {{ conversation.transcript }}
    </transcript>

--- a/echo/server/prompt_templates/context_conversations.fr.jinja
+++ b/echo/server/prompt_templates/context_conversations.fr.jinja
@@ -6,6 +6,8 @@ Aucune conversation n'a encore été ajoutée par l'utilisateur. Encouragez-les 
 <conversation>
    <name>{{ conversation.name }}</name>
    <tags>{{ conversation.tags }}</tags>
+   <date>{{ conversation.created_at }}</date>
+   <duration>{{ conversation.duration }}</duration>
    <transcript>
    {{ conversation.transcript }}
    </transcript>

--- a/echo/server/prompt_templates/context_conversations.nl.jinja
+++ b/echo/server/prompt_templates/context_conversations.nl.jinja
@@ -6,6 +6,8 @@ Nog geen gesprekken door de gebruiker toegevoegd. Moedig hen voorzichtig aan om 
 <conversation>
    <name>{{ conversation.name }}</name>
    <tags>{{ conversation.tags }}</tags>
+   <date>{{ conversation.created_at }}</date>
+   <duration>{{ conversation.duration }}</duration>
    <transcript>
    {{ conversation.transcript }}
    </transcript>

--- a/echo/server/prompt_templates/system_chat.de.jinja
+++ b/echo/server/prompt_templates/system_chat.de.jinja
@@ -6,6 +6,8 @@ GESPRÄCHSSTRUKTUR:
 Jedes Gespräch enthält:
 - Name in <name> Tags
 - Zugehörige Tags in <tags> Tags
+- Erstellungsdatum in <date> Tags
+- Dauer in <duration> Tags
 - Gesprächsinhalt in <transcript> Tags
 
 RICHTLINIEN:

--- a/echo/server/prompt_templates/system_chat.en.jinja
+++ b/echo/server/prompt_templates/system_chat.en.jinja
@@ -6,6 +6,8 @@ CONVERSATION STRUCTURE:
 Each conversation contains:
 - Name in <name> tags
 - Associated tags in <tags> tags
+- Creation date in <date> tags
+- Duration in <duration> tags
 - Conversation content in <transcript> tags
 
 GUIDELINES:

--- a/echo/server/prompt_templates/system_chat.es.jinja
+++ b/echo/server/prompt_templates/system_chat.es.jinja
@@ -6,6 +6,8 @@ ESTRUCTURA DE LA CONVERSACIÓN:
 Cada conversación contiene:
 - Nombre en etiquetas <name>
 - Etiquetas asociadas en etiquetas <tags>
+- Fecha de creación en etiquetas <date>
+- Duración en etiquetas <duration>
 - Contenido de la conversación en etiquetas <transcript>
 
 DIRECTRICES:

--- a/echo/server/prompt_templates/system_chat.fr.jinja
+++ b/echo/server/prompt_templates/system_chat.fr.jinja
@@ -6,6 +6,8 @@ STRUCTURE DE LA CONVERSATION:
 Chaque conversation contient:
 - Nom dans les balises <name>
 - Tags associés dans les balises <tags>
+- Date de création dans les balises <date>
+- Durée dans les balises <duration>
 - Contenu de la conversation dans les balises <transcript>
 
 DIRECTIVES:

--- a/echo/server/prompt_templates/system_chat.nl.jinja
+++ b/echo/server/prompt_templates/system_chat.nl.jinja
@@ -6,6 +6,8 @@ GESPREKSSTRUCTUUR:
 Elk gesprek bevat:
 - Naam in <name> tags
 - Geassocieerde tags in <tags> tags
+- Creëer datum in <date> tags
+- Duur in <duration> tags
 - Gespreksinhoud in <transcript> tags
 
 RICHTLIJNEN:


### PR DESCRIPTION
- add created_at field in chat_utils file
- pass date and duration for conversations in "context_conversations" and "system_chat" prompt files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Conversations now include creation date and duration as metadata.
  - These fields appear in conversation context and system guidance across all supported languages (EN, DE, ES, FR, NL).
  - The platform stores call duration for each conversation.
  - API responses for conversations may include an optional duration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->