### PR TITLE
fix(server): resolve 11s conversations stall from bad tag queries and…

### DIFF
--- a/echo/AGENTS.md
+++ b/echo/AGENTS.md
@@ -168,6 +168,7 @@ Which group powers which feature is non-obvious, so don't downgrade silently.
 - `create_item` / `update_item` return `{"data": {...}}`. **MUST** unwrap with `["data"]`
 - `get_items` / `get_item` return data directly (no wrapper)
 - `get_items` requires `{"query": {filter, fields, sort, ...}}` wrapper
+- Nested relational fields use dot notation strings: `"project_tag_id.id"`, never `{"project_tag_id": ["id"]}`. The dict form is a TS SDK convenience; the Python client passes queries to the REST API verbatim, and Directus 500s on it
 - `search()` silently returns `{"error": "..."}` on failure; always validate the return is a list before iterating
 
 ### TypeScript Directus SDK

--- a/echo/server/dembrane/api/search.py
+++ b/echo/server/dembrane/api/search.py
@@ -232,15 +232,10 @@ def _search_conversations(
                     "participant_name",
                     "participant_email",
                     "summary",
-                    {
-                        "project_id": ["id", "name"],
-                    },
-                    {
-                        "chunks": [
-                            "timestamp",
-                            "created_at",
-                        ],
-                    },
+                    "project_id.id",
+                    "project_id.name",
+                    "chunks.timestamp",
+                    "chunks.created_at",
                 ],
                 "deep": {
                     "chunks": {
@@ -285,9 +280,8 @@ def _search_chunks(client: DirectusClient, term: str, limit: int) -> List[Search
                     "transcript",
                     "timestamp",
                     "created_at",
-                    {
-                        "conversation_id": ["id", "participant_name"],
-                    },
+                    "conversation_id.id",
+                    "conversation_id.participant_name",
                 ],
                 "sort": ["-timestamp"],
                 "limit": limit,
@@ -350,9 +344,8 @@ def _search_chats(client: DirectusClient, term: str, limit: int) -> List[SearchC
                 "fields": [
                     "id",
                     "name",
-                    {
-                        "project_id": ["id", "name"],
-                    },
+                    "project_id.id",
+                    "project_id.name",
                 ],
                 "sort": ["-date_updated", "-date_created"],
                 "limit": limit,

--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -281,7 +281,9 @@ async def list_conversations(
                             "fields": [
                                 "id",
                                 "conversation_id",
-                                {"project_tag_id": ["id", "text", "created_at"]},
+                                "project_tag_id.id",
+                                "project_tag_id.text",
+                                "project_tag_id.created_at",
                             ],
                             "limit": -1,
                         }
@@ -513,7 +515,9 @@ async def get_conversation(
                         "filter": {"conversation_id": {"_eq": conversation_id}},
                         "fields": [
                             "id",
-                            {"project_tag_id": ["id", "text", "created_at"]},
+                            "project_tag_id.id",
+                            "project_tag_id.text",
+                            "project_tag_id.created_at",
                         ],
                         "limit": -1,
                     }
@@ -737,7 +741,9 @@ async def list_conversation_tags(
                 "fields": [
                     "id",
                     "conversation_id",
-                    {"project_tag_id": ["id", "text", "created_at"]},
+                    "project_tag_id.id",
+                    "project_tag_id.text",
+                    "project_tag_id.created_at",
                 ],
                 "limit": -1,
             }
@@ -797,7 +803,7 @@ async def replace_conversation_tags(
                     "filter": {"conversation_id": {"_eq": body.conversation_id}},
                     "fields": [
                         "id",
-                        {"project_tag_id": ["id"]},
+                        "project_tag_id.id",
                     ],
                     "limit": -1,
                 }
@@ -865,7 +871,9 @@ async def replace_conversation_tags(
                 "fields": [
                     "id",
                     "conversation_id",
-                    {"project_tag_id": ["id", "text", "created_at"]},
+                    "project_tag_id.id",
+                    "project_tag_id.text",
+                    "project_tag_id.created_at",
                 ],
                 "limit": -1,
             }

--- a/echo/server/dembrane/directus.py
+++ b/echo/server/dembrane/directus.py
@@ -96,7 +96,7 @@ def make_request_with_retry(
         requests.exceptions.RequestException: If the request fails after all retries
     """
     retries = 0
-    while retries < max_retries:
+    while True:
         try:
             if client.temporary_token is not None and client.refresh_token is not None:
                 try:
@@ -109,8 +109,11 @@ def make_request_with_retry(
 
             if is_recoverable_error(response):
                 retries += 1
-                if retries == max_retries:
-                    response.raise_for_status()
+                if retries >= max_retries:
+                    # Exhausted: return the response as-is so callers can
+                    # interpret the Directus error envelope. Never fall
+                    # through and return None.
+                    return response
 
                 wait_time = retry_delay * (2 ** (retries - 1))
                 time.sleep(wait_time)
@@ -133,7 +136,7 @@ def make_request_with_retry(
                     raise
 
             retries += 1
-            if retries == max_retries:
+            if retries >= max_retries:
                 raise
 
             wait_time = retry_delay * (2 ** (retries - 1))

--- a/echo/server/dembrane/directus.py
+++ b/echo/server/dembrane/directus.py
@@ -111,8 +111,10 @@ def make_request_with_retry(
                 retries += 1
                 if retries >= max_retries:
                     # Exhausted: return the response as-is so callers can
-                    # interpret the Directus error envelope. Never fall
-                    # through and return None.
+                    # interpret the Directus error envelope. Exhausted
+                    # recoverable statuses have always surfaced through the
+                    # envelope path (DirectusBadRequest); DirectusServerError
+                    # is for connection errors only.
                     return response
 
                 wait_time = retry_delay * (2 ** (retries - 1))

--- a/echo/server/dembrane/directus_async.py
+++ b/echo/server/dembrane/directus_async.py
@@ -90,35 +90,34 @@ class AsyncDirectusClient:
         retry_delay: float = DEFAULT_RETRY_DELAY,
         **kwargs: Any,
     ) -> httpx.Response:
-        """Make an HTTP request with retry logic for recoverable errors."""
+        """Make an HTTP request with retry logic for recoverable errors.
+
+        At most `max_retries` requests are sent. A response with a
+        recoverable status that persists through every attempt is
+        returned as-is so callers can interpret the Directus error
+        envelope; transport errors raise once retries are exhausted.
+        """
         client = self._get_client()
         retries = 0
 
-        while retries < max_retries:
+        while True:
             try:
                 response = await client.request(method, path, **kwargs)
-
-                if response.status_code in RECOVERABLE_STATUS_CODES:
-                    retries += 1
-                    if retries == max_retries:
-                        response.raise_for_status()
-
-                    wait_time = retry_delay * (2 ** (retries - 1))
-                    await asyncio.sleep(wait_time)
-                    continue
-
-                return response
-
             except httpx.HTTPError:
                 retries += 1
-                if retries == max_retries:
+                if retries >= max_retries:
                     raise
-
-                wait_time = retry_delay * (2 ** (retries - 1))
-                await asyncio.sleep(wait_time)
+                await asyncio.sleep(retry_delay * (2 ** (retries - 1)))
                 continue
 
-        return await client.request(method, path, **kwargs)
+            if response.status_code in RECOVERABLE_STATUS_CODES:
+                retries += 1
+                if retries >= max_retries:
+                    return response
+                await asyncio.sleep(retry_delay * (2 ** (retries - 1)))
+                continue
+
+            return response
 
     # ------------------------------------------------------------------
     # HTTP verbs (match sync client return semantics)

--- a/echo/server/tests/test_directus_retry.py
+++ b/echo/server/tests/test_directus_retry.py
@@ -1,0 +1,102 @@
+"""Retry behavior of the Directus HTTP clients.
+
+Regression tests for the retry off-by-one that turned every persistently
+failing (but "recoverable", e.g. 500) Directus response into an 11-second
+stall: 1s + 2s backoff, then a swallowed raise_for_status, an extra 8s
+sleep, and a 4th request. Desired contract:
+
+- at most `max_retries` requests total
+- backoff sleeps only between attempts (1s, 2s for the default 3 attempts)
+- after exhausting retries on a recoverable status, return the last
+  response so callers can interpret the Directus error envelope
+- transport errors raise after exhausting retries
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+import requests
+
+from dembrane.directus import make_request_with_retry
+from dembrane.directus_async import AsyncDirectusClient
+
+
+class _CountingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, status_code: int = 500):
+        self.requests = 0
+        self.status_code = status_code
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:  # noqa: ARG002
+        self.requests += 1
+        return httpx.Response(self.status_code, json={"errors": [{"message": "boom"}]})
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_500_returns_last_response_after_3_attempts():
+    transport = _CountingTransport(500)
+    client = AsyncDirectusClient(url="http://directus.test", token="t")
+    client._client = httpx.AsyncClient(  # noqa: SLF001 — inject mock transport
+        base_url="http://directus.test", transport=transport
+    )
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    with patch("dembrane.directus_async.asyncio.sleep", side_effect=fake_sleep):
+        response = await client._request("SEARCH", "/items/whatever")  # noqa: SLF001
+
+    assert response.status_code == 500
+    assert transport.requests == 3
+    assert sleeps == [1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_async_success_does_not_sleep():
+    transport = _CountingTransport(200)
+    client = AsyncDirectusClient(url="http://directus.test", token="t")
+    client._client = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://directus.test", transport=transport
+    )
+
+    with patch("dembrane.directus_async.asyncio.sleep") as sleep_mock:
+        response = await client._request("SEARCH", "/items/whatever")  # noqa: SLF001
+
+    assert response.status_code == 200
+    assert transport.requests == 1
+    sleep_mock.assert_not_called()
+
+
+class _SyncClientStub:
+    temporary_token = None
+    refresh_token = None
+    email = None
+    password = None
+
+
+def test_sync_persistent_500_returns_last_response_after_3_attempts():
+    calls = {"n": 0}
+
+    def fake_request(method, url, **kwargs):  # noqa: ARG001
+        calls["n"] += 1
+        response = requests.Response()
+        response.status_code = 500
+        response._content = b'{"errors": [{"message": "boom"}]}'  # noqa: SLF001
+        return response
+
+    sleeps: list[float] = []
+
+    with (
+        patch("dembrane.directus.requests.request", side_effect=fake_request),
+        patch("dembrane.directus.time.sleep", side_effect=sleeps.append),
+    ):
+        response = make_request_with_retry(
+            _SyncClientStub(), "SEARCH", "http://directus.test/items/whatever"
+        )
+
+    assert response is not None, "must never fall through and return None"
+    assert response.status_code == 500
+    assert calls["n"] == 3
+    assert sleeps == [1.0, 2.0]

--- a/echo/server/tests/test_directus_retry.py
+++ b/echo/server/tests/test_directus_retry.py
@@ -69,6 +69,36 @@ async def test_async_success_does_not_sleep():
     sleep_mock.assert_not_called()
 
 
+class _FailingTransport(httpx.AsyncBaseTransport):
+    def __init__(self):
+        self.requests = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:  # noqa: ARG002
+        self.requests += 1
+        raise httpx.ConnectError("connection refused")
+
+
+@pytest.mark.asyncio
+async def test_async_persistent_transport_error_raises_after_3_attempts():
+    transport = _FailingTransport()
+    client = AsyncDirectusClient(url="http://directus.test", token="t")
+    client._client = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://directus.test", transport=transport
+    )
+
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    with patch("dembrane.directus_async.asyncio.sleep", side_effect=fake_sleep):
+        with pytest.raises(httpx.ConnectError):
+            await client._request("SEARCH", "/items/whatever")  # noqa: SLF001
+
+    assert transport.requests == 3
+    assert sleeps == [1.0, 2.0]
+
+
 class _SyncClientStub:
     temporary_token = None
     refresh_token = None
@@ -98,5 +128,27 @@ def test_sync_persistent_500_returns_last_response_after_3_attempts():
 
     assert response is not None, "must never fall through and return None"
     assert response.status_code == 500
+    assert calls["n"] == 3
+    assert sleeps == [1.0, 2.0]
+
+
+def test_sync_persistent_transport_error_raises_after_3_attempts():
+    calls = {"n": 0}
+
+    def fake_request(method, url, **kwargs):  # noqa: ARG001
+        calls["n"] += 1
+        raise requests.exceptions.ConnectionError("connection refused")
+
+    sleeps: list[float] = []
+
+    with (
+        patch("dembrane.directus.requests.request", side_effect=fake_request),
+        patch("dembrane.directus.time.sleep", side_effect=sleeps.append),
+    ):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            make_request_with_retry(
+                _SyncClientStub(), "SEARCH", "http://directus.test/items/whatever"
+            )
+
     assert calls["n"] == 3
     assert sleeps == [1.0, 2.0]


### PR DESCRIPTION
 Every /v2/bff/conversations call took ~11s and silently returned empty
  tags. Two bugs compounded:

  - BFF queries used TS-SDK-style dict nested fields ({"project_tag_id": [...]}) which the Python client forwards verbatim to the Directus REST API. Directus 500s on it (field.includes is not a function). Replaced with dot notation strings in the conversations BFF and global search.
  - Both Directus clients had an off-by-one in their retry loops: the final raise_for_status was swallowed by their own except handler, adding an extra 8s sleep and a 4th request (1+2+8s = the 11s). The sync variant then fell off the loop and returned None. Retries are now capped at 3 attempts (1s + 2s backoff) and the last response is returned so callers can read the Directus error envelope.

  Measured: list endpoint 11.2s -> 0.07s, tags now populate. Adds
  regression tests for both retry loops and documents the dot notation
  rule in AGENTS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on querying nested relational fields with proper syntax conventions.

* **Bug Fixes**
  * Improved HTTP request retry logic for more reliable recovery from transient errors and network issues.

* **Tests**
  * Added regression tests to verify correct retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->