### PR TITLE
feat(sidebar): add footer user menu with logout and language picker

### DIFF
--- a/echo/frontend/src/components/common/UserAvatar.tsx
+++ b/echo/frontend/src/components/common/UserAvatar.tsx
@@ -50,7 +50,7 @@ export const UserAvatar = ({ size = 32 }: UserAvatarProps) => {
 			src={avatarUrl}
 			size={size}
 			radius="50%"
-			color="blue"
+			color="primary"
 			className="shrink-0"
 		>
 			{initials}

--- a/echo/frontend/src/features/sidebar/AppSidebar.tsx
+++ b/echo/frontend/src/features/sidebar/AppSidebar.tsx
@@ -7,6 +7,7 @@ import { useRecordRecents } from "./hooks/useRecordRecents";
 import { useSidebarView } from "./hooks/useSidebarView";
 import { SidebarHeader } from "./shell/SidebarHeader";
 import { SidebarShell } from "./shell/SidebarShell";
+import { UserMenu } from "./shell/UserMenu";
 import { useSidebarWhitelabelLogo } from "./shell/useSidebarWhitelabelLogo";
 import { AdminHomeView } from "./views/admin/AdminHomeView";
 import { HelpView } from "./views/HelpView";
@@ -50,7 +51,20 @@ export const AppSidebar = () => {
 	})();
 
 	return (
-		<SidebarShell header={<SidebarHeader />} footer={<HelpBlock />}>
+		<SidebarShell
+			header={<SidebarHeader />}
+			footer={
+				<>
+					<HelpBlock />
+					<div
+						className="mt-1 border-t pt-1.5 pb-1"
+						style={{ borderColor: "rgba(45, 45, 44, 0.06)" }}
+					>
+						<UserMenu />
+					</div>
+				</>
+			}
+		>
 			<div
 				className="flex shrink-0 flex-col gap-0.5 border-b p-1.5"
 				style={{ borderColor: "rgba(45, 45, 44, 0.06)" }}

--- a/echo/frontend/src/features/sidebar/shell/UserMenu.tsx
+++ b/echo/frontend/src/features/sidebar/shell/UserMenu.tsx
@@ -2,75 +2,42 @@ import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Box, Group, Menu, Text, UnstyledButton } from "@mantine/core";
 import {
-	ArrowUpRight,
-	Bug,
-	ChatCircle,
 	Envelope,
 	Gear,
-	Note,
 	ShieldStar,
 	SignOut,
 	Sparkle,
-	Users,
 } from "@phosphor-icons/react";
-import * as Sentry from "@sentry/react";
-import { useState } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation } from "react-router";
 import {
 	useAuthenticated,
 	useCurrentUser,
 	useLogoutMutation,
 } from "@/components/auth/hooks";
 import { isAuthPath } from "@/components/auth/utils/authPaths";
-import { FeedbackPortalModal } from "@/components/common/FeedbackPortalModal";
 import { UserAvatar } from "@/components/common/UserAvatar";
 import { LanguagePicker } from "@/components/language/LanguagePicker";
 import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
-import { COMMUNITY_SLACK_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useV2Me } from "@/hooks/useV2Me";
 
