### PR TITLE
fix: Asyncio loops fix for lightrag support

### DIFF
--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -22,6 +22,7 @@ from dembrane.audio_lightrag.utils.lightrag_utils import (
     get_segment_from_conversation_chunk_ids,
 )
 
+# LightRAG requires nest_asyncio for nested event loops
 nest_asyncio.apply()
 
 logger = getLogger("api.stateless")

--- a/echo/server/dembrane/lightrag_uvicorn_worker.py
+++ b/echo/server/dembrane/lightrag_uvicorn_worker.py
@@ -1,0 +1,19 @@
+"""LightRAG-compatible Uvicorn worker for Gunicorn with asyncio loop support.
+
+LightRAG uses asyncio.run() in its codebase, which requires nest_asyncio to handle
+nested event loops. However, nest_asyncio cannot patch uvloop (Uvicorn's default).
+
+This worker uses the standard asyncio loop instead of uvloop, allowing nest_asyncio
+to properly patch the event loop and support LightRAG's synchronous wrapper functions.
+
+Performance note: uvloop is ~10-20% faster than asyncio, but this overhead is
+negligible compared to LLM and database I/O operations.
+"""
+
+from uvicorn.workers import UvicornWorker
+
+
+class LightRagUvicornWorker(UvicornWorker):
+    """Uvicorn worker configured to use asyncio instead of uvloop for LightRAG compatibility."""
+
+    CONFIG_KWARGS = {"loop": "asyncio"}

--- a/echo/server/dembrane/main.py
+++ b/echo/server/dembrane/main.py
@@ -37,6 +37,7 @@ from dembrane.audio_lightrag.utils.lightrag_utils import (
     check_audio_lightrag_tables,
 )
 
+# LightRAG requires nest_asyncio for nested event loops
 nest_asyncio.apply()
 
 logger = getLogger("server")

--- a/echo/server/prod.sh
+++ b/echo/server/prod.sh
@@ -12,10 +12,11 @@ echo "  Timeout: ${TIMEOUT}s"
 echo "  Max Requests: $MAX_REQUESTS"
 echo "📊 Scale with K8s replicas (not workers per pod)"
 
+# Use custom worker that configures asyncio loop for LightRAG compatibility
+# (LightRAG uses asyncio.run() which requires nest_asyncio, incompatible with uvloop)
 exec gunicorn dembrane.main:app \
   --workers "$WORKERS" \
-  --worker-class uvicorn.workers.UvicornWorker \
-  --loop asyncio \
+  --worker-class dembrane.lightrag_uvicorn_worker.LightRagUvicornWorker \
   --bind 0.0.0.0:8000 \
   --timeout "$TIMEOUT" \
   --graceful-timeout 30 \


### PR DESCRIPTION
- Create LightRagUvicornWorker to use asyncio instead of uvloop
- nest_asyncio (required by LightRAG) cannot patch uvloop
- Add documentation comments explaining LightRAG dependency
- Remove invalid --loop asyncio flag from gunicorn (uvicorn-only flag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved server compatibility with async workloads, enhancing reliability for LightRAG scenarios.
- Chores
  - Updated production worker configuration to ensure consistent asyncio behavior in deployments.
  - Adjusted startup script to use the new worker setup for more stable operation.
- Documentation
  - Added clarifying comments around event loop handling and nest_asyncio usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->