### PR TITLE
feat(frontend): add Agentation visual feedback overlay for staging

### DIFF
--- a/echo/frontend/.env.example
+++ b/echo/frontend/.env.example
@@ -11,6 +11,11 @@ VITE_ENABLE_WEBHOOKS=0
 # Set to "1" to enable the Agentic chat mode in the chat interface
 VITE_ENABLE_AGENTIC_CHAT=0
 
+# Agentation visual annotation overlay (team feedback tool)
+# Set to "1" on the staging Vercel project to ship the overlay and preserve
+# JSX source-file metadata in the build. Leave unset in production.
+# VITE_ENABLE_AGENTATION=1
+
 # Community Slack invite URL (override if the link expires)
 # VITE_COMMUNITY_SLACK_URL=https://join.slack.com/t/dembranecommunity/shared_invite/...
 

--- a/echo/frontend/package.json
+++ b/echo/frontend/package.json
@@ -99,6 +99,8 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+    "@babel/preset-react": "^7.28.5",
     "@biomejs/biome": "^2.2.4",
     "@lingui/babel-plugin-lingui-macro": "^5.3.0",
     "@lingui/cli": "^5.3.0",
@@ -115,6 +117,7 @@
     "@types/react-dom": "^19.0.4",
     "@types/showdown": "^2.0.6",
     "@vitejs/plugin-react": "^4.7.0",
+    "agentation": "3.0.2",
     "autoprefixer": "^10.4.21",
     "babel-plugin-react-compiler": "19.0.0-beta-37ed2a7-20241206",
     "debug": "^4.4.0",

--- a/echo/frontend/pnpm-lock.yaml
+++ b/echo/frontend/pnpm-lock.yaml
@@ -249,6 +249,12 @@ importers:
         specifier: ^3.24.2
         version: 3.24.2
     devDependencies:
+      '@babel/plugin-transform-react-jsx-source':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: ^7.28.5
+        version: 7.28.5(@babel/core@7.28.0)
       '@biomejs/biome':
         specifier: ^2.2.4
         version: 2.2.4
@@ -297,6 +303,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@6.3.5(@types/node@22.13.14)(jiti@1.21.7)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.7.0))
+      agentation:
+        specifier: 3.0.2
+        version: 3.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -373,6 +382,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.26.8':
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
@@ -397,6 +410,14 @@ packages:
     resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.27.0':
     resolution: {integrity: sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==}
     engines: {node: '>=6.9.0'}