-const ReportIssueItem = ({ onFallback }: { onFallback: () => void }) => {
-	const handleClick = async () => {
-		const feedback = Sentry.getFeedback();
-		if (feedback) {
-			const form = await feedback.createForm();
-			if (form) {
-				form.appendToDom();
-				form.open();
-				return;
-			}
-		}
-		onFallback();
-	};
-	return (
-		<Menu.Item leftSection={<Bug size={14} />} onClick={handleClick}>
-			<Trans>Report an issue</Trans>
-		</Menu.Item>
-	);
-};
-
+// Docs, Slack, and feedback intentionally live in HelpBlock (rendered
+// directly above this row in the sidebar footer), so this menu only
+// carries user-scoped actions: settings, language, staff, logout.
 export const UserMenu = () => {
 	const { isAuthenticated } = useAuthenticated();
 	const { data: user } = useCurrentUser({ enabled: isAuthenticated });
 	const { data: meV2 } = useV2Me({ enabled: isAuthenticated });
 	const logoutMutation = useLogoutMutation();
-	const { language } = useParams();
 	const location = useLocation();
 	const navigate = useI18nNavigate();
 	const { runTransition } = useTransitionCurtain();
-	const [feedbackOpen, setFeedbackOpen] = useState(false);
 
 	if (!isAuthenticated || !user) return null;
 
 	const needsOnboarding = meV2?.onboarding_completed === false;
 	const hasPendingInvites = meV2?.has_pending_invites === true;
 	const isStaff = meV2?.is_staff === true;
-
-	const docUrl =
-		language === "nl-NL"
-			? "https://docs.dembrane.com/nl-NL"
-			: "https://docs.dembrane.com/en-US";
 
 	const handleLogout = async () => {
 		if (logoutMutation.isPending) return;
@@ -83,133 +50,86 @@ export const UserMenu = () => {
 	};
 
 	return (
-		<>
-			<Menu
-				withArrow
-				arrowPosition="center"
-				width={240}
-				position="right-end"
-				offset={8}
-				keepMounted
-			>
-				<Menu.Target>
-					<UnstyledButton
-						className="flex h-[36px] w-full items-center gap-2 rounded-md px-2 transition-colors hover:bg-black/[0.04]"
-						style={{ color: "#2d2d2c" }}
-					>
-						<UserAvatar size={22} />
-						<Box className="min-w-0 flex-1 text-left">
-							<Text size="xs" lh={1.1} truncate>
-								{user.first_name ?? t`there`}
-							</Text>
-							<Text size="xs" c="dimmed" lh={1.1} truncate>
-								{user.email ?? ""}
-							</Text>
-						</Box>
-					</UnstyledButton>
-				</Menu.Target>
-
-				<Menu.Dropdown className="py-2 [&_.mantine-Menu-item]:my-0.5">
-					{needsOnboarding && (
-						<Menu.Item
-							leftSection={<Sparkle size={14} />}
-							onClick={() => navigate("/onboarding")}
-							color="blue"
-						>
-							<Trans>Set up workspace</Trans>
-						</Menu.Item>
-					)}
-					{hasPendingInvites && (
-						<Menu.Item
-							leftSection={<Envelope size={14} />}
-							onClick={() => navigate("/invites")}
-							color="blue"
-						>
-							<Trans>You have a pending invite</Trans>
-						</Menu.Item>
-					)}
-					<Menu.Item
-						leftSection={<Gear size={14} />}
-						onClick={() => navigate("/settings")}
-					>
-						<Trans>Settings</Trans>
-					</Menu.Item>
-					<Menu.Item
-						className="group"
-						leftSection={<Note size={14} />}
-						rightSection={
-							<ArrowUpRight
-								size={11}
-								className="opacity-0 transition-opacity group-hover:opacity-55"
-							/>
-						}
-						component="a"
-						href={docUrl}
-						target="_blank"
-					>
-						<Trans>Documentation</Trans>
-					</Menu.Item>
-
-					<Menu.Divider my={6} />
-
-					<Menu.Item
-						leftSection={<ChatCircle size={14} />}
-						onClick={() => setFeedbackOpen(true)}
-					>
-						<Trans>Feedback portal</Trans>
-					</Menu.Item>
-					<ReportIssueItem onFallback={() => setFeedbackOpen(true)} />
-					<Menu.Item
-						className="group"
-						leftSection={<Users size={14} />}
-						rightSection={
-							<ArrowUpRight
-								size={11}
-								className="opacity-0 transition-opacity group-hover:opacity-55"
-							/>
-						}
-						component="a"
-						href={COMMUNITY_SLACK_URL}
-						target="_blank"
-					>
-						<Trans>Slack community</Trans>
-					</Menu.Item>
-
-					<Menu.Divider my={6} />
-
-					{isStaff && (
-						<Menu.Item
-							leftSection={<ShieldStar size={14} />}
-							onClick={() => navigate("/admin")}
-						>
-							<Trans>Staff</Trans>
-						</Menu.Item>
-					)}
-
-					<Box px="sm" py={4}>
-						<Group justify="space-between" align="center">
-							<Text size="xs" c="dimmed">
-								<Trans>Language</Trans>
-							</Text>
-							<LanguagePicker />
-						</Group>
+		<Menu
+			withArrow
+			arrowPosition="center"
+			width={240}
+			position="right-end"
+			offset={8}
+			keepMounted
+		>
+			<Menu.Target>
+				<UnstyledButton
+					className="flex h-[36px] w-full items-center gap-2 rounded-md px-2 transition-colors hover:bg-black/[0.04]"
+					style={{ color: "#2d2d2c" }}
+				>
+					<UserAvatar size={22} />
+					<Box className="min-w-0 flex-1 text-left">
+						<Text size="xs" lh={1.1} truncate>
+							{user.first_name ?? t`there`}
+						</Text>
+						<Text size="xs" c="dimmed" lh={1.1} truncate>
+							{user.email ?? ""}
+						</Text>
 					</Box>
+				</UnstyledButton>
+			</Menu.Target>
 
+			<Menu.Dropdown className="py-2 [&_.mantine-Menu-item]:my-0.5">
+				{needsOnboarding && (
 					<Menu.Item
-						leftSection={<SignOut size={14} />}
-						onClick={handleLogout}
-						color="red"
+						leftSection={<Sparkle size={14} />}
+						onClick={() => navigate("/onboarding")}
+						color="primary"
 					>
-						<Trans>Logout</Trans>
+						<Trans>Set up workspace</Trans>
 					</Menu.Item>
-				</Menu.Dropdown>
-			</Menu>
+				)}
+				{hasPendingInvites && (
+					<Menu.Item
+						leftSection={<Envelope size={14} />}
+						onClick={() => navigate("/invites")}
+						color="primary"
+					>
+						<Trans>You have a pending invite</Trans>
+					</Menu.Item>
+				)}
+				<Menu.Item
+					leftSection={<Gear size={14} />}
+					onClick={() => navigate("/settings")}
+				>
+					<Trans>Settings</Trans>
+				</Menu.Item>
+				{isStaff && (
+					<Menu.Item
+						leftSection={<ShieldStar size={14} />}
+						onClick={() => navigate("/admin")}
+					>
+						<Trans>Staff</Trans>
+					</Menu.Item>
+				)}
 
-			<FeedbackPortalModal
-				opened={feedbackOpen}
-				onClose={() => setFeedbackOpen(false)}
-				locale={language}
-			/>
-		</>
+				<Menu.Divider my={6} />
+
+				<Box px="sm" py={4}>
+					<Group justify="space-between" align="center">
+						<Text size="xs" c="dimmed">
+							<Trans>Language</Trans>
+						</Text>
+						<LanguagePicker />
+					</Group>
+				</Box>
+
+				<Menu.Divider my={6} />
+
+				<Menu.Item
+					leftSection={<SignOut size={14} />}
+					onClick={handleLogout}
+					color="red"
+				>
+					<Trans>Logout</Trans>
+				</Menu.Item>
+			</Menu.Dropdown>
+		</Menu>
 	);
 };

--- a/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
+++ b/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
@@ -1,26 +1,17 @@
-import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import {
 	BuildingsIcon,
 	PaletteIcon,
 	ScalesIcon,
 	ShieldStarIcon,
-	SignOutIcon,
 } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useLocation } from "react-router";
