### PR TITLE
ECHO-438 remove the tooltip that says 'audio recording will be deleted'

### DIFF
--- a/echo/frontend/src/routes/project/conversation/ProjectConversationTranscript.tsx
+++ b/echo/frontend/src/routes/project/conversation/ProjectConversationTranscript.tsx
@@ -216,9 +216,6 @@ export const ProjectConversationTranscript = () => {
               label={t`Show audio player`}
               disabled={isAudioExpired()}
             />
-            <InformationTooltip
-              label={t`Audio recordings are scheduled to be deleted after 30 days from the recording date`}
-            />
           </Group>
         </Group>
 

--- a/echo/frontend/src/routes/project/conversation/ProjectConversationTranscript.tsx
+++ b/echo/frontend/src/routes/project/conversation/ProjectConversationTranscript.tsx
@@ -146,12 +146,12 @@ export const ProjectConversationTranscript = () => {
   };
 
   // Add function to check if conversation is older than 30 days
-  const isAudioExpired = () => {
-    if (!conversationQuery.data?.created_at) return false;
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-    return new Date(conversationQuery.data.created_at) < thirtyDaysAgo;
-  };
+  // const isAudioExpired = () => {
+  //   if (!conversationQuery.data?.created_at) return false;
+  //   const thirtyDaysAgo = new Date();
+  //   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  //   return new Date(conversationQuery.data.created_at) < thirtyDaysAgo;
+  // };
 
   return (
     <Stack>
@@ -200,7 +200,6 @@ export const ProjectConversationTranscript = () => {
                 size="md"
                 variant="subtle"
                 color="gray"
-                disabled={isAudioExpired()}
               >
                 <IconRefresh size={48} />
               </ActionIcon>
@@ -214,7 +213,6 @@ export const ProjectConversationTranscript = () => {
                 setShowAudioPlayer(event.currentTarget.checked)
               }
               label={t`Show audio player`}
-              disabled={isAudioExpired()}
             />
           </Group>
         </Group>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the informational tooltip in the audio player section that stated recordings are deleted after 30 days. The audio player toggle, layout, and behavior remain unchanged. Expired recordings still cannot be played according to existing rules; only the explanatory tooltip has been removed. This streamlines the interface without altering how audio availability works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->