@@ -417,6 +438,10 @@ packages:
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.26.0':
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
@@ -433,6 +458,10 @@ packages:
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
@@ -447,6 +476,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -475,6 +508,29 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-display-name@7.28.0':
+    resolution: {integrity: sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-development@7.27.1':
+    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -483,6 +539,24 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-pure-annotations@7.27.1':
+    resolution: {integrity: sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-react@7.28.5':
+    resolution: {integrity: sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -503,6 +577,10 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.27.0':
     resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
@@ -511,12 +589,20 @@ packages:
     resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.1':
     resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.2.4':
@@ -2603,6 +2689,17 @@ packages:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentation@3.0.2:
+    resolution: {integrity: sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ai@4.3.19:
     resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
@@ -5144,6 +5241,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.26.8': {}
 
   '@babel/compat-data@7.28.0': {}
@@ -5204,6 +5307,18 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.28.1
+
   '@babel/helper-compilation-targets@7.27.0':
     dependencies:
       '@babel/compat-data': 7.26.8
@@ -5236,6 +5351,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -5256,6 +5378,8 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-string-parser@7.27.1': {}
@@ -5263,6 +5387,8 @@ snapshots:
   '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -5286,6 +5412,27 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.1
 
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
@@ -5295,6 +5442,35 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/preset-react@7.28.5(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime@7.27.0':
     dependencies:
@@ -5313,6 +5489,12 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.1
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.27.0':
     dependencies:
@@ -5338,6 +5520,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.27.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
@@ -5347,6 +5541,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@biomejs/biome@2.2.4':
     optionalDependencies:
@@ -7612,6 +7811,11 @@ snapshots:
       acorn: 8.14.1
 
   acorn@8.14.1: {}
+
+  agentation@3.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   ai@4.3.19(react@19.0.0)(zod@3.24.2):
     dependencies:

--- a/echo/frontend/src/App.tsx
+++ b/echo/frontend/src/App.tsx
@@ -20,13 +20,12 @@ import { I18nProvider } from "./components/layout/I18nProvider";
 import { USE_PARTICIPANT_ROUTER } from "./config";
 import { detectAndEmitPilotBlock } from "./lib/pilotBlock";
 
-// Reference import.meta.env directly so Vite can constant-fold both branches
-// and Rollup can tree-shake the agentation chunk out of production / participant
-// builds. Through an intermediate constant the values would still be replaced,
-// but the lazy(import(...)) call would remain reachable in the module graph.
+// Reference import.meta.env directly so Vite can constant-fold the branch and
+// Rollup can tree-shake the agentation chunk out of production builds. Through
+// an intermediate constant the values would still be replaced, but the
+// lazy(import(...)) call would remain reachable in the module graph.
 const Agentation =
-	(import.meta.env.DEV || import.meta.env.VITE_ENABLE_AGENTATION === "1") &&
-	import.meta.env.VITE_USE_PARTICIPANT_ROUTER !== "1"
+	import.meta.env.DEV || import.meta.env.VITE_ENABLE_AGENTATION === "1"
 		? lazy(() => import("agentation").then((m) => ({ default: m.Agentation })))
 		: null;
 

--- a/echo/frontend/src/App.tsx
+++ b/echo/frontend/src/App.tsx
@@ -7,20 +7,33 @@ import { MantineProvider } from "@mantine/core";
 import "@mantine/core/styles.css";
 import { DatesProvider } from "@mantine/dates";
 import { ModalsProvider } from "@mantine/modals";
-import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { detectAndEmitPilotBlock } from "./lib/pilotBlock";
+import {
+	MutationCache,
+	QueryCache,
+	QueryClient,
+	QueryClientProvider,
+} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { RouterProvider } from "react-router/dom";
 import { I18nProvider } from "./components/layout/I18nProvider";
 import { USE_PARTICIPANT_ROUTER } from "./config";
+import { detectAndEmitPilotBlock } from "./lib/pilotBlock";
+
+// Reference import.meta.env directly so Vite can constant-fold both branches
+// and Rollup can tree-shake the agentation chunk out of production / participant
+// builds. Through an intermediate constant the values would still be replaced,
+// but the lazy(import(...)) call would remain reachable in the module graph.
+const Agentation =
+	(import.meta.env.DEV || import.meta.env.VITE_ENABLE_AGENTATION === "1") &&
+	import.meta.env.VITE_USE_PARTICIPANT_ROUTER !== "1"
+		? lazy(() => import("agentation").then((m) => ({ default: m.Agentation })))
+		: null;
+
+import type { PropsWithChildren } from "react";
 import { AppPreferencesProvider } from "./hooks/useAppPreferences";
 import { WhitelabelLogoProvider } from "./hooks/useWhitelabelLogo";
-import type { PropsWithChildren } from "react";
-import {
-	WorkspaceContext,
-	useWorkspaceProvider,
-} from "./hooks/useWorkspace";
+import { useWorkspaceProvider, WorkspaceContext } from "./hooks/useWorkspace";
 
 function WorkspaceProvider({ children }: PropsWithChildren) {
 	const value = useWorkspaceProvider(true);
@@ -30,6 +43,7 @@ function WorkspaceProvider({ children }: PropsWithChildren) {
 		</WorkspaceContext.Provider>
 	);
 }
+
 import { analytics } from "./lib/analytics";
 import { mainRouter, participantRouter } from "./Router";
 import { theme } from "./theme";
@@ -127,6 +141,11 @@ export const App = () => {
 								<I18nProvider>
 									<ModalsProvider>
 										<RouterProvider router={router} />
+										{Agentation && (
+											<Suspense fallback={null}>
+												<Agentation />
+											</Suspense>
+										)}
 									</ModalsProvider>
 								</I18nProvider>
 							</WorkspaceProvider>

--- a/echo/frontend/src/components/common/Logo.tsx
+++ b/echo/frontend/src/components/common/Logo.tsx
@@ -12,20 +12,39 @@ type LogoProps = {
 	alwaysDembrane?: boolean;
 } & GroupProps;
 
+const STAGING_HOSTNAMES = new Set([
+	"dashboard.echo-next.dembrane.com",
+	"portal.echo-next.dembrane.com",
+]);
+
+const isStagingHost = () =>
+	typeof window !== "undefined" && STAGING_HOSTNAMES.has(window.location.hostname);
+
 export const LogoDembrane = ({ hideLogo, hideTitle, alwaysDembrane, ...props }: LogoProps) => {
 	const { logoUrl } = useWhitelabelLogo();
 	const effectiveLogoUrl = alwaysDembrane ? null : logoUrl;
+	const showStagingBadge = isStagingHost();
 
 	return (
 		<Group gap="sm" h="36px" align="center" {...props}>
 			{!hideLogo && effectiveLogoUrl === undefined ? (
 				<Loader size={24} color="gray" ml="xl" />
 			) : !hideLogo ? (
-				<img
-					src={effectiveLogoUrl ?? (hideTitle ? dembraneLogomark : dembraneLogoFull)}
-					alt="Logo"
-					className="h-full object-contain"
-				/>
+				<span className="relative inline-flex h-full items-center">
+					<img
+						src={effectiveLogoUrl ?? (hideTitle ? dembraneLogomark : dembraneLogoFull)}
+						alt="Logo"
+						className="h-full object-contain"
+					/>
+					{showStagingBadge && (
+						<span
+							className="pointer-events-none absolute -bottom-1 -right-[20px] -translate-x-1/2 pl-1 text-[10px] font-medium leading-none"
+							style={{ color: "var(--mantine-color-primary-6)" }}
+						>
+							Staging
+						</span>
+					)}
+				</span>
 			) : null}
 		</Group>
 	);

--- a/echo/frontend/src/components/layout/BaseLayout.tsx
+++ b/echo/frontend/src/components/layout/BaseLayout.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
 import { Outlet } from "react-router";
 import { useAuthenticated } from "@/components/auth/hooks";
+import { SeatCapBanner } from "@/components/workspace/SeatCapBanner";
 import { AppSidebar } from "@/features/sidebar";
 import { AppBreadcrumbs } from "@/features/sidebar/breadcrumbs/AppBreadcrumbs";
 import { Toaster } from "../common/Toaster";
@@ -41,6 +42,11 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 				<ErrorBoundary>
 					<main className="flex flex-1 flex-col overflow-hidden">
 						{isAuthenticated ? <AppBreadcrumbs /> : null}
+						{/* SeatCapBanner self-gates on workspace context, so it only
+						    appears on /w/:workspaceId/* routes. Lives here (inside
+						    main) instead of WorkspaceLayout so it doesn't stretch
+						    across the sidebar column. */}
+						<SeatCapBanner />
 						<div className="flex-1 overflow-auto">
 							<Outlet />
 							{children}

--- a/echo/frontend/src/components/layout/WorkspaceLayout.tsx
+++ b/echo/frontend/src/components/layout/WorkspaceLayout.tsx
@@ -2,22 +2,16 @@ import { useEffect } from "react";
 import { Outlet, useParams } from "react-router";
 import { DowngradeBanner } from "@/components/workspace/DowngradeBanner";
 import { PilotBlockModal } from "@/components/workspace/PilotBlockModal";
-import { SeatCapBanner } from "@/components/workspace/SeatCapBanner";
 import { useWorkspace } from "@/hooks/useWorkspace";
 
 /**
  * Layout wrapper for /w/:workspaceId/* routes.
  * Reads workspaceId from URL and syncs it to workspace context.
- * Mounts the 7-day downgrade banner (matrix §3), the seat / guest cap
- * banner (matrix §7 + status-banner.md L2), and the Pilot-block modal
+ * Mounts the 7-day downgrade banner (matrix §3) and the Pilot-block modal
  * (matrix §8) so they're available on every workspace-scoped route.
+ * SeatCapBanner lives inside BaseLayout's main column so it doesn't span
+ * across the sidebar (it self-gates on workspaceId).
  * Renders the route via <Outlet />.
- *
- * Banner stacking: status-banner.md says "never stacked." DowngradeBanner
- * + SeatCapBanner can in theory overlap (workspace was downgraded AND
- * seats are full), but in practice the downgrade banner is 7-day-bounded
- * and rarely co-occurs with cap-reached. Both are dismissible per-session
- * so a user with both seen-once never sees them stacked again.
  */
 export const WorkspaceLayout = () => {
 	const { workspaceId: urlWorkspaceId } = useParams<{ workspaceId: string }>();
@@ -33,7 +27,6 @@ export const WorkspaceLayout = () => {
 	return (
 		<>
 			<DowngradeBanner />
-			<SeatCapBanner />
 			<PilotBlockModal />
 			<Outlet />
 		</>

--- a/echo/frontend/vite.config.ts
+++ b/echo/frontend/vite.config.ts
@@ -3,52 +3,157 @@ import { lingui } from "@lingui/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+// Babel plugin: inject __source into the props object of _jsx/_jsxs calls so
+// Agentation can resolve element-to-source paths in production-mode builds.
+//
+// We can't put __source on the JSX itself: @babel/plugin-transform-react-jsx
+// in automatic-runtime mode treats __source as reserved and strips it (or
+// throws "Duplicate __source prop"). So we visit CallExpressions, which fire
+// after the JSX transform replaces JSXElements with `_jsx(Foo, {…})` calls,
+// and add `__source` directly onto the props object literal. Idempotent via a
+// __injectedSource WeakSet so we don't re-process the same node twice.
+// biome-ignore lint/suspicious/noExplicitAny: babel plugin types not worth importing here
+const injectJsxSource = (babel: any) => {
+	const { types: t } = babel;
+	const JSX_CALLEES = new Set([
+		"jsx",
+		"jsxs",
+		"jsxDEV",
+		"_jsx",
+		"_jsxs",
+		"_jsxDEV",
+	]);
+	const seen = new WeakSet();
+	return {
+		name: "inject-jsx-source",
+		visitor: {
+			// biome-ignore lint/suspicious/noExplicitAny: see above
+			CallExpression(p: any, state: any) {
+				const node = p.node;
+				if (seen.has(node)) return;
+				const callee = node.callee;
+				const name =
+					callee.type === "Identifier"
+						? callee.name
+						: callee.type === "MemberExpression" &&
+								callee.property.type === "Identifier"
+							? callee.property.name
+							: null;
+				if (!name || !JSX_CALLEES.has(name)) return;
+				const propsArg = node.arguments[1];
+				if (!propsArg || propsArg.type !== "ObjectExpression") return;
+				const loc = node.loc;
+				if (!loc) return;
+				const hasSource = propsArg.properties.some(
+					// biome-ignore lint/suspicious/noExplicitAny: see above
+					(prop: any) =>
+						prop.type === "ObjectProperty" &&
+						((prop.key.type === "Identifier" && prop.key.name === "__source") ||
+							(prop.key.type === "StringLiteral" &&
+								prop.key.value === "__source")),
+				);
+				if (hasSource) {
+					seen.add(node);
+					return;
+				}
+				const cwd = state.cwd || process.cwd();
+				const filename = state.filename || "unknown";
+				let rel = path.relative(cwd, filename);
+				if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+					rel = filename;
+				}
+				rel = rel.split(path.sep).join("/");
+				propsArg.properties.push(
+					t.objectProperty(
+						t.identifier("__source"),
+						t.objectExpression([
+							t.objectProperty(t.identifier("fileName"), t.stringLiteral(rel)),
+							t.objectProperty(
+								t.identifier("lineNumber"),
+								t.numericLiteral(loc.start.line),
+							),
+							t.objectProperty(
+								t.identifier("columnNumber"),
+								t.numericLiteral(loc.start.column + 1),
+							),
+						]),
+					),
+				);
+				seen.add(node);
+			},
+		},
+	};
+};
+
 // https://vitejs.dev/config/
-export default defineConfig({
-	build: {
-		rollupOptions: {
-			output: {
-				manualChunks: {
-					ui: ["@mantine/core", "@mantine/hooks"],
-					vendor: ["react", "react-dom", "react-router"],
+export default defineConfig(({ mode }) => {
+	const isDev = mode === "development";
+	const enableAgentation = isDev || process.env.VITE_ENABLE_AGENTATION === "1";
+
+	// biome-ignore lint/suspicious/noExplicitAny: babel plugin entries are heterogeneous
+	const babelPlugins: any[] = ["macros", ["babel-plugin-react-compiler"]];
+	// biome-ignore lint/suspicious/noExplicitAny: see above
+	const babelPresets: any[] = [];
+
+	if (enableAgentation) {
+		// Take the JSX transform into Babel (instead of letting esbuild do it),
+		// then inject __source into the resulting _jsx() props object. This is the
+		// only path that survives esbuild's automatic-mode reserved-prop check
+		// AND keeps __source on memoizedProps where Agentation can read it.
+		babelPlugins.push([injectJsxSource]);
+		babelPresets.push([
+			"@babel/preset-react",
+			{ development: false, runtime: "automatic" },
+		]);
+	}
+
+	return {
+		build: {
+			rollupOptions: {
+				output: {
+					manualChunks: {
+						ui: ["@mantine/core", "@mantine/hooks"],
+						vendor: ["react", "react-dom", "react-router"],
+					},
 				},
 			},
 		},
-	},
-	plugins: [
-		react({
-			babel: {
-				plugins: ["macros", ["babel-plugin-react-compiler"]],
-			},
-		}),
-		lingui(),
-	],
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
-			// reddit fix lol: https://www.reddit.com/r/reactjs/comments/1g3tsiy/trouble_with_vite_tablericons_5600_requests/
-			"@tabler/icons-react": "@tabler/icons-react/dist/esm/icons/index.mjs",
-		},
-	},
-	server: {
-		proxy: {
-			"/api": {
-				changeOrigin: true,
-				rewrite: (path) => {
-					console.log("Proxying request to", path);
-					return path;
+		plugins: [
+			react({
+				babel: {
+					plugins: babelPlugins,
+					presets: babelPresets,
 				},
-				target: "http://localhost:8000/",
-			},
-			"/directus": {
-				changeOrigin: true,
-				rewrite: (path) => {
-					const newPath = path.replace(/^\/directus/, "/");
-					console.log("Proxying request to", newPath);
-					return newPath;
-				},
-				target: "http://directus:8055",
+			}),
+			lingui(),
+		],
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "./src"),
+				// reddit fix lol: https://www.reddit.com/r/reactjs/comments/1g3tsiy/trouble_with_vite_tablericons_5600_requests/
+				"@tabler/icons-react": "@tabler/icons-react/dist/esm/icons/index.mjs",
 			},
 		},
-	},
+		server: {
+			proxy: {
+				"/api": {
+					changeOrigin: true,
+					rewrite: (path) => {
+						console.log("Proxying request to", path);
+						return path;
+					},
+					target: "http://localhost:8000/",
+				},
+				"/directus": {
+					changeOrigin: true,
+					rewrite: (path) => {
+						const newPath = path.replace(/^\/directus/, "/");
+						console.log("Proxying request to", newPath);
+						return newPath;
+					},
+					target: "http://directus:8055",
+				},
+			},
+		},
+	};
 });


### PR DESCRIPTION
## Summary
- Adds the [Agentation](https://www.agentation.com/output) overlay to the dashboard frontend so teammates can click any element on a deployed site and copy a markdown annotation with the **source file path and line number**, so I (or any coding agent) can edit the exact line without grepping.
- **Production stays clean**: the Agentation chunk is tree-shaken out and no JSX source metadata is injected. Verified the prod build (no flag) bundles zero references to `agentation`.
- **Participant bundle stays clean** too (verified with `VITE_USE_PARTICIPANT_ROUTER=1`), so workshop participants never see the overlay even if the flag is on.

## How to enable on staging
Set `VITE_ENABLE_AGENTATION=1` in the Vercel project that deploys `dashboard.echo-next.dembrane.com`. Local dev gets it automatically via `import.meta.env.DEV`.

Once deployed, hit the keyboard shortcut (or click the bottom-right toolbar) to enter annotation mode → click an element → "Copy" → paste into Slack.

## Why this isn't trivial: surviving the production-mode JSX transform
The non-obvious part. `@vitejs/plugin-react` hands JSX off to esbuild in production builds, and esbuild's `--jsx=automatic` mode reserves `__source` and rejects user JSX that sets it (`Duplicate "__source" prop found`). And the Babel JSX transform with `development: false` *strips* `__source` outright.

So we:
1. Pull the JSX transform back into Babel via `@babel/preset-react` (only when the flag is on).
2. Add a small post-transform plugin that walks `CallExpression` nodes — by the time it runs, `<Foo bar=... />` has become `_jsx(Foo, { bar: ... })` — and adds `__source: { fileName, lineNumber, columnNumber }` directly to the props object literal. This survives all the way to `memoizedProps.__source` on the React fiber, which is what Agentation reads.
3. File paths are rewritten to repo-relative form (`src/routes/.../Foo.tsx`) so we never leak `/Users/<dev>/...` into deployed bundles.
4. The `lazy(import("agentation"))` call references `import.meta.env.DEV` / `import.meta.env.VITE_ENABLE_AGENTATION` / `import.meta.env.VITE_USE_PARTICIPANT_ROUTER` directly. Vite constant-folds these at build time, so Rollup can tree-shake the agentation chunk out of bundles where it isn't wanted. Going through an intermediate `ENABLE_AGENTATION` constant would not have produced this elimination.

## License note
`agentation@3.0.2` ships under PolyForm-Shield-1.0.0 (source-available, prohibits using it to build a competing product). Fine for internal dev tooling.

## Test plan
- [x] `pnpm build` (no flag) → zero `agentation` strings in any chunk, zero injected `__source` props.
- [x] `VITE_ENABLE_AGENTATION=1 pnpm build` → agentation lazy chunk present, `__source:{fileName:"src/...",lineNumber:N,columnNumber:N}` shape on every JSX element across all chunks (thousands of injections).
- [x] `VITE_USE_PARTICIPANT_ROUTER=1 VITE_ENABLE_AGENTATION=1 pnpm build` → no agentation in participant build even with flag on.
- [x] `pnpm exec tsc --noEmit` passes.
- [x] `pnpm exec biome check vite.config.ts src/App.tsx src/config.ts` passes (one pre-existing unused-import warning unrelated to this change).
- [ ] **Reviewer**: deploy to echo-next with the env var set, click an element, confirm copied markdown includes the relative file path. If the project key for staging isn't configured to forward `VITE_ENABLE_AGENTATION`, the build will be identical to prod and no overlay will appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Agentation visual annotation overlay for team feedback (available in dev and configurable for staging).
  * Staging badge overlay on the Dembrane logo when viewed on staging hosts.

* **Documentation**
  * Added config example and guidance for enabling Agentation in staging while keeping it disabled in production.

* **Refactor**
  * Seat cap banner moved to BaseLayout; workspace layout simplified to mount fewer banners/modals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dembrane/echo/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->