-import { useLogoutMutation } from "@/components/auth/hooks";
-import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
 import { API_BASE_URL } from "@/config";
 import { BackButton } from "../../primitives/BackButton";
-import { NavButton } from "../../primitives/NavButton";
 import { NavItem } from "../../primitives/NavItem";
 
+// Logout lives in the sidebar footer UserMenu, not here.
 export const UserSettingsView = () => {
-	const logoutMutation = useLogoutMutation();
-	const location = useLocation();
-	const { runTransition } = useTransitionCurtain();
-
 	const { data: accessData } = useQuery<{
 		organisations: Array<{ id: string }>;
 	} | null>({
@@ -36,16 +27,6 @@ export const UserSettingsView = () => {
 	});
 	const isExternalOnly =
 		accessData != null ? accessData.organisations.length === 0 : false;
-
-	const handleLogout = async () => {
-		if (logoutMutation.isPending) return;
-		await runTransition({ description: null, message: t`See you soon` });
-		const path = location.pathname + location.search + location.hash;
-		await logoutMutation.mutateAsync({
-			doRedirect: true,
-			next: path.startsWith("/login") ? undefined : path,
-		});
-	};
 
 	return (
 		<nav className="flex h-full flex-col gap-0.5 p-1.5">
@@ -72,13 +53,6 @@ export const UserSettingsView = () => {
 					icon={ScalesIcon}
 				/>
 			)}
-			<NavButton
-				label={<Trans>Log out</Trans>}
-				icon={SignOutIcon}
-				onClick={handleLogout}
-				disabled={logoutMutation.isPending}
-				destructive
-			/>
 		</nav>
 	);
 };


### PR DESCRIPTION
  Wire the unused UserMenu into the sidebar footer so logout is reachable
  from any scope, not just the settings page. Trim its dropdown to
  user-scoped actions (settings, staff, language, logout) since docs,
  Slack, and feedback already live in the Help block above it. Remove the
  now-duplicate logout button from the settings sidebar view and fix
  off-brand color="blue" to "primary".