### PR TITLE
Replace 'Restore Terminals with 'Terminal Keeper' in docs

### DIFF
--- a/echo/readme.md
+++ b/echo/readme.md
@@ -64,11 +64,11 @@ The following guide is to run the whole application locally. it is recommended t
 
 1. Run the [database migrations](./docs//database_migrations.md)
 
-1. (Optional) Use the "Restore Terminals" Extension for opening the relevant terminals from the container. (see [.vscode/settings.json](.vscode/settings.json) for the exact commands run when the terminals are opened)
+1. (Optional) Use the "Terminal Keeper" Extension for opening the relevant terminals from the container. (see [.vscode/settings.json](.vscode/sessions.json) for the exact commands run when the terminals are opened)
 
 	- <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> to open the command palette.
-	- Type **"Restore Terminals"**.
-	- Click **"Restore Terminals"**.
+	- Type **"Active session"**.
+	- Click **"Terminal Keeper: Active session"**.
 
 ## FAQ
 

--- a/echo/readme.md
+++ b/echo/readme.md
@@ -64,7 +64,7 @@ The following guide is to run the whole application locally. it is recommended t
 
 1. Run the [database migrations](./docs//database_migrations.md)
 
-1. (Optional) Use the "Terminal Keeper" Extension for opening the relevant terminals from the container. (see [.vscode/settings.json](.vscode/sessions.json) for the exact commands run when the terminals are opened)
+1. (Optional) Use the "Terminal Keeper" Extension for opening the relevant terminals from the container. (see [.vscode/sesssions.json](.vscode/sessions.json) for the exact commands run when the terminals are opened)
 
 	- <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> to open the command palette.
 	- Type **"Active session"**.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started to reference the Terminal Keeper extension instead of the previous terminal-restoration tool.
  * Revised VS Code guidance to point to the sessions configuration approach.
  * Updated command-palette instructions to use “Active session” and “Terminal Keeper: Active session.”
  * Note: displayed link text contains a typographical error ("sesssions.json"); actual guidance unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->