### PR TITLE
ECHO-707 fix(host-guide): use white background when printing

### DIFF
--- a/echo/frontend/src/routes/project/HostGuidePage.tsx
+++ b/echo/frontend/src/routes/project/HostGuidePage.tsx
@@ -421,16 +421,24 @@ const printStyles = `
     size: A4 landscape;
     margin: 12mm;
   }
-  body {
+  html, body {
+    background: #ffffff !important;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }
   .no-print { display: none !important; }
+  .print-only { display: block !important; }
   .print-page {
     height: auto !important;
     padding: 48px !important;
-    background: ${colors.parchment} !important;
+    background: #ffffff !important;
   }
+  .qr-screen { display: none !important; }
+  .qr-print { display: block !important; }
+}
+@media screen {
+  .print-only { display: none !important; }
+  .qr-print { display: none !important; }
 }
 `;
 
@@ -948,20 +956,41 @@ const LiveRecordingIndicator = ({
 };
 
 // QR Code component
+// Renders two QR canvases: parchment background for screen, white for print.
+// CSS print styles can't recolor canvas pixels, so we swap which one is visible.
 const BrandQRCode = ({ value }: { value: string }) => (
-	<QRCodeLogo
-		value={value}
-		logoImage="/dembrane-logomark-cropped.png"
-		logoWidth={50}
-		logoHeight={50}
-		bgColor={colors.parchment}
-		fgColor={colors.graphite}
-		eyeColor={colors.graphite}
-		logoPadding={4}
-		removeQrCodeBehindLogo
-		logoPaddingStyle="circle"
-		size={200}
-	/>
+	<>
+		<div className="qr-screen">
+			<QRCodeLogo
+				value={value}
+				logoImage="/dembrane-logomark-cropped.png"
+				logoWidth={50}
+				logoHeight={50}
+				bgColor={colors.parchment}
+				fgColor={colors.graphite}
+				eyeColor={colors.graphite}
+				logoPadding={4}
+				removeQrCodeBehindLogo
+				logoPaddingStyle="circle"
+				size={200}
+			/>
+		</div>
+		<div className="qr-print">
+			<QRCodeLogo
+				value={value}
+				logoImage="/dembrane-logomark-cropped.png"
+				logoWidth={50}
+				logoHeight={50}
+				bgColor="#ffffff"
+				fgColor={colors.graphite}
+				eyeColor={colors.graphite}
+				logoPadding={4}
+				removeQrCodeBehindLogo
+				logoPaddingStyle="circle"
+				size={200}
+			/>
+		</div>
+	</>
 );
 
 // ============================================================================


### PR DESCRIPTION
Force the printable host guide to render with a fully white background (page, content area, and QR code) instead of the parchment brand color. The on-screen experience is unchanged. Renders a separate white-bg QR canvas for print since CSS cannot recolor already-painted canvas pixels. Reported from field observation: parchment background prints as a noticeable color block and wastes ink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved QR code rendering on the Host Guide page with optimized display for both screen viewing and printing
  * Enhanced print layout with better background color handling for improved readability and printing quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->