### PR TITLE
ECHO-471 Update paths for accessing the 'Get Started' and 'Core Concepts' for User Docs

### DIFF
--- a/echo-user-docs/pages/en-US/index.mdx
+++ b/echo-user-docs/pages/en-US/index.mdx
@@ -36,8 +36,8 @@ ECHO allows you to capture, analyse, and understand conversations at scale, ensu
 
 ## What You'll Find Here
 
-- **[Getting Started with ECHO](echo)** - Set up your first project in minutes
-- **[ECHO's Core Concepts](/core-concepts)** - Understand Dembrane's key features
+- **[Getting Started with ECHO](/echo/getting-started)** - Set up your first project in minutes
+- **[ECHO's Core Concepts](/echo/core-concepts)** - Understand Dembrane's key features
 
 ## Quick Start
 

--- a/echo-user-docs/pages/nl-NL/index.mdx
+++ b/echo-user-docs/pages/nl-NL/index.mdx
@@ -11,8 +11,8 @@ ECHO stelt je in staat om gesprekken op grote schaal vast te leggen, te analyser
 
 ## Wat Je Hier Vindt
 
-- **[Aan de slag met ECHO](/echo/getting-started.nl-NL)** - Zet je eerste project op in enkele minuten
-- **[ECHO's Kernconcepten](/echo/core-concepts.nl-NL)** - Begrijp Dembrane's belangrijkste functies
+- **[Aan de slag met ECHO](/echo/getting-started)** - Zet je eerste project op in enkele minuten
+- **[ECHO's Kernconcepten](/echo/core-concepts)** - Begrijp Dembrane's belangrijkste functies
 - **[Geavanceerd Gebruik]()** - Ga verder met je onderzoek via geavanceerde prompting
 
 ## Snelle Start


### PR DESCRIPTION
…or User Docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated two links in the English “What You’ll Find Here” section to absolute /echo paths (/echo/getting-started and /echo/core-concepts) for consistent navigation.
  - Updated two links in the Dutch “Wat Je Hier Vindt” section to locale-agnostic /echo paths, replacing .nl-NL suffixed URLs, improving cross-locale navigation.
  - No other content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->