### PR TITLE
fix(auth): show dembrane logo on unauthenticated pages instead of spinner

### DIFF
--- a/echo/frontend/src/components/layout/AuthLayout.tsx
+++ b/echo/frontend/src/components/layout/AuthLayout.tsx
@@ -25,7 +25,7 @@ const AuthHeader = () => (
 		<Group justify="space-between" align="center" h={60} px="md">
 			<I18nLink to="/">
 				<Group align="center">
-					<Logo hideTitle={false} />
+					<Logo hideTitle={false} alwaysDembrane />
 				</Group>
 			</I18nLink>
 			<LanguagePicker />


### PR DESCRIPTION


  WhitelabelLogoProvider initializes logoUrl to undefined and only gets
  resolved by ParticipantHeader or useSidebarWhitelabelLogo — neither
  mounts under AuthLayout. On a cold /login (initial visit or logout +
  refresh), the value stayed undefined and LogoDembrane rendered its
  <Loader> forever.

  Pass alwaysDembrane to the Logo in AuthLayout so the auth header
  short-circuits whitelabel resolution and renders the dembrane logo
  immediately. Workspace whitelabel behavior is unchanged — the sidebar
  shell still resolves workspace.logo_url for authenticated routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated logo display in authentication screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dembrane/echo/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->