### PR TITLE
Fix/workspace external lockdown

### DIFF
--- a/echo/frontend/src/components/invite/InviteResultsList.tsx
+++ b/echo/frontend/src/components/invite/InviteResultsList.tsx
@@ -68,8 +68,16 @@ export function InviteResultsList({ rows, "data-testid": dataTestId }: Props) {
 									) : (
 										<Trans>Organisation only</Trans>
 									)}
-									{row.detail ? ` · ${row.detail}` : ""}
 								</Text>
+								{row.detail ? (
+									<Text
+										size="xs"
+										c="dimmed"
+										style={{ wordBreak: "break-word" }}
+									>
+										{row.detail}
+									</Text>
+								) : null}
 							</Stack>
 							<Badge size="sm" variant="light" color={badge.color}>
 								{badge.label}

--- a/echo/frontend/src/components/invite/InviteResultsList.tsx
+++ b/echo/frontend/src/components/invite/InviteResultsList.tsx
@@ -79,7 +79,12 @@ export function InviteResultsList({ rows, "data-testid": dataTestId }: Props) {
 									</Text>
 								) : null}
 							</Stack>
-							<Badge size="sm" variant="light" color={badge.color}>
+							<Badge
+								size="sm"
+								variant="light"
+								color={badge.color}
+								style={{ flexShrink: 0 }}
+							>
 								{badge.label}
 							</Badge>
 						</Group>

--- a/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useParams } from "react-router";
 import { API_BASE_URL } from "@/config";
+import { useV2Me } from "@/hooks/useV2Me";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { BackButton } from "../../primitives/BackButton";
 import { NavItem } from "../../primitives/NavItem";
@@ -37,6 +38,11 @@ export const OrgHomeView = () => {
 	}>();
 	const orgId = routeOrgId ?? organisationId;
 	const { workspaces: myWorkspaces } = useWorkspace();
+	const { data: me } = useV2Me();
+	const isManager = useMemo(() => {
+		const role = me?.orgs.find((o) => o.id === orgId)?.role;
+		return role === "admin" || role === "owner";
+	}, [me, orgId]);
 
 	const myOrgWorkspaces = useMemo(
 		() => myWorkspaces.filter((w) => w.org_id === orgId),
@@ -60,10 +66,14 @@ export const OrgHomeView = () => {
 	const orgName = myOrgWorkspaces[0]?.org_name ?? t`Organisation`;
 
 	const displayList = useMemo(() => {
-		if (isExternal) {
+		// Admins/owners see the whole org roster (they can open any workspace).
+		// Everyone else (member, billing, external) sees only the workspaces
+		// they directly belong to, so the sidebar never shows a workspace that
+		// dead-links on click. Discovering other workspaces happens on /w.
+		if (!isManager) {
 			return myOrgWorkspaces.map((w) => ({
 				id: w.id,
-				isExternal: true,
+				isExternal: w.role === "external",
 				name: w.name,
 			}));
 		}
@@ -83,10 +93,11 @@ export const OrgHomeView = () => {
 			isExternal: w.role === "external",
 			name: w.name,
 		}));
-	}, [isExternal, myOrgWorkspaces, orgWsQuery.data]);
+	}, [isManager, myOrgWorkspaces, orgWsQuery.data]);
 
-	// Org-only members get no children under the org node; /w handles discovery instead.
-	const hasDirectMembership = myOrgWorkspaces.length > 0;
+	// Show the Workspaces section whenever there is something to show — for
+	// managers that is the full org list, for everyone else their direct rows.
+	const showWorkspaces = displayList.length > 0;
 
 	if (!orgId) return null;
 	const base = `/o/${orgId}`;
@@ -111,7 +122,7 @@ export const OrgHomeView = () => {
 				/>
 			)}
 
