### PR TITLE
fix: repair regressions from sidebar PR (#585)

### DIFF
--- a/echo/AGENTS.md
+++ b/echo/AGENTS.md
@@ -145,11 +145,9 @@ Which group powers which feature is non-obvious — don't downgrade silently.
 **Never hand-write Directus sync/snapshot JSON files.** To create or modify collections:
 
 1. Write an idempotent Python script that uses the Directus REST API (`POST /collections`, `POST /fields`, `POST /relations`) with the admin token. Check `collection_exists()` / `field_exists()` before creating
-2. Run it step-by-step to verify each change
+2. Run it step-by-step to verify each change against a local Directus
 3. Pull the schema: `cd directus && bash sync.sh -u http://directus:8055 -e admin@dembrane.com -p admin pull`
-4. Commit the snapshot JSON
-
-See `scripts/create_schema.py` for the established pattern.
+4. Commit the snapshot JSON under `directus/sync/snapshot/` — that is the source of truth; the one-shot migration script does not need to be committed
 
 ### Python DirectusClient
 

--- a/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
+++ b/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
@@ -1,15 +1,17 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import {
-	Buildings,
-	Palette,
-	Scales,
-	ShieldStar,
-	SignOut,
+	BuildingsIcon,
+	PaletteIcon,
+	ScalesIcon,
+	ShieldStarIcon,
+	SignOutIcon,
 } from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router";
 import { useLogoutMutation } from "@/components/auth/hooks";
 import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
+import { API_BASE_URL } from "@/config";
 import { BackButton } from "../../primitives/BackButton";
 import { NavButton } from "../../primitives/NavButton";
 import { NavItem } from "../../primitives/NavItem";
@@ -18,6 +20,21 @@ export const UserSettingsView = () => {
 	const logoutMutation = useLogoutMutation();
 	const location = useLocation();
 	const { runTransition } = useTransitionCurtain();
+
+	const { data: accessData } = useQuery<{
+		organisations: Array<{ id: string }>;
+	} | null>({
+		queryFn: async () => {
+			const res = await fetch(`${API_BASE_URL}/v2/workspaces`, {
+				credentials: "include",
+			});
+			if (!res.ok) return null;
+			return res.json();
+		},
+		queryKey: ["v2", "workspaces"],
+		staleTime: 60_000,
+	});
+	const isExternalOnly = (accessData?.organisations.length ?? 0) === 0;
 
 	const handleLogout = async () => {
 		if (logoutMutation.isPending) return;
@@ -35,26 +52,28 @@ export const UserSettingsView = () => {
 			<NavItem
 				to="/settings/account"
 				label={<Trans>Account & security</Trans>}
-				icon={ShieldStar}
+				icon={ShieldStarIcon}
 			/>
 			<NavItem
 				to="/settings/access"
 				label={<Trans>My access</Trans>}
-				icon={Buildings}
+				icon={BuildingsIcon}
 			/>
 			<NavItem
 				to="/settings/appearance"
 				label={<Trans>Appearance</Trans>}
-				icon={Palette}
+				icon={PaletteIcon}
 			/>
-			<NavItem
-				to="/settings/project-defaults"
-				label={<Trans>Project defaults</Trans>}
-				icon={Scales}
-			/>
+			{!isExternalOnly && (
+				<NavItem
+					to="/settings/project-defaults"
+					label={<Trans>Project defaults</Trans>}
+					icon={ScalesIcon}
+				/>
+			)}
 			<NavButton
 				label={<Trans>Log out</Trans>}
-				icon={SignOut}
+				icon={SignOutIcon}
 				onClick={handleLogout}
 				disabled={logoutMutation.isPending}
 				destructive

--- a/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
+++ b/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
@@ -34,7 +34,8 @@ export const UserSettingsView = () => {
 		queryKey: ["v2", "workspaces"],
 		staleTime: 60_000,
 	});
-	const isExternalOnly = (accessData?.organisations.length ?? 0) === 0;
+	const isExternalOnly =
+		accessData != null ? accessData.organisations.length === 0 : false;
 
 	const handleLogout = async () => {
 		if (logoutMutation.isPending) return;

--- a/echo/server/dembrane/api/v2/middleware.py
+++ b/echo/server/dembrane/api/v2/middleware.py
@@ -123,25 +123,6 @@ async def get_workspace_context(
     from dembrane.policies import _normalize_legacy_role
 
     normalized_role = _normalize_legacy_role(role) or role
-    if source == "direct" and normalized_role != "external":
-        org_id = workspace.get("org_id")
-        if org_id:
-            org_rows = await async_directus.get_items(
-                "org_membership",
-                {
-                    "query": {
-                        "filter": {
-                            "org_id": {"_eq": org_id},
-                            "user_id": {"_eq": app_user_id},
-                            "deleted_at": {"_null": True},
-                        },
-                        "fields": ["id"],
-                        "limit": 1,
-                    }
-                },
-            )
-            if not isinstance(org_rows, list) or len(org_rows) == 0:
-                normalized_role = "external"
 
     return WorkspaceContext(
         workspace_id=workspace_id,

--- a/echo/server/dembrane/api/v2/project_sharing.py
+++ b/echo/server/dembrane/api/v2/project_sharing.py
@@ -389,6 +389,7 @@ async def change_project_share_role(
             message=f"You're now a **{body.role}** on this project.",
             action="NAVIGATE_PROJECT",
             ref_project_id=project_id,
+            ref_workspace_id=project.get("workspace_id"),
         )
 
     return {"status": "updated", "role": body.role}

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -1437,6 +1437,7 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
                             action="NAVIGATE_REPORT",
                             ref_project_id=project_id,
                             ref_report_id=report_id_str,
+                            ref_workspace_id=(project_row or {}).get("workspace_id"),
                         )
             except Exception as e:
                 logger.warning(f"Failed to emit REPORT_READY notification: {e}")
@@ -1467,6 +1468,7 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
                 from dembrane.notifications import emit_sync
                 with directus_client_context() as client:
                     report_row = client.get_item("project_report", report_id_str)
+                    project_row = client.get_item("project", project_id) if project_id else None
                 report_data = (report_row or {}).get("data") or report_row or {}
                 creator_directus_id = report_data.get("user_created")
                 if creator_directus_id:
@@ -1480,6 +1482,7 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
                             action="NAVIGATE_REPORT",
                             ref_project_id=project_id,
                             ref_report_id=report_id_str,
+                            ref_workspace_id=(project_row or {}).get("workspace_id"),
                         )
             except Exception as notif_err:
                 logger.warning(f"Failed to emit REPORT_FAILED: {notif_err}")

--- a/echo/server/tests/test_discount_fields.py
+++ b/echo/server/tests/test_discount_fields.py
@@ -10,12 +10,9 @@ Covers:
 - _create_workspace_for_request writes discount fields (already covered in Slice 10,
   but verified structurally here)
 - _upgrade_workspace_for_request writes discount fields (same)
-- create_schema step_21 is registered and callable
 - No code path computes a price using discount fields (grep guard)
 """
 
-import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -454,39 +451,6 @@ class TestAllActiveWorkspacesFields:
             assert "tier_expires_at" in fields
             assert "type_discount" in fields
             assert "percent_discount" in fields
-
-
-# ── Schema step_21 registration ──
-
-
-class TestSchemaStep21:
-    @pytest.fixture(autouse=True)
-    def _add_scripts_to_path(self):
-        scripts_dir = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
-        scripts_dir = os.path.abspath(scripts_dir)
-        if scripts_dir not in sys.path:
-            sys.path.insert(0, scripts_dir)
-        yield
-        if scripts_dir in sys.path:
-            sys.path.remove(scripts_dir)
-
-    def test_step_21_in_steps(self):
-        from create_schema import STEPS
-
-        assert "21" in STEPS
-        name, fn = STEPS["21"]
-        assert "discount" in name.lower()
-
-    def test_step_21_callable(self):
-        from create_schema import STEPS
-
-        _, fn = STEPS["21"]
-        assert callable(fn)
-
-    def test_step_21_function_name(self):
-        from create_schema import step_21_workspace_discount_fields
-
-        assert step_21_workspace_discount_fields.__name__ == "step_21_workspace_discount_fields"
 
 
 # ── Approve helpers write discount fields (structural) ──

--- a/echo/server/tests/test_tier_expiry.py
+++ b/echo/server/tests/test_tier_expiry.py
@@ -483,33 +483,6 @@ class TestSchedulerRegistration:
         assert str(minute_field) == "0"
 
 
-# ── Schema step 19 ──────────────────────────────────────────────────
-
-
-class TestSchemaStep19:
-    """Structural check that step_19 is wired in STEPS and is callable."""
-
-    def test_step_19_in_source(self):
-        src_path = os.path.join(
-            os.path.dirname(__file__), "..", "..", "scripts", "create_schema.py"
-        )
-        with open(src_path) as f:
-            source = f.read()
-
-        assert "step_19_workspace_tier_expires_at" in source
-        assert '"19"' in source
-
-    def test_step_19_adds_tier_expires_at(self):
-        src_path = os.path.join(
-            os.path.dirname(__file__), "..", "..", "scripts", "create_schema.py"
-        )
-        with open(src_path) as f:
-            source = f.read()
-
-        assert '"tier_expires_at"' in source
-        assert '"timestamp"' in source
-
-
 # ── Email template existence ─────────────────────────────────────────
 
 

--- a/echo/server/tests/test_tier_expiry_prewarning.py
+++ b/echo/server/tests/test_tier_expiry_prewarning.py
@@ -18,7 +18,6 @@ Covers:
 from __future__ import annotations
 
 import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -595,36 +594,3 @@ class TestPrewarningScheduler:
         assert "task_send_tier_expiry_prewarning" in str(job.func_ref)
 
 
-# ── Schema step 20 ───────────────────────────────────────────────────
-
-
-class TestSchemaStep20:
-    """Structural check for the pre_warning_sent field definition."""
-
-    @pytest.fixture(autouse=True)
-    def _add_scripts_to_path(self):
-        scripts_dir = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
-        scripts_dir = os.path.abspath(scripts_dir)
-        if scripts_dir not in sys.path:
-            sys.path.insert(0, scripts_dir)
-        yield
-        if scripts_dir in sys.path:
-            sys.path.remove(scripts_dir)
-
-    def test_step_20_in_steps(self):
-        from create_schema import STEPS
-
-        assert "20" in STEPS
-        name, fn = STEPS["20"]
-        assert "pre_warning_sent" in name
-
-    def test_step_20_callable(self):
-        from create_schema import STEPS
-
-        _, fn = STEPS["20"]
-        assert callable(fn)
-
-    def test_step_20_function_name(self):
-        from create_schema import step_20_workspace_pre_warning_sent
-
-        assert step_20_workspace_pre_warning_sent.__name__ == "step_20_workspace_pre_warning_sent"

--- a/echo/server/tests/test_workspace_requests.py
+++ b/echo/server/tests/test_workspace_requests.py
@@ -389,33 +389,6 @@ class TestBillingPeriodValidation:
         assert row["proposed_billing_period"] == cadence
 
 
-# ── Schema script step_18 ────────────────────────────────────────────
-
-
-class TestSchemaStep18:
-    """Structural checks that the schema step function exists and has the right shape."""
-
-    def _load_schema_module(self):
-        import os
-        import importlib.util
-        script_path = os.path.join(
-            os.path.dirname(__file__), "..", "..", "scripts", "create_schema.py"
-        )
-        spec = importlib.util.spec_from_file_location("create_schema", script_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-
-    def test_step_registered(self):
-        mod = self._load_schema_module()
-        assert "18" in mod.STEPS
-        assert mod.STEPS["18"][0] == "workspace_request collection"
-
-    def test_step_function_callable(self):
-        mod = self._load_schema_module()
-        assert callable(mod.step_18_workspace_request)
-
-
 # ── Row creation payload ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
  fix: repair regressions from sidebar PR (#585)

  The sidebar PR overlapped with #577, #581, #582, and #583 and introduced
  a few cross-cutting issues this commit addresses:

  - Restore the "hide Project defaults for external-only users" gate in the
    new sidebar's UserSettingsView. PR #582/#583 added this filter to the
    old UserSettingsRoute; when the sidebar moved navigation into a new
    view component, the NavItem rendered unconditionally and external-only
    users could click through to an empty pane.
  - Drop schema-step tests that imported the deleted scripts/create_schema.py
    one-shot seeding script. The committed snapshot under
    directus/sync/snapshot/ is the source of truth now, so those structural
    guards were checking a script that no longer exists.
  - Update AGENTS.md to remove the create_schema.py reference and point at
    the snapshot directory.
  - Populate ref_workspace_id on PROJECT_SHARE_ROLE_CHANGED (project_sharing.py),
    REPORT_READY, and REPORT_FAILED (tasks.py). The new useNotifications
    href builder requires both ref_workspace_id and ref_project_id to
    produce /w/{ws}/projects/... links; without it those notifications
    rendered as dead clicks.
  - Strip the per-request org_membership lookup in get_workspace_context.
    PR #582 enforces role='external' ⟺ no org_membership at every write
    path, and on_organisation_member_removed cascades workspace_membership
    soft-deletes correctly, so the read-side normalisation was redundant
    per-request DB overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User settings view now fetches and displays workspace access information, conditionally showing relevant configuration options based on access level.
  * Notifications for project sharing and report status now include workspace context information for better organization.

* **Documentation**
  * Updated deployment guide with clarified schema snapshot and migration script procedures.

* **Tests**
  * Removed legacy schema step validation tests from test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dembrane/echo/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->