### PR TITLE
fix(frontend): show env badge on local and dev hosts in Logo

### DIFF
--- a/echo/frontend/src/components/common/Logo.tsx
+++ b/echo/frontend/src/components/common/Logo.tsx
@@ -12,18 +12,42 @@ type LogoProps = {
 	alwaysDembrane?: boolean;
 } & GroupProps;
 
+
+// If the hostnames ever change we will need to update these 
+// ideally make these public Vite vars but im lazy
+const DEV_HOSTNAMES = new Set([
+	"dashboard.echo-testing.dembrane.com",
+	"portal.echo-testing.dembrane.com",
+]);
+
 const STAGING_HOSTNAMES = new Set([
 	"dashboard.echo-next.dembrane.com",
 	"portal.echo-next.dembrane.com",
 ]);
 
-const isStagingHost = () =>
-	typeof window !== "undefined" && STAGING_HOSTNAMES.has(window.location.hostname);
+const LOCAL_HOSTNAMES = new Set([
+	"localhost:5173",
+	"localhost:5174",
+]);
+
+
+const whichHost = () => {
+	if (DEV_HOSTNAMES.has(window.location.host)) {
+		return "dev";
+	}
+	if (STAGING_HOSTNAMES.has(window.location.host)) {
+		return "staging";
+	}
+	if (LOCAL_HOSTNAMES.has(window.location.host)) {
+		return "local";
+	}
+	return null;
+};
+
 
 export const LogoDembrane = ({ hideLogo, hideTitle, alwaysDembrane, ...props }: LogoProps) => {
 	const { logoUrl } = useWhitelabelLogo();
 	const effectiveLogoUrl = alwaysDembrane ? null : logoUrl;
-	const showStagingBadge = isStagingHost();
 
 	return (
 		<Group gap="sm" h="32px" align="center" {...props}>
@@ -36,12 +60,12 @@ export const LogoDembrane = ({ hideLogo, hideTitle, alwaysDembrane, ...props }: 
 						alt="Logo"
 						className="h-full object-contain"
 					/>
-					{showStagingBadge && (
+					{whichHost() && (
 						<span
-							className="pointer-events-none absolute -bottom-1 -right-[20px] -translate-x-1/2 pl-1 text-[10px] font-medium leading-none"
+							className="pointer-events-none absolute capitalize -bottom-1 -right-[15px] -translate-x-1/2 pl-1 text-[10px] font-medium leading-none"
 							style={{ color: "var(--mantine-color-primary-6)" }}
 						>
-							Staging
+							{whichHost()}
 						</span>
 					)}
 				</span>

--- a/echo/frontend/src/components/common/Logo.tsx
+++ b/echo/frontend/src/components/common/Logo.tsx
@@ -32,6 +32,9 @@ const LOCAL_HOSTNAMES = new Set([
 
 
 const whichHost = () => {
+	if (typeof window === "undefined") {
+		return null;
+	}
 	if (DEV_HOSTNAMES.has(window.location.host)) {
 		return "dev";
 	}
@@ -48,6 +51,7 @@ const whichHost = () => {
 export const LogoDembrane = ({ hideLogo, hideTitle, alwaysDembrane, ...props }: LogoProps) => {
 	const { logoUrl } = useWhitelabelLogo();
 	const effectiveLogoUrl = alwaysDembrane ? null : logoUrl;
+	const hostEnv = whichHost();
 
 	return (
 		<Group gap="sm" h="32px" align="center" {...props}>
@@ -60,12 +64,12 @@ export const LogoDembrane = ({ hideLogo, hideTitle, alwaysDembrane, ...props }: 
 						alt="Logo"
 						className="h-full object-contain"
 					/>
-					{whichHost() && (
+					{hostEnv && (
 						<span
 							className="pointer-events-none absolute capitalize -bottom-1 -right-[15px] -translate-x-1/2 pl-1 text-[10px] font-medium leading-none"
 							style={{ color: "var(--mantine-color-primary-6)" }}
 						>
-							{whichHost()}
+							{hostEnv}
 						</span>
 					)}
 				</span>


### PR DESCRIPTION
## What

Extends the environment badge in the Logo component so it surfaces `dev` and `local` environments alongside `staging`.

- Switches host matching from `window.location.hostname` to `window.location.host` so it includes the port. This lets `localhost:5173` / `localhost:5174` match.
- Replaces the single `isStagingHost()` check with a `whichHost()` helper that returns `"dev"`, `"staging"`, `"local"`, or `null`.
- The badge label now reflects the detected environment (capitalized via CSS) instead of always reading "Staging".

## Why

Previously the badge only appeared on staging hosts, and matched on hostname without port so local dev never triggered it. This makes it obvious at a glance which environment the dashboard/portal is pointing at.

## Notes

Hostnames are hardcoded in `Logo.tsx`. If they change, the sets need updating (a follow-up could move them to public Vite vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced environment indicator. The application logo now displays your current deployment environment (dev, staging, or local) via an updated badge component, replacing the previous staging-only indicator. This provides comprehensive environment visibility across all deployment contexts and helps you quickly identify your working environment. Badge positioning and styling have been optimized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->