-			{hasDirectMembership && (
+			{showWorkspaces && (
 				<>
 					<SectionLabel>
 						<Trans>Workspaces</Trans>

--- a/echo/server/dembrane/api/v2/_invite_helpers.py
+++ b/echo/server/dembrane/api/v2/_invite_helpers.py
@@ -7,6 +7,8 @@ from logging import getLogger
 from datetime import datetime, timezone
 from urllib.parse import urlencode
 
+from fastapi import HTTPException
+
 from dembrane.utils import generate_uuid
 from dembrane.directus_async import async_directus
 
@@ -271,3 +273,95 @@ def build_invite_accept_url(
     else:
         params["org"] = subject_name
     return f"{admin_base_url}/invite/accept?{urlencode(params)}"
+
+
+# ---------------------------------------------------------------------------
+# External membership reconciliation
+# ---------------------------------------------------------------------------
+
+
+async def _org_workspace_roles_local(org_id: str, user_id: str) -> list[str]:
+    """Roles on the user's active workspace memberships across this org.
+
+    Local to this module so reconcile's directus calls all route through the
+    module-level async_directus (keeps the write path easy to test in
+    isolation).
+    """
+    workspaces = await async_directus.get_items(
+        "workspace",
+        {
+            "query": {
+                "filter": {"org_id": {"_eq": org_id}, "deleted_at": {"_null": True}},
+                "fields": ["id"],
+                "limit": -1,
+            }
+        },
+    )
+    ws_ids = (
+        [w["id"] for w in workspaces if w.get("id")]
+        if isinstance(workspaces, list)
+        else []
+    )
+    if not ws_ids:
+        return []
+    rows = await async_directus.get_items(
+        "workspace_membership",
+        {
+            "query": {
+                "filter": {
+                    "workspace_id": {"_in": ws_ids},
+                    "user_id": {"_eq": user_id},
+                    "deleted_at": {"_null": True},
+                },
+                "fields": ["role"],
+                "limit": -1,
+            }
+        },
+    )
+    if not isinstance(rows, list):
+        return []
+    return [r.get("role") for r in rows if r.get("role")]
+
+
+async def reconcile_external_membership_org_row(org_id: str, user_id: str) -> None:
+    """Keep the insider/outsider invariant when a user is being made external.
+
+    Call this BEFORE creating the external workspace_membership, so the roles
+    read here are the user's OTHER memberships in the org:
+      - If any is internal (member/billing/admin/owner), being external too is
+        contradictory: raise 400.
+      - Otherwise soft-delete any active org_membership so the outsider rule
+        (external implies no org_membership) holds.
+    """
+    roles = await _org_workspace_roles_local(org_id, user_id)
+    if any(r in ("member", "billing", "admin", "owner") for r in roles):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This person is already a member of the organisation and cannot "
+                "also be added as an external. Remove them from the organisation first."
+            ),
+        )
+    rows = await async_directus.get_items(
+        "org_membership",
+        {
+            "query": {
+                "filter": {
+                    "org_id": {"_eq": org_id},
+                    "user_id": {"_eq": user_id},
+                    "deleted_at": {"_null": True},
+                },
+                "fields": ["id"],
+                "limit": -1,
+            }
+        },
+    )
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if row.get("id"):
+            await async_directus.update_item(
+                "org_membership",
+                row["id"],
+                {"deleted_at": datetime.now(timezone.utc).isoformat()},
+            )

--- a/echo/server/dembrane/api/v2/_invite_helpers.py
+++ b/echo/server/dembrane/api/v2/_invite_helpers.py
@@ -351,13 +351,26 @@ async def reconcile_external_membership_org_row(org_id: str, user_id: str) -> No
                     "user_id": {"_eq": user_id},
                     "deleted_at": {"_null": True},
                 },
-                "fields": ["id"],
+                "fields": ["id", "role"],
                 "limit": -1,
             }
         },
     )
     if not isinstance(rows, list):
         return
