### PR TITLE
fix(access): scope billing role to finance-only visibility

### DIFF
--- a/echo/frontend/src/components/invite/RoleSelect.tsx
+++ b/echo/frontend/src/components/invite/RoleSelect.tsx
@@ -38,7 +38,7 @@ export function RoleSelect({
 			{
 				value: "billing",
 				label: t`Billing`,
-				description: t`Manages plans and invoices for the organisation.`,
+				description: t`Sees usage and invoices. No project or content access.`,
 			},
 			{
 				value: "admin",

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -380,10 +380,16 @@ export const OrganisationRoute = () => {
 
 	const isAdmin =
 		organisation?.role === "owner" || organisation?.role === "admin";
-	// Admin-only views fall back to People for other roles so landing
-	// state is never an empty panel for them.
+	// Financial visibility mirrors the backend's `sees_financials`
+	// (orgs.py get_org_usage): owner/admin/billing. Billing is a
+	// finance-only role, so it must reach Usage + Billing even though it
+	// isn't an admin.
+	const canSeeFinancials =
+		isAdmin || organisation?.role === "billing";
+	// Views the caller can't open fall back to People so landing state is
+	// never an empty panel for them.
 	const view: TabValue =
-		!isAdmin && (viewRaw === "usage" || viewRaw === "billing")
+		!canSeeFinancials && (viewRaw === "usage" || viewRaw === "billing")
 			? "people"
 			: viewRaw;
 
@@ -679,7 +685,7 @@ export const OrganisationRoute = () => {
 						/>
 					</Tabs.Panel>
 
-					{isAdmin && (
+					{canSeeFinancials && (
 						<Tabs.Panel value="usage" pt="md">
 							<Stack gap="md">
 								{organisationId && (
@@ -689,7 +695,7 @@ export const OrganisationRoute = () => {
 						</Tabs.Panel>
 					)}
 
-					{isAdmin && (
+					{canSeeFinancials && (
 						<Tabs.Panel value="billing" pt="md">
 							<Paper withBorder p="md" radius="sm">
 								<Stack gap={8}>

--- a/echo/server/dembrane/api/v2/access_requests.py
+++ b/echo/server/dembrane/api/v2/access_requests.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 
 from dembrane.utils import generate_uuid
 from dembrane.app_user import get_app_user_or_raise
-from dembrane.inheritance import is_org_external_only
+from dembrane.inheritance import is_org_billing_only, is_org_external_only
 from dembrane.seat_capacity import assert_can_add_seat
 from dembrane.api.rate_limit import create_user_rate_limiter
 from dembrane.directus_async import async_directus
@@ -529,13 +529,25 @@ async def approve_access_request(
         # pending so the approving admin sees an upgrade prompt and can
         # act later.
         await assert_can_add_seat(workspace, audience="admin")
+
+        # Billers are finance-visibility only (matrix v1.1 §4/§5): they get
+        # the workspace 'billing' preset (usage/invoices/payment, no project
+        # or content access), never the operational 'member' role. Biller-ness
+        # covers both org-level billers (org_membership.role='billing') and
+        # workspace-scoped billers (only 'billing' workspace roles in this
+        # org) — see inheritance.is_org_billing_only. Everyone else gets
+        # 'member'.
+        requester_is_biller = await is_org_billing_only(
+            workspace.get("org_id") or "", requester_id
+        )
+        granted_role = "billing" if requester_is_biller else "member"
         await async_directus.create_item(
             "workspace_membership",
             {
                 "id": generate_uuid(),
                 "workspace_id": workspace_id,
                 "user_id": requester_id,
-                "role": "member",
+                "role": granted_role,
                 "source": "direct",
             },
         )

--- a/echo/server/dembrane/inheritance.py
+++ b/echo/server/dembrane/inheritance.py
@@ -195,6 +195,28 @@ async def is_org_external_only(org_id: str, user_id: str) -> bool:
     return has_external and not has_internal
 
 
+async def is_org_billing_only(org_id: str, user_id: str) -> bool:
+    """True when the user is a biller in this org (finance visibility only,
+    matrix v1.1 §4/§5) — they must never be granted operational access.
+
+    Two ways to be a biller:
+      - org_membership.role = 'billing' (org-level biller), regardless of
+        workspace rows, or
+      - workspace-scoped biller: org role is not admin/owner, and the user's
+        workspace roles in this org include 'billing' with no operational
+        role (member/admin/owner) anywhere in the org.
+    """
+    role = await _get_org_role(org_id, user_id)
+    if role == "billing":
+        return True
+    if role in ("admin", "owner"):
+        return False
+    roles = await org_workspace_membership_roles(org_id, user_id)
+    has_billing = any(r == "billing" for r in roles)
+    has_operational = any(r in ("member", "admin", "owner") for r in roles)
+    return has_billing and not has_operational
+
+
 async def user_can_access(workspace_id: str, user_id: str) -> Optional[tuple[str, str]]:
     """Return (role, source) for this user on this workspace, or None.
 

--- a/echo/server/tests/test_approve_access_request_role.py
+++ b/echo/server/tests/test_approve_access_request_role.py
@@ -1,0 +1,100 @@
+"""Tests for the workspace role granted by approve_access_request.
+
+Matrix v1.1 §4/§5: a biller is finance-visibility only. When their workspace
+access request is approved they must be granted the workspace 'billing' role
+(finance-only preset), NOT 'member' (operational access to projects +
+conversations). Biller-ness comes from inheritance.is_org_billing_only:
+org role 'billing', or workspace-scoped billers (only 'billing' workspace
+roles in the org). Everyone else still gets 'member'.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.api.dependency_auth import DirectusSession
+from dembrane.api.v2.access_requests import approve_access_request
+
+_ACTOR_DU = "du-actor"
+_ACTOR_APP = {"id": "actor-1", "email": "a@example.com", "display_name": "A"}
+_ORG_ID = "org-1"
+_WS_ID = "ws-1"
+_REQUESTER_ID = "requester-1"
+_WS = {"id": _WS_ID, "org_id": _ORG_ID, "visibility": "open_to_organisation", "tier": "pioneer", "name": "WS"}
+
+
+def _mock() -> AsyncMock:
+    async def get_items(collection: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        filt = params.get("query", {}).get("filter", {})
+        if collection == "org_membership":
+            # Actor authorization (_require_can_action_requests) filters on role.
+            if "role" in filt:
+                return [{"role": "admin"}]
+            return []
+        if collection == "workspace_membership":
+            # No direct rows for either actor or requester.
+            return []
+        if collection == "access_request":
+            return [
+                {
+                    "id": "req-1",
+                    "workspace_id": _WS_ID,
+                    "user_id": _REQUESTER_ID,
+                    "status": "pending",
+                }
+            ]
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    mock.get_item = AsyncMock(return_value=dict(_WS))
+    mock.create_item = AsyncMock(return_value={"data": {"id": "wm-1"}})
+    mock.update_item = AsyncMock(return_value={"data": {}})
+    return mock
+
+
+async def _approve(*, requester_is_biller: bool) -> str:
+    """Run approve and return the workspace_membership role that was created."""
+    mock = _mock()
+    biller_mock = AsyncMock(return_value=requester_is_biller)
+    with (
+        patch("dembrane.api.v2.access_requests.async_directus", mock),
+        patch(
+            "dembrane.api.v2.access_requests.get_app_user_or_raise",
+            AsyncMock(return_value=_ACTOR_APP),
+        ),
+        patch(
+            "dembrane.api.v2.access_requests.assert_can_add_seat", AsyncMock()
+        ),
+        patch(
+            "dembrane.api.v2.access_requests.is_org_billing_only", biller_mock
+        ),
+        patch(
+            "dembrane.cache_utils.invalidate_workspace_and_org_usage", AsyncMock()
+        ),
+        patch("dembrane.notifications.emit", AsyncMock()),
+    ):
+        auth = DirectusSession(user_id=_ACTOR_DU, is_admin=False)
+        await approve_access_request(_WS_ID, "req-1", auth)
+
+    # The predicate must be evaluated for the REQUESTER in the workspace's org.
+    biller_mock.assert_awaited_once_with(_ORG_ID, _REQUESTER_ID)
+
+    membership_calls = [
+        c for c in mock.create_item.call_args_list if c[0][0] == "workspace_membership"
+    ]
+    assert membership_calls, "expected a workspace_membership to be created"
+    return membership_calls[0][0][1]["role"]
+
+
+@pytest.mark.asyncio
+async def test_non_biller_requester_granted_member_role():
+    assert await _approve(requester_is_biller=False) == "member"
+
+
+@pytest.mark.asyncio
+async def test_biller_requester_granted_billing_role():
+    assert await _approve(requester_is_biller=True) == "billing"

--- a/echo/server/tests/test_is_org_billing_only.py
+++ b/echo/server/tests/test_is_org_billing_only.py
@@ -1,0 +1,70 @@
+"""Unit tests for inheritance.is_org_billing_only (finance-only insider).
+
+A biller must never be granted operational access from an access-request
+approval. Two ways to be a biller in an org:
+  - org_membership.role = 'billing' (org-level biller), or
+  - workspace-scoped biller: only 'billing' workspace roles in the org and
+    no operational role (member/admin/owner) anywhere in it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.inheritance import is_org_billing_only
+
+_ORG = "org-1"
+_USER = "user-1"
+
+
+def _mock(*, org_role: str | None, ws_roles: list[str]) -> AsyncMock:
+    """Branch-aware async_directus mock for the inheritance module.
+
+    Calls in order: org_membership (role) -> workspace (ids) -> workspace_membership (roles).
+    """
+    ids = ["ws-1"] if ws_roles else []
+
+    async def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
+        if collection == "org_membership":
+            return [{"role": org_role}] if org_role else []
+        if collection == "workspace":
+            return [{"id": wid} for wid in ids]
+        if collection == "workspace_membership":
+            return [{"role": r} for r in ws_roles]
+        return []
+
+    mock = AsyncMock()
+    mock.get_items = AsyncMock(side_effect=get_items)
+    return mock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "org_role,ws_roles,expected",
+    [
+        # Org-level biller: always a biller, regardless of workspace rows.
+        ("billing", [], True),
+        ("billing", ["billing"], True),
+        ("billing", ["member"], True),
+        # Workspace-scoped biller (org member, only billing ws roles).
+        ("member", ["billing"], True),
+        ("member", ["billing", "billing"], True),
+        # Mixed roles: operational somewhere -> not a pure biller.
+        ("member", ["billing", "member"], False),
+        ("member", ["member"], False),
+        # Org-only member (ADR 0004): no ws roles, not a biller.
+        ("member", [], False),
+        # Admin/owner are never billers.
+        ("admin", ["billing"], False),
+        ("owner", ["billing"], False),
+        # No org row: stale/edge states. Billing-only ws roles still a biller.
+        (None, ["billing"], True),
+        (None, [], False),
+    ],
+)
+async def test_is_org_billing_only_truth_table(org_role, ws_roles, expected):
+    with patch("dembrane.inheritance.async_directus", _mock(org_role=org_role, ws_roles=ws_roles)):
+        assert await is_org_billing_only(_ORG, _USER) is expected


### PR DESCRIPTION
  Billers could gain operational access while being locked out of the
  financial surfaces they own:

  - approve_access_request wrote a hardcoded role='member' row, so a biller approved into a workspace could create projects and read content. Grant role='billing' instead, decided by the new inheritance.is_org_billing_only predicate: org-level billers (org_membership.role='billing') and workspace-scoped billers (only 'billing' workspace roles in the org, no operational role). Mixed roles still grant 'member'.
  - The org settings Usage and Billing tabs were gated on admin/owner, bouncing org billers to Members. Gate on canSeeFinancials (owner/admin/billing), mirroring the backend's sees_financials in get_org_usage.
  - The invite role picker described Billing as org-wide ("Manages plans and invoices for the organisation") while workspace invites are workspace-scoped. Reword to "Sees usage and invoices. No project or content access."

  Tests: truth table for is_org_billing_only; approval grants billing to
  billers and member to everyone else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing role users now have access to financial views including usage information and invoicing panels.
  * Access request approvals now correctly assign the billing role to billing-only users instead of the member role.

* **Updates**
  * Updated Billing invite role description to clarify permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->