### PR TITLE
Reduce default number of CPU worker processes

### DIFF
--- a/echo/server/prod-worker-cpu.sh
+++ b/echo/server/prod-worker-cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Starting CPU Workers (Kubernetes mode)"
 
-PROCESSES=${CPU_WORKER_PROCESSES:-8}
+PROCESSES=${CPU_WORKER_PROCESSES:-2}
 THREADS=${CPU_WORKER_THREADS:-1}
 
 echo "Configuration:"


### PR DESCRIPTION
Reduce default number of CPU worker processes from 8 to 2 in prod-workers.sh