### PR TITLE
fix(frontend): remove sidebar pending-requests stub and gate org pend…

### DIFF
--- a/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { AppWindow, Folder, Gear, UserPlus } from "@phosphor-icons/react";
+import { AppWindowIcon, FolderIcon, GearIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useParams } from "react-router";
@@ -106,7 +106,7 @@ export const OrgHomeView = () => {
 				<NavItem
 					to={`${base}/overview`}
 					label={<Trans>Overview</Trans>}
-					icon={AppWindow}
+					icon={AppWindowIcon}
 					end
 				/>
 			)}
@@ -121,7 +121,7 @@ export const OrgHomeView = () => {
 							key={ws.id}
 							to={`/w/${ws.id}/home`}
 							label={ws.name}
-							icon={Folder}
+							icon={FolderIcon}
 							badge={ws.isExternal ? <Trans>External</Trans> : undefined}
 							pushes
 						/>
@@ -131,18 +131,11 @@ export const OrgHomeView = () => {
 
 			{!isExternal && (
 				<>
-					{hasDirectMembership && (
-						<NavItem
-							to={`${base}/requests`}
-							label={<Trans>Pending requests</Trans>}
-							icon={UserPlus}
-						/>
-					)}
 					<div className="mt-auto" />
 					<NavItem
 						to={`${base}/settings/general`}
 						label={<Trans>Settings</Trans>}
-						icon={Gear}
+						icon={GearIcon}
 						pushes
 					/>
 				</>

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -297,7 +297,6 @@ export const OrganisationRoute = () => {
 	// (`/o/:organisationId/<tab>`) so browser back steps between tabs and URLs
 	// are shareable. We ALSO recognise sidebar-driven URLs:
 	//   /o/:id/settings/<section>  → maps to an existing tab
-	//   /o/:id/requests            → stub, renders overview for now
 	// The sidebar pushes those URLs so its view resolver lands on
 	// "org-settings" while the content panel keeps using existing tabs.
 	const allowedTabs = [
@@ -311,7 +310,6 @@ export const OrganisationRoute = () => {
 	const segment = segments[0] ?? "";
 
 	const isSettingsPath = segment === "settings";
-	const isRequestsPath = segment === "requests";
 
 	const viewRaw: TabValue = isSettingsPath
 		? (() => {
@@ -322,16 +320,14 @@ export const OrganisationRoute = () => {
 				// general / anything else → overview (general settings).
 				return "overview";
 			})()
-		: isRequestsPath
-			? "overview"
-			: (allowedTabs as readonly string[]).includes(segment)
-				? (segment as TabValue)
-				: "overview";
+		: (allowedTabs as readonly string[]).includes(segment)
+			? (segment as TabValue)
+			: "overview";
 
 	useEffect(() => {
-		// Bounce bare /o/:id to /o/:id/overview. Don't bounce /settings/* or /requests; those are canonical sidebar URLs.
+		// Bounce bare /o/:id to /o/:id/overview. Don't bounce /settings/*; those are canonical sidebar URLs.
 		if (!organisationId) return;
-		if (isSettingsPath || isRequestsPath) return;
+		if (isSettingsPath) return;
 		if (segment !== viewRaw) {
 			navigate(`/o/${organisationId}/${viewRaw}${urlSearch}`, {
 				replace: true,
@@ -342,7 +338,6 @@ export const OrganisationRoute = () => {
 		viewRaw,
 		segment,
 		isSettingsPath,
-		isRequestsPath,
 		navigate,
 		urlSearch,
 	]);

--- a/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
@@ -294,11 +294,14 @@ export const WorkspaceSettingsRoute = () => {
 			err instanceof WorkspaceAccessDeniedError ? false : failureCount < 3,
 	});
 
-	// Live count for the "N pending" counter; the settings payload's `pending_invites` array can lag after a revoke.
+	// Live count for the "N pending" counter; endpoint is org-admin-only so gate via enabled.
 	const { data: livePendingInvites } = usePendingInvites({
+		enabled:
+			!!workspaceId &&
+			!!settings?.org_id &&
+			(settings?.my_policies?.includes("member:manage") ?? false),
 		orgId: settings?.org_id,
 		workspaceId,
-		enabled: !!workspaceId && !!settings?.org_id,
 	});
 
 	// Lightweight usage probe so the Members tab can disable the invite
@@ -450,7 +453,15 @@ export const WorkspaceSettingsRoute = () => {
 				replace: true,
 			});
 		}
-	}, [workspaceId, segment, activeTab, navigate, urlSearch, settings, defaultTab]);
+	}, [
+		workspaceId,
+		segment,
+		activeTab,
+		navigate,
+		urlSearch,
+		settings,
+		defaultTab,
+	]);
 
 	// Members list order (2026-04-24): internals first — sorted by role
 	// (owner → admin → billing → member) — then externals at the bottom.
@@ -804,7 +815,8 @@ export const WorkspaceSettingsRoute = () => {
 														</Trans>
 													) : (
 														<Trans>
-															Invite to this workspace, or just the organisation.
+															Invite to this workspace, or just the
+															organisation.
 														</Trans>
 													)
 												}
@@ -914,7 +926,11 @@ export const WorkspaceSettingsRoute = () => {
 															<Tooltip
 																label={t`Ownership is locked. Contact support to transfer.`}
 															>
-																<Badge size="sm" variant="light" color="primary">
+																<Badge
+																	size="sm"
+																	variant="light"
+																	color="primary"
+																>
 																	<Trans>Admin</Trans>
 																</Badge>
 															</Tooltip>
@@ -926,7 +942,11 @@ export const WorkspaceSettingsRoute = () => {
 															<Tooltip
 																label={t`You're the only admin. Promote someone else before changing your role.`}
 															>
-																<Badge size="sm" variant="light" color="primary">
+																<Badge
+																	size="sm"
+																	variant="light"
+																	color="primary"
+																>
 																	<Trans>Admin</Trans>
 																</Badge>
 															</Tooltip>
@@ -1105,10 +1125,8 @@ export const WorkspaceSettingsRoute = () => {
 									</Stack>
 								</Stack>
 
-								{/* Pending invites — unified component talks to
-								    /v2/orgs/:id/pending-invites?workspace_id= and the
-								    new /v2/invites/:id resend/revoke endpoints. */}
-								{workspaceId && settings.org_id && (
+								{/* Endpoint is org-admin-only; gate matches AccessRequestsList below. */}
+								{canManage && workspaceId && settings.org_id && (
 									<PendingInvitesSection
 										orgId={settings.org_id}
 										scope="workspace"


### PR DESCRIPTION
pending-invites for non-admins

  - Drop unused "Pending requests" sidebar item and /o/:id/requests stub
  - Gate PendingInvitesSection + livePendingInvites on member:manage so plain workspace members don't 403 on the org pending-invites endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed "Pending requests" navigation item from organization home view
  * Adjusted Settings link positioning and availability in organization view
  * Corrected URL routing behavior for settings sections and request pages
  * Restricted pending invites counter visibility to users with workspace management permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->