+    # Never silently demote a privileged org member. A plain 'member' org row
+    # with no internal workspace foothold is the stale-leftover case we clean
+    # up when making someone external; admin/owner/billing must be resolved
+    # explicitly (this mirrors is_org_external_only, which never treats those
+    # roles as external).
+    if any(r.get("role") in ("admin", "owner", "billing") for r in rows):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This person is an organisation admin, owner, or billing member and "
+                "cannot be added as an external. Change their organisation role first."
+            ),
+        )
     for row in rows:
         if row.get("id"):
             await async_directus.update_item(

--- a/echo/server/dembrane/api/v2/access_requests.py
+++ b/echo/server/dembrane/api/v2/access_requests.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 
 from dembrane.utils import generate_uuid
 from dembrane.app_user import get_app_user_or_raise
+from dembrane.inheritance import is_org_external_only
 from dembrane.seat_capacity import assert_can_add_seat
 from dembrane.api.rate_limit import create_user_rate_limiter
 from dembrane.directus_async import async_directus
@@ -655,6 +656,11 @@ async def list_discoverable_workspaces(
     org_role = await _org_role(org_id, app_user_id)
     if org_role is None:
         raise HTTPException(status_code=403, detail="Not a member of this organisation")
+
+    # Outsiders (external-only, even with a stale org_membership) get no
+    # discovery surface — they may only see the workspace they were invited to.
+    if await is_org_external_only(org_id, app_user_id):
+        return DiscoverResponse(workspaces=[])
 
     is_org_admin = org_role in ("admin", "owner")
 

--- a/echo/server/dembrane/api/v2/access_requests.py
+++ b/echo/server/dembrane/api/v2/access_requests.py
@@ -328,8 +328,13 @@ async def request_workspace_access(
     if org_role in ("admin", "owner"):
         raise HTTPException(
             status_code=400,
-            detail="Organisation admins can join directly — no approval needed",
+            detail="Organisation admins can join directly, no approval needed",
         )
+
+    # Outsiders (external-only, even with a stale org_membership) cannot request
+    # access — they are scoped to the workspace they were invited to.
+    if await is_org_external_only(org_id, app_user_id):
+        raise HTTPException(status_code=403, detail="Not a member of this organisation")
 
     if await _has_direct_row(workspace_id, app_user_id):
         return RequestAccessResponse(status="already_member")

--- a/echo/server/dembrane/api/v2/invites.py
+++ b/echo/server/dembrane/api/v2/invites.py
@@ -232,6 +232,16 @@ async def invite_to_workspace(
                     logger.info(f"Added {email} to org {ws_org_id} as member")
                     newly_joined_organisation = True
 
+            # External add: enforce insider XOR outsider before creating the
+            # external row (removes a stale org_membership, or rejects if the
+            # user is already an internal member of this org).
+            if is_external_invite and ws_org_id:
+                from dembrane.api.v2._invite_helpers import (
+                    reconcile_external_membership_org_row,
+                )
+
+                await reconcile_external_membership_org_row(ws_org_id, app_user["id"])
+
             # Reactivate a soft-deleted row if present; otherwise create fresh. Distinct status so UI can show "reactivated" vs "added".
             reactivated = False
             if existing_row and existing_row.get("deleted_at"):

--- a/echo/server/dembrane/api/v2/me.py
+++ b/echo/server/dembrane/api/v2/me.py
@@ -494,6 +494,15 @@ async def accept_my_invite(invite_id: str, auth: DependencyDirectusSession) -> d
             )
             newly_joined_organisation = True
 
+    # External acceptance: enforce insider XOR outsider before creating the
+    # external row.
+    if is_external_invite and ws.get("org_id"):
+        from dembrane.api.v2._invite_helpers import (
+            reconcile_external_membership_org_row,
+        )
+
+        await reconcile_external_membership_org_row(ws["org_id"], app_user_id)
+
     # Create workspace membership (if not already)
     existing_ws_mem = await async_directus.get_items(
         "workspace_membership",

--- a/echo/server/dembrane/api/v2/me.py
+++ b/echo/server/dembrane/api/v2/me.py
@@ -1505,6 +1505,17 @@ async def accept_invite_by_hash(
                             },
                         )
 
+                # External heal: enforce insider XOR outsider before recreating
+                # the external row, so the self-heal path can't bypass the lockdown.
+                if heal_is_external and ws.get("org_id"):
+                    from dembrane.api.v2._invite_helpers import (
+                        reconcile_external_membership_org_row,
+                    )
+
+                    await reconcile_external_membership_org_row(
+                        ws["org_id"], app_user_id
+                    )
+
                 await async_directus.create_item(
                     "workspace_membership",
                     {
@@ -1664,6 +1675,16 @@ async def accept_invite_by_hash(
                     "role": "member",
                 },
             )
+
+    # External acceptance: enforce insider XOR outsider before creating the
+    # external row (same guard as accept_my_invite; the email-link flow must
+    # not be a bypass).
+    if is_external_invite and ws.get("org_id"):
+        from dembrane.api.v2._invite_helpers import (
+            reconcile_external_membership_org_row,
+        )
+
+        await reconcile_external_membership_org_row(ws["org_id"], app_user_id)
 
     # Create workspace membership
     existing_ws_mem = await async_directus.get_items(

--- a/echo/server/dembrane/api/v2/orgs.py
+++ b/echo/server/dembrane/api/v2/orgs.py
@@ -34,7 +34,7 @@ from dembrane.app_user import resolve_app_user, get_app_user_or_raise
 from dembrane.directus import directus
 from dembrane.policies import ROLE_HIERARCHY
 from dembrane.settings import get_settings
-from dembrane.inheritance import on_organisation_member_removed
+from dembrane.inheritance import on_organisation_member_removed, is_org_external_only
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.seat_capacity import (
     tier_hard_blocks_seats,
@@ -1394,6 +1394,15 @@ async def list_organisation_workspaces(
             raise
     caller_is_manager = caller_role in ("admin", "owner")
     is_org_member = caller_role is not None
+
+    # An external-only caller (outsider with a stale org_membership) is scoped
+    # exactly like a guest: only the workspaces they directly belong to. Real
+    # members and managers are unaffected, so OrganisationRoute and InviteModal
+    # keep their current behavior.
+    if is_org_member and not caller_is_manager and await is_org_external_only(
+        org_id, app_user["id"]
+    ):
+        is_org_member = False
 
     ws_filter: dict = {
         "org_id": {"_eq": org_id},

--- a/echo/server/dembrane/api/v2/orgs.py
+++ b/echo/server/dembrane/api/v2/orgs.py
@@ -34,7 +34,7 @@ from dembrane.app_user import resolve_app_user, get_app_user_or_raise
 from dembrane.directus import directus
 from dembrane.policies import ROLE_HIERARCHY
 from dembrane.settings import get_settings
-from dembrane.inheritance import on_organisation_member_removed, is_org_external_only
+from dembrane.inheritance import is_org_external_only, on_organisation_member_removed
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.seat_capacity import (
     tier_hard_blocks_seats,
@@ -1399,8 +1399,10 @@ async def list_organisation_workspaces(
     # exactly like a guest: only the workspaces they directly belong to. Real
     # members and managers are unaffected, so OrganisationRoute and InviteModal
     # keep their current behavior.
-    if is_org_member and not caller_is_manager and await is_org_external_only(
-        org_id, app_user["id"]
+    if (
+        is_org_member
+        and not caller_is_manager
+        and await is_org_external_only(org_id, app_user["id"])
     ):
         is_org_member = False
 

--- a/echo/server/dembrane/inheritance.py
+++ b/echo/server/dembrane/inheritance.py
@@ -133,6 +133,68 @@ async def _get_org_role(org_id: str, user_id: str) -> Optional[str]:
     return None
 
 
+async def org_workspace_membership_roles(org_id: str, user_id: str) -> list[str]:
+    """Roles on the user's active workspace memberships across this org.
+
+    One workspace-id lookup for the org, then one membership lookup. Used to
+    decide insider (any member/billing/admin/owner row) vs outsider (only
+    external rows).
+    """
+    workspaces = await async_directus.get_items(
+        "workspace",
+        {
+            "query": {
+                "filter": {"org_id": {"_eq": org_id}, "deleted_at": {"_null": True}},
+                "fields": ["id"],
+                "limit": -1,
+            }
+        },
+    )
+    ws_ids = (
+        [w["id"] for w in workspaces if w.get("id")]
+        if isinstance(workspaces, list)
+        else []
+    )
+    if not ws_ids:
+        return []
+    rows = await async_directus.get_items(
+        "workspace_membership",
+        {
+            "query": {
+                "filter": {
+                    "workspace_id": {"_in": ws_ids},
+                    "user_id": {"_eq": user_id},
+                    "deleted_at": {"_null": True},
+                },
+                "fields": ["role"],
+                "limit": -1,
+            }
+        },
+    )
+    if not isinstance(rows, list):
+        return []
+    return [r.get("role") for r in rows if r.get("role")]
+
+
+async def is_org_external_only(org_id: str, user_id: str) -> bool:
+    """True when the user is an outsider (external) in this org regardless of
+    any org_membership row.
+
+    Per the confirmed invariant (insider XOR outsider per org), this holds
+    when the org role is not admin/owner/billing, the user has at least one
+    external workspace membership in the org, and zero internal workspace
+    memberships in the org. Robust to a stale org_membership left behind when
+    someone was converted to external.
+    """
+    role = await _get_org_role(org_id, user_id)
+    if role in ("admin", "owner", "billing"):
+        return False
+    roles = await org_workspace_membership_roles(org_id, user_id)
+    has_external = any(r == "external" for r in roles)
+    has_internal = any(r in ("member", "billing", "admin", "owner") for r in roles)
+    return has_external and not has_internal
+
+
 async def user_can_access(workspace_id: str, user_id: str) -> Optional[tuple[str, str]]:
     """Return (role, source) for this user on this workspace, or None.
 

--- a/echo/server/tests/test_discoverable_workspaces.py
+++ b/echo/server/tests/test_discoverable_workspaces.py
@@ -86,6 +86,15 @@ def _make_directus_mock(
     return mock
 
 
+@pytest.fixture(autouse=True)
+def _default_not_external():
+    with patch(
+        "dembrane.api.v2.access_requests.is_org_external_only",
+        AsyncMock(return_value=False),
+    ):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_member_only_sees_open_workspaces_with_member_counts():
     """Org member: private hidden, open workspaces return member_count."""
@@ -258,3 +267,30 @@ async def test_workspace_query_filters_deleted_tier_and_for_member_filters_visib
         "non-admin caller must positive-match open_to_organisation; "
         "_neq:private would surface NULL-visibility rows that the submit endpoint 404s on"
     )
+
+
+@pytest.mark.asyncio
+async def test_external_only_caller_gets_empty_discovery():
+    """A member-role caller who is external-only (stale org_membership) sees nothing."""
+    mock = _make_directus_mock(
+        caller_role="member",
+        workspaces=[_WS_OPEN_A, _WS_OPEN_B],
+        member_counts_by_ws={"ws-open-a": 4, "ws-open-b": 8},
+    )
+
+    with (
+        patch("dembrane.api.v2.access_requests.async_directus", mock),
+        patch(
+            "dembrane.api.v2.access_requests.get_app_user_or_raise",
+            AsyncMock(return_value=_APP_USER),
+        ),
+        patch(
+            "dembrane.api.v2.access_requests.is_org_external_only",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        app = _build_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get(f"/v2/orgs/{_ORG_ID}/discoverable-workspaces")
+    assert res.status_code == 200
+    assert res.json()["workspaces"] == []

--- a/echo/server/tests/test_is_org_external_only.py
+++ b/echo/server/tests/test_is_org_external_only.py
@@ -1,0 +1,53 @@
+"""Unit tests for inheritance.is_org_external_only (external-lockdown spec)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.inheritance import is_org_external_only
+
+_ORG = "org-1"
+_USER = "user-1"
+
+
+def _mock(*, org_role: str | None, ws_roles: list[str], org_ws_ids: list[str] | None = None) -> AsyncMock:
+    """Branch-aware async_directus mock for the inheritance module.
+
+    Calls in order: org_membership (role) -> workspace (ids) -> workspace_membership (roles).
+    """
+    ids = org_ws_ids if org_ws_ids is not None else (["ws-1"] if ws_roles else [])
+
+    async def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
+        if collection == "org_membership":
+            return [{"role": org_role}] if org_role else []
+        if collection == "workspace":
+            return [{"id": wid} for wid in ids]
+        if collection == "workspace_membership":
+            return [{"role": r} for r in ws_roles]
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    return mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "org_role,ws_roles,expected",
+    [
+        (None, ["external"], True),
+        ("member", ["external"], True),
+        ("member", ["member", "external"], False),
+        ("member", [], False),
+        ("billing", ["external"], False),
+        ("admin", ["external"], False),
+        ("owner", ["external"], False),
+        (None, [], False),
+    ],
+)
+async def test_is_org_external_only_truth_table(org_role, ws_roles, expected):
+    with patch("dembrane.inheritance.async_directus", _mock(org_role=org_role, ws_roles=ws_roles)):
+        assert await is_org_external_only(_ORG, _USER) is expected

--- a/echo/server/tests/test_org_workspaces_external_scoping.py
+++ b/echo/server/tests/test_org_workspaces_external_scoping.py
@@ -9,14 +9,26 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI
 
-from dembrane.api.dependency_auth import DirectusSession, require_directus_session
 from dembrane.api.v2.orgs import router
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
 
 _USER_ID = "du-1"
 _APP_USER = {"id": "au-1", "email": "u@example.com", "display_name": "U"}
 _ORG_ID = "org-1"
-_WS_MINE = {"id": "ws-mine", "name": "Mine", "tier": "guardian", "is_default": False, "settings": {}}
-_WS_OTHER = {"id": "ws-other", "name": "Other", "tier": "guardian", "is_default": False, "settings": {}}
+_WS_MINE = {
+    "id": "ws-mine",
+    "name": "Mine",
+    "tier": "guardian",
+    "is_default": False,
+    "settings": {},
+}
+_WS_OTHER = {
+    "id": "ws-other",
+    "name": "Other",
+    "tier": "guardian",
+    "is_default": False,
+    "settings": {},
+}
 
 
 def _build_app() -> FastAPI:

--- a/echo/server/tests/test_org_workspaces_external_scoping.py
+++ b/echo/server/tests/test_org_workspaces_external_scoping.py
@@ -1,0 +1,90 @@
+"""GET /v2/orgs/:id/workspaces scopes external-only callers to their direct workspaces."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+from dembrane.api.v2.orgs import router
+
+_USER_ID = "du-1"
+_APP_USER = {"id": "au-1", "email": "u@example.com", "display_name": "U"}
+_ORG_ID = "org-1"
+_WS_MINE = {"id": "ws-mine", "name": "Mine", "tier": "guardian", "is_default": False, "settings": {}}
+_WS_OTHER = {"id": "ws-other", "name": "Other", "tier": "guardian", "is_default": False, "settings": {}}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    async def _fake_auth() -> DirectusSession:
+        return DirectusSession(user_id=_USER_ID, is_admin=False)
+
+    app.dependency_overrides[require_directus_session] = _fake_auth
+    app.include_router(router, prefix="/v2/orgs")
+    return app
+
+
+def _mock() -> AsyncMock:
+    """Caller has org_membership=member (stale) and a direct membership only in ws-mine."""
+
+    async def get_items(collection: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        query = params.get("query", {})
+        filt = query.get("filter", {})
+        if collection == "org_membership":
+            return [{"role": "member"}]
+        if collection == "workspace_membership":
+            if query.get("aggregate"):
+                return [{"workspace_id": "ws-mine", "count": {"id": 1}}]
+            return [{"workspace_id": "ws-mine"}]
+        if collection == "workspace":
+            id_filter = (filt.get("id") or {}).get("_in")
+            if id_filter is not None:
+                return [w for w in (_WS_MINE, _WS_OTHER) if w["id"] in id_filter]
+            return [_WS_MINE, _WS_OTHER]
+        if collection == "project":
+            return []
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_external_only_caller_sees_only_direct_workspaces():
+    mock = _mock()
+    with (
+        patch("dembrane.api.v2.orgs.async_directus", mock),
+        patch("dembrane.api.v2.orgs.get_app_user_or_raise", AsyncMock(return_value=_APP_USER)),
+        patch("dembrane.api.v2.orgs.is_org_external_only", AsyncMock(return_value=True)),
+        patch("dembrane.api.v2.orgs.get_capacity", lambda *_a, **_k: None),
+    ):
+        app = _build_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get(f"/v2/orgs/{_ORG_ID}/workspaces")
+    assert res.status_code == 200
+    ids = [w["id"] for w in res.json()]
+    assert ids == ["ws-mine"]
+
+
+@pytest.mark.asyncio
+async def test_real_member_still_sees_full_list():
+    mock = _mock()
+    with (
+        patch("dembrane.api.v2.orgs.async_directus", mock),
+        patch("dembrane.api.v2.orgs.get_app_user_or_raise", AsyncMock(return_value=_APP_USER)),
+        patch("dembrane.api.v2.orgs.is_org_external_only", AsyncMock(return_value=False)),
+        patch("dembrane.api.v2.orgs.get_capacity", lambda *_a, **_k: None),
+    ):
+        app = _build_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.get(f"/v2/orgs/{_ORG_ID}/workspaces")
+    assert res.status_code == 200
+    ids = sorted(w["id"] for w in res.json())
+    assert ids == ["ws-mine", "ws-other"]

--- a/echo/server/tests/test_reconcile_external_org_membership.py
+++ b/echo/server/tests/test_reconcile_external_org_membership.py
@@ -1,0 +1,60 @@
+"""Tests for reconcile_external_membership_org_row (external-lockdown spec)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from dembrane.api.v2._invite_helpers import reconcile_external_membership_org_row
+
+_ORG = "org-1"
+_USER = "user-1"
+
+
+def _mock(*, ws_roles: list[str], org_membership_ids: list[str]) -> AsyncMock:
+    async def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
+        if collection == "workspace":
+            return [{"id": "ws-1"}]
+        if collection == "workspace_membership":
+            return [{"role": r} for r in ws_roles]
+        if collection == "org_membership":
+            return [{"id": i} for i in org_membership_ids]
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    mock.update_item = AsyncMock(return_value={"data": {}})
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_soft_deletes_stale_org_membership_when_no_internal():
+    mock = _mock(ws_roles=[], org_membership_ids=["om-1"])
+    with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
+        await reconcile_external_membership_org_row(_ORG, _USER)
+    mock.update_item.assert_awaited_once()
+    args = mock.update_item.await_args.args
+    assert args[0] == "org_membership"
+    assert args[1] == "om-1"
+    assert args[2].get("deleted_at") is not None
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_user_has_internal_membership():
+    mock = _mock(ws_roles=["member"], org_membership_ids=["om-1"])
+    with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
+        with pytest.raises(HTTPException) as exc:
+            await reconcile_external_membership_org_row(_ORG, _USER)
+    assert exc.value.status_code == 400
+    mock.update_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_no_org_membership():
+    mock = _mock(ws_roles=[], org_membership_ids=[])
+    with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
+        await reconcile_external_membership_org_row(_ORG, _USER)
+    mock.update_item.assert_not_awaited()

--- a/echo/server/tests/test_reconcile_external_org_membership.py
+++ b/echo/server/tests/test_reconcile_external_org_membership.py
@@ -14,14 +14,14 @@ _ORG = "org-1"
 _USER = "user-1"
 
 
-def _mock(*, ws_roles: list[str], org_membership_ids: list[str]) -> AsyncMock:
+def _mock(*, ws_roles: list[str], org_memberships: list[dict[str, Any]]) -> AsyncMock:
     async def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
         if collection == "workspace":
             return [{"id": "ws-1"}]
         if collection == "workspace_membership":
             return [{"role": r} for r in ws_roles]
         if collection == "org_membership":
-            return [{"id": i} for i in org_membership_ids]
+            return list(org_memberships)
         return []
 
     mock = AsyncMock()
@@ -31,8 +31,9 @@ def _mock(*, ws_roles: list[str], org_membership_ids: list[str]) -> AsyncMock:
 
 
 @pytest.mark.asyncio
-async def test_soft_deletes_stale_org_membership_when_no_internal():
-    mock = _mock(ws_roles=[], org_membership_ids=["om-1"])
+async def test_soft_deletes_member_org_membership_when_no_internal():
+    """A plain org-only member becoming external: their member org row is cleaned up."""
+    mock = _mock(ws_roles=[], org_memberships=[{"id": "om-1", "role": "member"}])
     with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
         await reconcile_external_membership_org_row(_ORG, _USER)
     mock.update_item.assert_awaited_once()
@@ -43,8 +44,8 @@ async def test_soft_deletes_stale_org_membership_when_no_internal():
 
 
 @pytest.mark.asyncio
-async def test_rejects_when_user_has_internal_membership():
-    mock = _mock(ws_roles=["member"], org_membership_ids=["om-1"])
+async def test_rejects_when_user_has_internal_workspace_membership():
+    mock = _mock(ws_roles=["member"], org_memberships=[{"id": "om-1", "role": "member"}])
     with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
         with pytest.raises(HTTPException) as exc:
             await reconcile_external_membership_org_row(_ORG, _USER)
@@ -53,8 +54,21 @@ async def test_rejects_when_user_has_internal_membership():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("org_role", ["admin", "owner", "billing"])
+async def test_rejects_and_preserves_privileged_org_role(org_role):
+    """An org admin/owner/billing must never be silently demoted to external."""
+    mock = _mock(ws_roles=[], org_memberships=[{"id": "om-1", "role": org_role}])
+    with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
+        with pytest.raises(HTTPException) as exc:
+            await reconcile_external_membership_org_row(_ORG, _USER)
+    assert exc.value.status_code == 400
+    # The privileged org_membership must be left intact, not soft-deleted.
+    mock.update_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_noop_when_no_org_membership():
-    mock = _mock(ws_roles=[], org_membership_ids=[])
+    mock = _mock(ws_roles=[], org_memberships=[])
     with patch("dembrane.api.v2._invite_helpers.async_directus", mock):
         await reconcile_external_membership_org_row(_ORG, _USER)
     mock.update_item.assert_not_awaited()

--- a/echo/server/tests/test_request_workspace_access.py
+++ b/echo/server/tests/test_request_workspace_access.py
@@ -1,0 +1,79 @@
+"""Tests for POST /v2/workspaces/:id/access-requests role gating."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+from dembrane.api.v2.access_requests import router
+
+_USER_ID = "du-1"
+_APP_USER = {"id": "au-1", "email": "u@example.com", "display_name": "U"}
+_ORG_ID = "org-1"
+_WS_ID = "ws-1"
+_WS = {"id": _WS_ID, "org_id": _ORG_ID, "visibility": "open_to_organisation", "tier": "pioneer", "name": "WS"}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    async def _fake_auth() -> DirectusSession:
+        return DirectusSession(user_id=_USER_ID, is_admin=False)
+
+    app.dependency_overrides[require_directus_session] = _fake_auth
+    app.include_router(router, prefix="/v2/workspaces")
+    return app
+
+
+def _mock(*, org_role: str | None) -> AsyncMock:
+    async def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
+        if collection == "org_membership":
+            return [{"role": org_role}] if org_role else []
+        if collection == "workspace_membership":
+            return []
+        if collection == "access_request":
+            return []
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    mock.get_item = AsyncMock(return_value=dict(_WS))
+    mock.create_item = AsyncMock(return_value={"data": {"id": "req-1"}})
+    return mock
+
+
+async def _post(*, org_role: str, is_external: bool) -> int:
+    mock = _mock(org_role=org_role)
+    with (
+        patch("dembrane.api.v2.access_requests.async_directus", mock),
+        patch("dembrane.api.v2.access_requests._request_access_rate_limiter.check", AsyncMock()),
+        patch("dembrane.api.v2.access_requests.get_app_user_or_raise", AsyncMock(return_value=_APP_USER)),
+        patch("dembrane.api.v2.access_requests.is_org_external_only", AsyncMock(return_value=is_external)),
+        patch("dembrane.notifications.emit_to_audience", AsyncMock()),
+        patch("dembrane.notifications.audience_workspace_admins", AsyncMock(return_value=[])),
+        patch("dembrane.notifications.audience_organisation_admins", AsyncMock(return_value=[])),
+    ):
+        app = _build_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.post(f"/v2/workspaces/{_WS_ID}/access-requests")
+    return res.status_code
+
+
+@pytest.mark.asyncio
+async def test_member_can_request():
+    assert await _post(org_role="member", is_external=False) == 200
+
+
+@pytest.mark.asyncio
+async def test_billing_can_request():
+    assert await _post(org_role="billing", is_external=False) == 200
+
+
+@pytest.mark.asyncio
+async def test_external_only_rejected():
+    assert await _post(org_role="member", is_external=True) == 403


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced external membership classification for organization users with associated access restrictions.
  * External-only members can no longer request workspace access or discover workspaces.

* **Improvements**
  * Enhanced invite results display with improved formatting and readability.
  * Updated workspace sidebar visibility to respect user role and membership status within organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->