### PR TITLE
feat(email): route SendGrid sends through EU data residency

### DIFF
--- a/echo/server/.env.sample
+++ b/echo/server/.env.sample
@@ -91,7 +91,12 @@ EMBEDDING_API_VERSION=
 # Email (SendGrid)
 ############################################################
 # API key for SendGrid transactional emails. Leave empty to disable sends.
+# For EU data residency this must be an EU regional subuser key.
 SENDGRID_API_KEY=
+# Data residency region: "eu" (default, routes via api.eu.sendgrid.com) or
+# "global". "eu" keeps recipient PII and content in EU data centers and
+# requires the key above to belong to an EU regional subuser.
+SENDGRID_REGION=eu
 EMAIL_FROM=do-not-reply@dembrane.com
 EMAIL_FROM_NAME=dembrane
 # Where "Request upgrade" CTAs route. Shared inbox per matrix v1.1 §11.

--- a/echo/server/AGENTS.md
+++ b/echo/server/AGENTS.md
@@ -10,6 +10,15 @@ Cross-cutting rules (Directus, BFF, LLM model groups, Dramatiq/gevent, transcrip
 - Embeddings: populate `EMBEDDING_*` env vars (model, key, base URL, version) before calling `dembrane.embedding.embed_text`. The placeholder in `dembrane/embedding.py` is not yet the production implementation
 - Production API uses a **custom asyncio uvicorn worker** (`dembrane.asyncio_uvicorn_worker.AsyncioUvicornWorker`); avoid `uvloop` for `nest_asyncio` compatibility
 
+## Email (two independent senders)
+
+There are two separate email paths and they are easy to conflate. They use different transports, keys, and config.
+
+1. **App transactional email**: `dembrane/email.py` → SendGrid **HTTP API**, keyed by `SENDGRID_API_KEY`. This is the main path: workspace invites, tier notifications, digests, auth emails. Called from `tasks.py` (Dramatiq) and `api/v2/*`. The Python app does **not** read any `*_SMTP_*` vars.
+2. **Directus-native email**: the `echo-directus` container → SendGrid **SMTP** (`smtp.sendgrid.net`), keyed by `EMAIL_SMTP_PASSWORD` (sealed as `DIRECTUS_EMAIL_SMTP_PASSWORD`). Only for emails Directus generates itself. Configured on the Directus deployment, never in `dembrane/settings.py`.
+
+EU data residency: `SENDGRID_REGION=eu` makes `email.py` route through `api.eu.sendgrid.com` (`set_sendgrid_data_residency`), but the key must belong to an **EU regional subuser**, a global-account key is not EU-resident even on the EU host. The Directus path must be moved separately (`smtp.eu.sendgrid.net` + EU key); changing one does not affect the other.
+
 ## Background task design
 
 When fixing or extending Dramatiq flows:

--- a/echo/server/dembrane/email.py
+++ b/echo/server/dembrane/email.py
@@ -177,6 +177,12 @@ def send_email_sync(
         )
 
         sg = SendGridAPIClient(api_key)
+        # Pin the send to a data-residency region. "eu" routes through
+        # api.eu.sendgrid.com so recipient PII and content stay in the EU.
+        # The key must belong to a subuser in this region.
+        region = settings.email.sendgrid_region
+        if region and region != "global":
+            sg.set_sendgrid_data_residency(region)
         response = sg.send(message)
 
         if response.status_code >= 400:

--- a/echo/server/dembrane/settings.py
+++ b/echo/server/dembrane/settings.py
@@ -323,6 +323,15 @@ class EmailSettings(BaseSettings):
             "SENDGRID_API_KEY", "EMAIL__SENDGRID_API_KEY", "EMAIL_SMTP_PASSWORD"
         ),
     )
+    # SendGrid data residency region. "eu" routes sends through
+    # api.eu.sendgrid.com so recipient PII and content stay in EU data
+    # centers (GDPR). Requires an EU regional subuser key. "global" uses
+    # api.sendgrid.com. The key must belong to a subuser in this region.
+    sendgrid_region: str = Field(
+        default="eu",
+        alias="SENDGRID_REGION",
+        validation_alias=AliasChoices("SENDGRID_REGION", "EMAIL__SENDGRID_REGION"),
+    )
     from_email: str = Field(
         default="do-not-reply@dembrane.com",
         alias="EMAIL_FROM",


### PR DESCRIPTION
## What

Routes the app's transactional email through SendGrid's **EU data residency** region so recipient PII and email content stay in EU data centers (GDPR).

- Adds `SENDGRID_REGION` setting (`EmailSettings`), default `"eu"`.
- `email.py` calls `set_sendgrid_data_residency(region)` before sending, switching the client host to `api.eu.sendgrid.com` when region != `global`.
- Documents `SENDGRID_REGION` in `server/.env.sample`.

## Why

dembrane is moving email to EU residency. An EU regional subuser (`sameer-eu`, EU IP `159.183.46.124`) and the `dembrane.com` domain authentication (EU CNAMEs in Cloudflare) are already set up. This wires the **app sender** (`email.py` → SendGrid HTTP API) to use it.

Verified: a live test send via `api.eu.sendgrid.com` with the EU subuser key returns `202`, and the residency call flips the client host correctly.

## Requires (infra, not in this PR)

1. `SENDGRID_API_KEY` must be set to the **EU regional subuser** key (restricted Mail Send) in the `echo-api` + `echo-worker` sealed secrets. A global-account key won't be EU-resident even on the EU host.
2. **Separate path:** the `echo-directus` container sends its own emails via SMTP. To make those EU-resident too, set `EMAIL_SMTP_HOST=smtp.eu.sendgrid.net` and `EMAIL_SMTP_PASSWORD=<EU subuser key>` on that deployment.

## Scope note

This is backend/infra email routing. It is **not** related to the email-template mobile-layout work in #608 / ECHO-832, despite both touching "email".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SendGrid data residency region configuration option to enable EU-compliant email delivery, with EU region set as the default.
  * Introduced environment variable support for customizing the configured email routing region.
  * Enhanced configuration documentation with EU data residency requirements and guidance on how regional routing affects recipient data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->