### PR TITLE
ECHO-746 feat(verify): raise custom prompt limit to 10k and add chars-remaining indicator

### DIFF
--- a/echo/frontend/src/components/common/CharsRemainingIndicator.tsx
+++ b/echo/frontend/src/components/common/CharsRemainingIndicator.tsx
@@ -33,7 +33,8 @@ export const CharsRemainingIndicator = ({
 	numberThresholdCap = DEFAULT_NUMBER_THRESHOLD_CAP,
 	align = "right",
 }: CharsRemainingIndicatorProps) => {
-	const remaining = max - value.length;
+	if (max <= 0) return null;
+	const remaining = Math.max(0, max - value.length);
 	if (remaining > Math.min(numberThresholdCap, max * numberThresholdRatio)) {
 		return null;
 	}

--- a/echo/frontend/src/components/common/CharsRemainingIndicator.tsx
+++ b/echo/frontend/src/components/common/CharsRemainingIndicator.tsx
@@ -1,0 +1,58 @@
+import { Group, RingProgress, Text } from "@mantine/core";
+
+const DEFAULT_NUMBER_THRESHOLD_RATIO = 0.5;
+const DEFAULT_NUMBER_THRESHOLD_CAP = 50;
+
+type CharsRemainingIndicatorProps = {
+	value: string;
+	max: number;
+	/** Ratio of `max` below which the indicator appears. @default 0.5 */
+	numberThresholdRatio?: number;
+	/** Upper bound (in chars) on the visibility threshold. @default 50 */
+	numberThresholdCap?: number;
+	/** @default "right" */
+	align?: "left" | "center" | "right";
+};
+
+const ALIGN_TO_JUSTIFY = {
+	center: "center",
+	left: "flex-start",
+	right: "flex-end",
+} as const;
+
+/**
+ * Custom remaining-characters indicator. Renders nothing until the
+ * field is close to its limit, then shows a ring with the remaining count
+ * inside — colored with the brand caution tone, switching to the brand
+ * danger tone at the cap.
+ */
+export const CharsRemainingIndicator = ({
+	value,
+	max,
+	numberThresholdRatio = DEFAULT_NUMBER_THRESHOLD_RATIO,
+	numberThresholdCap = DEFAULT_NUMBER_THRESHOLD_CAP,
+	align = "right",
+}: CharsRemainingIndicatorProps) => {
+	const remaining = max - value.length;
+	if (remaining > Math.min(numberThresholdCap, max * numberThresholdRatio)) {
+		return null;
+	}
+	const filled = Math.min(100, (value.length / max) * 100);
+	const atLimit = remaining === 0;
+	const ringColor = atLimit ? "salmon" : "peach";
+	const textColor = atLimit ? "salmon" : "dimmed";
+	return (
+		<Group justify={ALIGN_TO_JUSTIFY[align]}>
+			<RingProgress
+				size={32}
+				thickness={2}
+				sections={[{ color: ringColor, value: filled }]}
+				label={
+					<Text size="xs" ta="center" c={textColor}>
+						{remaining}
+					</Text>
+				}
+			/>
+		</Group>
+	);
+};

--- a/echo/frontend/src/components/project/CustomTopicModal.tsx
+++ b/echo/frontend/src/components/project/CustomTopicModal.tsx
@@ -14,11 +14,12 @@ import {
 import { useDisclosure } from "@mantine/hooks";
 import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
+import { CharsRemainingIndicator } from "@/components/common/CharsRemainingIndicator";
 import type { VerificationTopicMetadata } from "@/lib/api";
 import { testId } from "@/lib/testUtils";
 
 const MAX_LABEL_LENGTH = 100;
-const MAX_PROMPT_LENGTH = 1000;
+const MAX_PROMPT_LENGTH = 10000;
 const MAX_ICON_LENGTH = 10;
 
 const EMOJI_REGEX = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/gu;
@@ -142,18 +143,24 @@ export const CustomTopicModal = ({
 			{...testId("custom-topic-modal")}
 		>
 			<Stack gap="md">
-				<TextInput
-					label={t`Topic label`}
-					placeholder={t`Required`}
-					value={labels["en-US"] ?? ""}
-					onChange={(e) => {
-						const val = e.currentTarget.value;
-						setLabels((prev) => ({ ...prev, "en-US": val }));
-					}}
-					maxLength={MAX_LABEL_LENGTH}
-					required
-					{...testId("custom-topic-label-en-US")}
-				/>
+				<Stack gap={4}>
+					<TextInput
+						label={t`Topic label`}
+						placeholder={t`Required`}
+						value={labels["en-US"] ?? ""}
+						onChange={(e) => {
+							const val = e.currentTarget.value;
+							setLabels((prev) => ({ ...prev, "en-US": val }));
+						}}
+						maxLength={MAX_LABEL_LENGTH}
+						required
+						{...testId("custom-topic-label-en-US")}
+					/>
+					<CharsRemainingIndicator
+						value={labels["en-US"] ?? ""}
+						max={MAX_LABEL_LENGTH}
+					/>
+				</Stack>
 
 				<Stack gap={4}>
 					<UnstyledButton onClick={toggleTranslations}>
@@ -178,41 +185,51 @@ export const CustomTopicModal = ({
 						<Stack gap="xs" pt="xs" pl="md">
 							{SUPPORTED_LANGUAGES.filter((l) => l.code !== "en-US").map(
 								(lang) => (
-									<TextInput
-										key={lang.code}
-										label={lang.label}
-										placeholder={t`Optional (falls back to English)`}
-										value={labels[lang.code] ?? ""}
-										onChange={(e) => {
-											const val = e.currentTarget.value;
-											setLabels((prev) => ({
-												...prev,
-												[lang.code]: val,
-											}));
-										}}
-										maxLength={MAX_LABEL_LENGTH}
-										{...testId(`custom-topic-label-${lang.code}`)}
-									/>
+									<Stack key={lang.code} gap={4}>
+										<TextInput
+											label={lang.label}
+											placeholder={t`Optional (falls back to English)`}
+											value={labels[lang.code] ?? ""}
+											onChange={(e) => {
+												const val = e.currentTarget.value;
+												setLabels((prev) => ({
+													...prev,
+													[lang.code]: val,
+												}));
+											}}
+											maxLength={MAX_LABEL_LENGTH}
+											{...testId(`custom-topic-label-${lang.code}`)}
+										/>
+										<CharsRemainingIndicator
+											value={labels[lang.code] ?? ""}
+											max={MAX_LABEL_LENGTH}
+										/>
+									</Stack>
 								),
 							)}
 						</Stack>
 					</Collapse>
 				</Stack>
 
-				<Textarea
-					label={t`Prompt`}
-					description={
-						<Trans>Instructions for generating the verification outcome</Trans>
-					}
-					placeholder={t`Describe what the language model should extract or summarize from the conversation...`}
-					value={prompt}
-					onChange={(e) => setPrompt(e.currentTarget.value)}
-					maxLength={MAX_PROMPT_LENGTH}
-					autosize
-					minRows={4}
-					required
-					{...testId("custom-topic-prompt")}
-				/>
+				<Stack gap={4}>
+					<Textarea
+						label={t`Prompt`}
+						description={
+							<Trans>
+								Instructions for generating the verification outcome
+							</Trans>
+						}
+						placeholder={t`Describe what the language model should extract or summarize from the conversation...`}
+						value={prompt}
+						onChange={(e) => setPrompt(e.currentTarget.value)}
+						maxLength={MAX_PROMPT_LENGTH}
+						autosize
+						minRows={4}
+						required
+						{...testId("custom-topic-prompt")}
+					/>
+					<CharsRemainingIndicator value={prompt} max={MAX_PROMPT_LENGTH} />
+				</Stack>
 
 				<TextInput
 					label={t`Emoji`}

--- a/echo/server/dembrane/api/verify.py
+++ b/echo/server/dembrane/api/verify.py
@@ -81,14 +81,14 @@ class UpdateVerificationTopicsRequest(BaseModel):
 
 class CreateCustomTopicRequest(BaseModel):
     label: str = Field(..., max_length=100)
-    prompt: str = Field(..., max_length=1000)
+    prompt: str = Field(..., max_length=10000)
     icon: Optional[str] = Field(None, max_length=10)
     translations: Dict[str, str] = Field(default_factory=dict)
 
 
 class UpdateCustomTopicRequest(BaseModel):
     label: Optional[str] = Field(None, max_length=100)
-    prompt: Optional[str] = Field(None, max_length=1000)
+    prompt: Optional[str] = Field(None, max_length=10000)
     icon: Optional[str] = Field(None, max_length=10)
     translations: Optional[Dict[str, str]] = None
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time character count indicator showing remaining characters for input fields (labels and prompts).

* **Improvements**
  * Increased maximum prompt length limit from 1,000 to 10,000 characters for custom topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->