### PR TITLE
fix(chat): allow selecting individual conversations; de-dupe picker CTA

### DIFF
--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -111,12 +111,6 @@ const getTagText = (tag: ConversationProjectTag) => {
 	return typeof projectTag === "object" && projectTag ? projectTag.text : null;
 };
 
-const hasTranscriptContent = (conversation: Conversation) =>
-	conversation.chunks?.some((chunk) => {
-		const transcript = (chunk as ConversationChunk).transcript;
-		return typeof transcript === "string" && transcript.trim().length > 0;
-	}) ?? false;
-
 const hasVerifiedArtifacts = (conversation: Conversation) =>
 	conversation.conversation_artifacts?.some(
 		(artifact) => (artifact as ConversationArtifact).approved_at,
@@ -172,18 +166,15 @@ const ConversationSelectionCheckbox = ({
 		(c) => c.conversation_id === conversation.id && c.locked,
 	);
 	const isOverCapLocked = !!conversation.locked;
-	const hasContent = hasTranscriptContent(conversation);
-	const isDisabled = isChatLocked || isOverCapLocked || !hasContent;
+	const isDisabled = isChatLocked || isOverCapLocked;
 
 	const tooltipLabel = isOverCapLocked
 		? t`Conversation locked. Upgrade to add it.`
 		: isChatLocked
 			? t`Already used in this chat`
-			: !hasContent
-				? t`This conversation has no transcript yet`
-				: isSelected
-					? t`Remove from chat`
-					: t`Add to chat`;
+			: isSelected
+				? t`Remove from chat`
+				: t`Add to chat`;
 
 	const handleChange = () => {
 		if (isSelected) {
@@ -667,7 +658,7 @@ export const ProjectConversationsPanel = ({
 						<Text size="sm" c="dimmed">
 							{selectionMode ? (
 								<Trans>
-									Search and choose the conversations for this chat.
+									Search and select the conversations for this chat.
 								</Trans>
 							) : (
 								<Trans>

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -851,20 +851,12 @@ export const ProjectChatRoute = () => {
 								variant="light"
 								{...testId("chat-no-conversations-alert")}
 							>
-								<Group justify="space-between" gap="sm" wrap="wrap">
-									<Text size="sm">
-										<Trans>
-											Specific Details needs at least one conversation.
-										</Trans>
-									</Text>
-									<Button
-										variant="outline"
-										size="xs"
-										onClick={() => setConversationPickerOpen(true)}
-									>
-										<Trans>Choose conversations</Trans>
-									</Button>
-								</Group>
+								<Text size="sm">
+									<Trans>
+										Specific Details needs at least one conversation. Use Select
+										conversations above to add one.
+									</Trans>
+								</Text>
 							</Alert>
 						)}
 


### PR DESCRIPTION
## Problem
In the chat "Specific Details" conversation picker, individual conversation
checkboxes were greyed out ("no transcript yet") and couldn't be selected,
while "Select all visible" worked. Separately, a new chat showed two CTAs
at once: a "Select conversations" toolbar button and a "Choose
conversations" button inside the alert.

## Root cause
Each row's checkbox was disabled by a client-side `hasTranscriptContent()`
heuristic computed from the picker's chunk payload. "Select all" evaluates
transcript content on the backend, so the two paths could disagree. I
verified against the live BFF
(`/api/v2/bff/conversations?include_chunks=true`) that the chunk/transcript
payload is actually correct, so the client-side guess is the fragile part.

## Fix
- Drop the client-side content gate. Checkboxes now disable only for real
lock reasons (chat-locked, over-cap). The backend stays authoritative —
"Select all" still skips empty conversations and individual add accepts
them.
- Remove the duplicate "Choose conversations" button from the
no-conversations alert (the persistent "Select conversations" toolbar
button already opens the picker); align wording to "select".

## Verification
TypeScript + Biome clean. Verified live BFF returns chunks with transcripts
(`has_transcript=true`, `locked=false`) for the affected workspace.
