### PR TITLE
fix: migrate legacy chat endpoints to workspace access model

### DIFF
--- a/echo/frontend/src/features/sidebar/primitives/NavButton.tsx
+++ b/echo/frontend/src/features/sidebar/primitives/NavButton.tsx
@@ -34,7 +34,8 @@ export const NavButton = ({
 				{Icon ? <Icon size={16} /> : null}
 				<span className="truncate">{label}</span>
 			</span>
-			{badge && (
+			{/* != null, not truthiness: badge={0} would render a bare "0" */}
+			{badge != null && (
 				<span
 					className="relative shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none"
 					style={{

--- a/echo/frontend/src/features/sidebar/primitives/NavItem.tsx
+++ b/echo/frontend/src/features/sidebar/primitives/NavItem.tsx
@@ -78,7 +78,8 @@ export const NavItem = ({
 				{Icon ? <Icon size={16} /> : null}
 				<span className="truncate">{label}</span>
 			</span>
-			{badge && (
+			{/* != null, not truthiness: badge={0} would render a bare "0" */}
+			{badge != null && (
 				<span
 					className="relative shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none"
 					style={{

--- a/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
@@ -59,16 +59,16 @@ export const ProjectHomeView = () => {
 				</div>
 			)}
 
-			<NavItem to={`${base}/home`} label={<Trans>Overview</Trans>} icon={AppWindowIcon} />
+			<NavItem
+				to={`${base}/home`}
+				label={<Trans>Overview</Trans>}
+				icon={AppWindowIcon}
+			/>
 			<NavItem
 				to={`${base}/chats/new`}
 				label={<Trans>Ask</Trans>}
 				icon={ChatCircleDotsIcon}
-				badge={
-					typeof chatsCountQuery.data === "number"
-						? chatsCountQuery.data
-						: undefined
-				}
+				badge={chatsCountQuery.data || undefined}
 			/>
 			<NavButton
 				label={<Trans>Explore</Trans>}
@@ -103,11 +103,7 @@ export const ProjectHomeView = () => {
 				to={`${base}/conversations`}
 				label={<Trans>Conversations</Trans>}
 				icon={ChatCircleTextIcon}
-				badge={
-					typeof conversationsCountQuery.data === "number"
-						? conversationsCountQuery.data
-						: undefined
-				}
+				badge={conversationsCountQuery.data || undefined}
 			/>
 
 			<div className="mt-auto" />

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -20,13 +20,13 @@ import {
 	ChatModeIndicator,
 } from "@/components/chat/ChatAccordion";
 import { ChatModeSelector } from "@/components/chat/ChatModeSelector";
-import { ChatSkeleton } from "@/components/chat/ChatSkeleton";
 import {
 	useInfiniteProjectChats,
 	useInitializeChatModeMutation,
 	usePrefetchSuggestions,
 	useProjectChatsCount,
 } from "@/components/chat/hooks";
+import { BaseSkeleton } from "@/components/common/BaseSkeleton";
 import { NavigationButton } from "@/components/common/NavigationButton";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { useCreateChatMutation } from "@/components/project/hooks";
@@ -35,6 +35,15 @@ import { useLanguage } from "@/hooks/useLanguage";
 import type { ChatMode } from "@/lib/api";
 
 const CHATS_PAGE_SIZE = 10;
+
+// Standalone fallback: ChatSkeleton renders a bare Accordion.Item and
+// throws when mounted outside an <Accordion>.
+const ChatsSectionSkeleton = () => (
+	<Stack gap="lg">
+		<BaseSkeleton width="120px" height="28px" radius="xs" />
+		<BaseSkeleton count={3} height="40px" width="100%" radius="xs" />
+	</Stack>
+);
 
 const ProjectChatsSection = ({
 	projectId,
@@ -48,8 +57,8 @@ const ProjectChatsSection = ({
 		hasMessages: true,
 	});
 	const chatsQuery = useInfiniteProjectChats(projectId, undefined, {
-		initialLimit: CHATS_PAGE_SIZE,
 		hasMessages: true,
+		initialLimit: CHATS_PAGE_SIZE,
 	});
 
 	useEffect(() => {
@@ -207,7 +216,7 @@ export const NewChatRoute = () => {
 					onModeSelected={handleModeSelected}
 				/>
 
-				<Suspense fallback={<ChatSkeleton />}>
+				<Suspense fallback={<ChatsSectionSkeleton />}>
 					<ProjectChatsSection
 						projectId={projectId}
 						workspaceId={workspaceId}

--- a/echo/server/dembrane/api/chat.py
+++ b/echo/server/dembrane/api/chat.py
@@ -155,12 +155,10 @@ async def raise_if_chat_not_found_or_not_authorized(
     auth_session: DirectusSession,
     *,
     include_used_conversations: bool = False,
+    require: Optional[str] = None,
 ) -> dict:
-    # Always use the global (admin) chat_service for reads here.
-    # Authorization is checked manually below (project owner vs user_id).
-    # Using user-scoped Directus client would cause junction table data
-    # (e.g., used_conversations) to be filtered by Directus permissions,
-    # leading to inconsistencies where writes succeed but reads return empty.
+    # v2 access gate shared with the BFF (chat:use; `require` adds a stricter
+    # policy). Reads use the admin client: row ACL is admin-only post-lockdown.
     chat_svc = chat_service
     try:
         chat = await run_in_thread_pool(
@@ -175,27 +173,44 @@ async def raise_if_chat_not_found_or_not_authorized(
         logger.error("Failed to fetch chat %s: %s", chat_id, exc)
         raise HTTPException(status_code=500, detail="Failed to load chat") from exc
 
-    project_owner: Optional[str] = None
-    project_info = chat.get("project_id")
-    if isinstance(project_info, dict):
-        project_owner = project_info.get("directus_user_id")
+    # Soft-deleted chats 404 for everyone, including staff admins.
+    if chat.get("deleted_at"):
+        raise HTTPException(status_code=404, detail="Chat not found")
 
-    if not auth_session.is_admin and project_owner != auth_session.user_id:
-        logger.debug(
-            "Chat %s not authorized for user %s (owner=%s)",
-            chat_id,
-            auth_session.user_id,
-            project_owner,
-        )
-        raise HTTPException(status_code=403, detail="You are not authorized to access this chat")
+    # Staff admins bypass the app-layer model (they may have no app_user row).
+    if not auth_session.is_admin:
+        from dembrane.api.v2.bff._access import resolve_chat_access
+
+        access, _ = await resolve_chat_access(chat_id, auth_session)
+        if require:
+            access.require(require)
 
     return chat
+
+
+def _chat_project_id(chat: dict) -> Optional[str]:
+    """Extract the parent project id from a chat row (relation dict or raw id)."""
+    project_info = chat.get("project_id")
+    if isinstance(project_info, dict):
+        return project_info.get("id")
+    return project_info
+
+
+def _raise_if_project_mismatch(chat: dict, body_project_id: Optional[str]) -> None:
+    """Reject a caller-supplied project_id that isn't the chat's own project
+    (admin-client reads would otherwise leak another tenant's conversations)."""
+    if body_project_id is not None and body_project_id != _chat_project_id(chat):
+        raise HTTPException(
+            status_code=400,
+            detail="project_id does not match this chat",
+        )
 
 
 @ChatRouter.delete("/{chat_id}")
 async def delete_chat(chat_id: str, auth: DependencyDirectusSession) -> dict:
     """Soft-delete a chat by setting deleted_at."""
-    await raise_if_chat_not_found_or_not_authorized(chat_id, auth)
+    # Same policy as the BFF's chat rename / message delete.
+    await raise_if_chat_not_found_or_not_authorized(chat_id, auth, require="project:update")
 
     from datetime import datetime
 
@@ -373,17 +388,12 @@ async def add_chat_context(
         auth,
         include_used_conversations=True,
     )
+    _raise_if_project_mismatch(chat, body.project_id)
 
     chat_svc = chat_service
     conversation_svc = conversation_service
 
-    project_info = chat.get("project_id")
-    project_id: Optional[str] = body.project_id
-    if project_id is None:
-        if isinstance(project_info, dict):
-            project_id = project_info.get("id")
-        else:
-            project_id = project_info
+    project_id: Optional[str] = body.project_id or _chat_project_id(chat)
 
     options_provided = sum(
         [
@@ -799,12 +809,7 @@ async def get_chat_suggestions(
 
     chat_mode = chat.get("chat_mode")
 
-    # Get project_id from nested object
-    project_id_obj = chat.get("project_id")
-    if isinstance(project_id_obj, dict):
-        project_id = project_id_obj.get("id")
-    else:
-        project_id = project_id_obj
+    project_id = _chat_project_id(chat)
 
     if not project_id:
         logger.warning(f"No project_id found for chat {chat_id}")
@@ -873,6 +878,7 @@ async def initialize_chat_mode(
         auth,
         include_used_conversations=True,
     )
+    _raise_if_project_mismatch(chat, body.project_id)
 
     # Check if mode is already set
     existing_mode = chat.get("chat_mode")
@@ -976,12 +982,7 @@ async def post_chat(
     chat_svc = chat_service
     conversation_svc = conversation_service
 
-    project_info = chat.get("project_id")
-    project_id: Optional[str]
-    if isinstance(project_info, dict):
-        project_id = project_info.get("id")
-    else:
-        project_id = project_info  # directus may return an ID string
+    project_id: Optional[str] = _chat_project_id(chat)
 
     if not project_id:
         raise HTTPException(status_code=500, detail="Chat is missing a project reference")

--- a/echo/server/dembrane/service/chat.py
+++ b/echo/server/dembrane/service/chat.py
@@ -37,6 +37,7 @@ class ChatService:
             "name",
             "auto_select",
             "chat_mode",
+            "deleted_at",
             "project_id.id",
             "project_id.directus_user_id",
         ]


### PR DESCRIPTION
  The legacy /api/chats gate still used the pre-workspaces creator-only
  check, so any workspace member who did not create the project got 403
  on initialize-mode, context, add-context, suggestions and message send.
  New chats created via the BFF then failed mid-flow on the Ask route.

  - gate now delegates to resolve_chat_access (chat:use); delete requires project:update; staff admins keep their bypass
  - soft-deleted chats 404 on every path, including for staff admins
  - add-context and initialize-mode reject a project_id that is not the chat's own project (admin-client reads would cross tenants)
  - Ask route: standalone Suspense fallback; ChatSkeleton renders a bare Accordion.Item and crashed the route when mounted outside an Accordion
  - sidebar: hide zero count badges and never render badge={0} as a bare "0" text node