### PR TITLE
ECHO-856  fix: rework home/org navigation and move home from /w to /o

### DIFF
--- a/echo/frontend/src/Router.tsx
+++ b/echo/frontend/src/Router.tsx
@@ -122,6 +122,10 @@ const WorkspaceSelectorRoute = createLazyNamedRoute(
 	() => import("./routes/workspaces/WorkspaceSelectorRoute"),
 	"WorkspaceSelectorRoute",
 );
+const RootRedirect = createLazyNamedRoute(
+	() => import("./routes/workspaces/WorkspaceSelectorRoute"),
+	"RootRedirect",
+);
 const CreateWorkspaceRoute = createLazyNamedRoute(
 	() => import("./routes/workspaces/CreateWorkspaceRoute"),
 	"CreateWorkspaceRoute",
@@ -290,9 +294,13 @@ export const mainRouter = createBrowserRouter([
 	{
 		children: [
 			{
-				// Root → workspace selector. Legacy /projects routes are gone;
-				// the canonical "home" for an authed user is /w.
-				element: <Navigate to="w" replace />,
+				// Root entry: RootRedirect sends single-org users to their org
+				// overview, everyone else to the /o home list.
+				element: (
+					<Protected>
+						<RootRedirect />
+					</Protected>
+				),
 				path: "",
 			},
 			{
@@ -368,15 +376,12 @@ export const mainRouter = createBrowserRouter([
 				path: "invites",
 			},
 			{
-				// Workspace selector + create — canonical path is /w.
+				// Request-workspace wizard. Bare /w is retired (home moved to /o)
+				// and falls through to the 404; /w/:workspaceId/* is defined below.
 				children: [
 					{
-						element: <WorkspaceSelectorRoute />,
-						index: true,
-					},
-					{
 						element: <CreateWorkspaceRoute />,
-						path: "new",
+						index: true,
 					},
 				],
 				element: (
@@ -384,12 +389,16 @@ export const mainRouter = createBrowserRouter([
 						<BaseLayout />
 					</Protected>
 				),
-				path: "w",
+				path: "w/new",
 			},
 			{
-				// Organisation (org) admin surface. Canonical path is /o/:organisationId —
-				// matches the /w/:workspaceId pattern.
+				// Bare /o is the home list (organisations); /o/:organisationId is a
+				// single org's admin surface.
 				children: [
+					{
+						element: <WorkspaceSelectorRoute />,
+						index: true,
+					},
 					{
 						// Splat so tab state lives in the path
 						// (/o/:organisationId/:tab) — matches the project-tab pattern.

--- a/echo/frontend/src/components/common/AccessDeniedPanel.tsx
+++ b/echo/frontend/src/components/common/AccessDeniedPanel.tsx
@@ -26,7 +26,7 @@ export function AccessDeniedPanel({
 				<Button
 					variant="subtle"
 					size="xs"
-					onClick={() => navigate("/w")}
+					onClick={() => navigate("/o")}
 					data-testid={`${testId}-back-button`}
 				>
 					<Trans>Back to your workspaces</Trans>

--- a/echo/frontend/src/components/layout/AuthLayout.tsx
+++ b/echo/frontend/src/components/layout/AuthLayout.tsx
@@ -55,7 +55,7 @@ const AuthLayoutInner = (props: PropsWithChildren) => {
 
 	useEffect(() => {
 		if (auth.isAuthenticated && !isActive && !skipRedirect) {
-			const nextLink = query.get("next") ?? "/w";
+			const nextLink = query.get("next") ?? "/o";
 			navigate(nextLink);
 		}
 	}, [auth.isAuthenticated, isActive, navigate, query, skipRedirect]);

--- a/echo/frontend/src/components/project/ProjectDangerZone.tsx
+++ b/echo/frontend/src/components/project/ProjectDangerZone.tsx
@@ -77,7 +77,7 @@ export const ProjectDangerZone = ({ project }: { project: Project }) => {
 			console.warn("Analytics tracking failed:", error);
 		}
 		deleteProjectByIdMutation.mutate(project.id);
-		navigate(workspaceId ? `/w/${workspaceId}/home` : "/w");
+		navigate(workspaceId ? `/w/${workspaceId}/home` : "/o");
 	};
 
 	return (

--- a/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
+++ b/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
@@ -53,6 +53,7 @@ const ORG_SECTION_LABELS: Record<string, string> = {
 	billing: "Billing",
 	overview: "Overview",
 	people: "Members",
+	"request-workspace": "Request workspace",
 	usage: "Usage",
 };
 
@@ -96,12 +97,20 @@ export const AppBreadcrumbs = () => {
 		// Always start with Home so the trail is anchored to a real
 		// clickable parent.
 		const out: Crumb[] = [{ href: "/", label: "Home" }];
+		// Emit the org crumb before the workspace one, so workspace/project
+		// trails read Home › Org › Workspace › Project.
+		const pushWorkspaceCrumbs = (ws: NonNullable<typeof workspace>) => {
+			if (ws.org_id) {
+				out.push({ href: `/o/${ws.org_id}/overview`, label: ws.org_name });
+			}
+			out.push({ href: `/w/${ws.id}/home`, label: ws.name });
+		};
 		switch (view) {
 			case "inbox":
 			case "help":
 				return out;
 			case "user-home":
-				// The home page (/w, the organisations list) has no breadcrumb —
+				// The home page (/o, the organisations list) has no breadcrumb —
 				// it's the root, so a lone "Home" crumb is just noise.
 				return [];
 			case "user-settings": {
@@ -147,10 +156,7 @@ export const AppBreadcrumbs = () => {
 			}
 			case "workspace-home": {
 				if (!workspace) return out;
-				out.push({
-					href: `/w/${workspace.id}/home`,
-					label: workspace.name,
-				});
+				pushWorkspaceCrumbs(workspace);
 				if (window.location.pathname.endsWith("/projects/new")) {
 					out.push({ label: "New project" });
 				}
@@ -158,10 +164,7 @@ export const AppBreadcrumbs = () => {
 			}
 			case "workspace-settings": {
 				if (workspace) {
-					out.push({
-						href: `/w/${workspace.id}/home`,
-						label: workspace.name,
-					});
+					pushWorkspaceCrumbs(workspace);
 				}
 				out.push({ label: "Settings" });
 				const section = params.section;
@@ -172,10 +175,7 @@ export const AppBreadcrumbs = () => {
 			}
 			case "project-home": {
 				if (workspace) {
-					out.push({
-						href: `/w/${workspace.id}/home`,
-						label: workspace.name,
-					});
+					pushWorkspaceCrumbs(workspace);
 				}
 				if (projectQuery.data?.name) {
 					out.push({
@@ -207,10 +207,7 @@ export const AppBreadcrumbs = () => {
 			}
 			case "project-settings": {
 				if (workspace) {
-					out.push({
-						href: `/w/${workspace.id}/home`,
-						label: workspace.name,
-					});
+					pushWorkspaceCrumbs(workspace);
 				}
 				if (projectQuery.data?.name) {
 					out.push({

--- a/echo/frontend/src/features/sidebar/hooks/useSidebarView.ts
+++ b/echo/frontend/src/features/sidebar/hooks/useSidebarView.ts
@@ -94,6 +94,20 @@ export function resolveSidebarView(
 		};
 	}
 
+	// /w/new (request-workspace) carries its org in ?organisationId=, so surface
+	// it under that org's context. No org param → fall through to user-home.
+	if (segs[0] === "w" && segs[1] === "new") {
+		const orgId = new URLSearchParams(search).get("organisationId");
+		if (orgId) {
+			return {
+				backTo: `/o/${orgId}/overview`,
+				params: { orgId, section: "request-workspace" },
+				scope: "org",
+				view: "org-home",
+			};
+		}
+	}
+
 	// /w/:workspaceId/...
 	if (segs[0] === "w" && segs[1] && segs[1] !== "new") {
 		const workspaceId = segs[1];

--- a/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
+++ b/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { I18nLink } from "@/components/common/i18nLink";
 import { Logo } from "@/components/common/Logo";
 
 export const SidebarHeader = () => {
@@ -7,13 +7,13 @@ export const SidebarHeader = () => {
 			className="flex h-[57px] shrink-0 items-center border-b pl-[12.5px] pr-3"
 			style={{ borderColor: "rgba(45, 45, 44, 0.06)" }}
 		>
-			<Link
+			<I18nLink
 				to="/"
 				className="flex items-center gap-2 transition-opacity hover:opacity-80"
 				aria-label="dembrane home"
 			>
 				<Logo hideTitle={false} />
-			</Link>
+			</I18nLink>
 		</div>
 	);
 };

--- a/echo/frontend/src/features/sidebar/views/HelpView.tsx
+++ b/echo/frontend/src/features/sidebar/views/HelpView.tsx
@@ -26,7 +26,7 @@ export const HelpView = () => {
 	return (
 		<>
 			<nav className="flex h-full flex-col gap-0.5 p-1.5">
-				<ViewHeader to={backTo ?? "/w"} title={<Trans>Help</Trans>} />
+				<ViewHeader to={backTo ?? "/o"} title={<Trans>Help</Trans>} />
 				<NavButton
 					label={<Trans>Contact support</Trans>}
 					icon={EnvelopeSimple}

--- a/echo/frontend/src/features/sidebar/views/InboxView.tsx
+++ b/echo/frontend/src/features/sidebar/views/InboxView.tsx
@@ -102,7 +102,7 @@ export const InboxView = () => {
 		<div className="flex h-full w-full justify-center overflow-hidden">
 			<nav className="flex h-full w-full max-w-2xl flex-col px-4 py-6">
 				<div className="shrink-0 p-1.5">
-					<ViewHeader to={backTo ?? "/w"} title={<Trans>Inbox</Trans>} />
+					<ViewHeader to={backTo ?? "/o"} title={<Trans>Inbox</Trans>} />
 				</div>
 	
 				<div className="flex shrink-0 items-center justify-between gap-1 px-3 pb-2">

--- a/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/org/OrgHomeView.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router";
 import { API_BASE_URL } from "@/config";
 import { useV2Me } from "@/hooks/useV2Me";
 import { useWorkspace } from "@/hooks/useWorkspace";
+import { useSidebarView } from "../../hooks/useSidebarView";
 import { BackButton } from "../../primitives/BackButton";
 import { NavItem } from "../../primitives/NavItem";
 import { SectionLabel } from "../../primitives/SectionLabel";
@@ -36,7 +37,10 @@ export const OrgHomeView = () => {
 		orgId?: string;
 		organisationId?: string;
 	}>();
-	const orgId = routeOrgId ?? organisationId;
+	// On /w/new (request-workspace) the org isn't a path param — it rides in on
+	// the query string and is surfaced through the resolved sidebar view.
+	const { params: sidebarParams } = useSidebarView();
+	const orgId = routeOrgId ?? organisationId ?? sidebarParams.orgId;
 	const { workspaces: myWorkspaces } = useWorkspace();
 	const { data: me } = useV2Me();
 	const isManager = useMemo(() => {
@@ -72,7 +76,7 @@ export const OrgHomeView = () => {
 		// Admins/owners see the whole org roster (they can open any workspace).
 		// Everyone else (member, billing, external) sees only the workspaces
 		// they directly belong to, so the sidebar never shows a workspace that
-		// dead-links on click. Discovering other workspaces happens on /w.
+		// dead-links on click. Discovering other workspaces happens on /o.
 		if (!isManager) {
 			return myOrgWorkspaces.map((w) => ({
 				id: w.id,
@@ -109,7 +113,7 @@ export const OrgHomeView = () => {
 		<nav className="flex h-full flex-col gap-0.5 p-1.5">
 			{/* The back button doubles as the section title: its centered label is
 			    the org name (the current context), not the destination. */}
-			<BackButton to="/w" label={orgName} center />
+			<BackButton to="/o" label={orgName} center />
 
 			{!isExternal && (
 				<>

--- a/echo/frontend/src/features/sidebar/views/user/UserHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/user/UserHomeView.tsx
@@ -70,7 +70,7 @@ export const UserHomeView = () => {
 			{needsOnboarding && (
 				<NavItem to="/onboarding" label={<Trans>Setup</Trans>} icon={Sparkle} />
 			)}
-			<NavItem to="/w" label={<Trans>Home</Trans>} icon={House} end />
+			<NavItem to="/o" label={<Trans>Home</Trans>} icon={House} end />
 
 			{noWorkspaces ? (
 				<>

--- a/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
+++ b/echo/frontend/src/features/sidebar/views/user/UserSettingsView.tsx
@@ -30,7 +30,7 @@ export const UserSettingsView = () => {
 
 	return (
 		<nav className="flex h-full flex-col gap-0.5 p-1.5">
-			<BackButton to="/w" label={<Trans>Settings</Trans>} />
+			<BackButton to="/o" label={<Trans>Settings</Trans>} />
 			<NavItem
 				to="/settings/account"
 				label={<Trans>Account & security</Trans>}

--- a/echo/frontend/src/routes/auth/Login.tsx
+++ b/echo/frontend/src/routes/auth/Login.tsx
@@ -211,11 +211,11 @@ export const LoginRoute = () => {
 			} else if (lastStillValid) {
 				navigate(`/w/${lastUsedId}/home`);
 			} else if (workspaceCount > 1 || isOrganisationAdmin) {
-				navigate("/w");
+				navigate("/o");
 			} else if (firstWorkspaceId) {
 				navigate(`/w/${firstWorkspaceId}/home`);
 			} else {
-				navigate("/w");
+				navigate("/o");
 			}
 		} catch (error) {
 			// biome-ignore lint/suspicious/noExplicitAny: <todo>

--- a/echo/frontend/src/routes/auth/VerifyEmail.tsx
+++ b/echo/frontend/src/routes/auth/VerifyEmail.tsx
@@ -112,7 +112,7 @@ export const VerifyEmailRoute = () => {
 									</Text>
 								</Stack>
 							</Alert>
-							<Button size="md" onClick={() => navigate("/w")}>
+							<Button size="md" onClick={() => navigate("/o")}>
 								<Trans>Go to dashboard</Trans>
 							</Button>
 						</Stack>

--- a/echo/frontend/src/routes/invite/AcceptInviteRoute.tsx
+++ b/echo/frontend/src/routes/invite/AcceptInviteRoute.tsx
@@ -105,13 +105,13 @@ export const AcceptInviteRoute = () => {
 				toast.success(t`You're in`);
 			}
 			setTimeout(() => {
-				// Org-only acceptance lands on /w (WorkspaceSelectorRoute surfaces DiscoverableWorkspaces per-org).
+				// Org-only acceptance lands on /o (WorkspaceSelectorRoute surfaces DiscoverableWorkspaces per-org).
 				if (data.type === "org") {
-					navigate("/w");
+					navigate("/o");
 				} else if (data.workspace_id) {
 					navigate(`/w/${data.workspace_id}/home`);
 				} else {
-					navigate("/w");
+					navigate("/o");
 				}
 			}, 800);
 		} catch (err) {
@@ -354,7 +354,7 @@ export const AcceptInviteRoute = () => {
 									size="md"
 									fullWidth
 									variant="outline"
-									onClick={() => navigate("/w")}
+									onClick={() => navigate("/o")}
 								>
 									<Trans>Back to my workspaces</Trans>
 								</Button>
@@ -475,7 +475,7 @@ export const AcceptInviteRoute = () => {
 													onClick={() =>
 														navigate(
 															inviteState.type === "org"
-																? "/w"
+																? "/o"
 																: `/w/${inviteState.workspace_id}/home`,
 														)
 													}
@@ -487,7 +487,7 @@ export const AcceptInviteRoute = () => {
 											size="md"
 											fullWidth
 											variant="outline"
-											onClick={() => navigate("/w")}
+											onClick={() => navigate("/o")}
 										>
 											<Trans>Back to my workspaces</Trans>
 										</Button>
@@ -515,7 +515,7 @@ export const AcceptInviteRoute = () => {
 													onClick={() =>
 														navigate(
 															inviteState.type === "org"
-																? "/w"
+																? "/o"
 																: `/w/${inviteState.workspace_id}/home`,
 														)
 													}
@@ -563,7 +563,7 @@ export const AcceptInviteRoute = () => {
 													size="md"
 													fullWidth
 													variant="outline"
-													onClick={() => navigate("/w")}
+													onClick={() => navigate("/o")}
 												>
 													<Trans>Not now</Trans>
 												</Button>

--- a/echo/frontend/src/routes/invite/MyInvitesRoute.tsx
+++ b/echo/frontend/src/routes/invite/MyInvitesRoute.tsx
@@ -50,9 +50,9 @@ export const MyInvitesRoute = () => {
 		try {
 			const data = await acceptMutation.mutateAsync(inviteId);
 			toast.success(t`Joined ${subjectName}`);
-			// Org-only invites have no workspace target; land on /w where DiscoverableWorkspaces is mounted.
+			// Org-only invites have no workspace target; land on /o where DiscoverableWorkspaces is mounted.
 			if (data.type === "org" || !data.workspace_id) {
-				navigate("/w");
+				navigate("/o");
 			} else {
 				navigate(`/w/${data.workspace_id}/home`);
 			}
@@ -118,7 +118,7 @@ export const MyInvitesRoute = () => {
 					<Title order={4} fw={400} c="dimmed">
 						<Trans>No pending invites</Trans>
 					</Title>
-					<Button variant="outline" size="sm" onClick={() => navigate("/w")}>
+					<Button variant="outline" size="sm" onClick={() => navigate("/o")}>
 						<Trans>Back to workspaces</Trans>
 					</Button>
 				</Stack>

--- a/echo/frontend/src/routes/onboarding/OnboardingRoute.tsx
+++ b/echo/frontend/src/routes/onboarding/OnboardingRoute.tsx
@@ -98,7 +98,7 @@ export const OnboardingRoute = () => {
 		if (workspaceId) {
 			navigate(`/w/${workspaceId}/home`);
 		} else {
-			navigate("/w");
+			navigate("/o");
 		}
 	}, [workspaceId, navigate]);
 

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -585,7 +585,7 @@ export const OrganisationRoute = () => {
 				}
 				secondaryAction={{
 					label: <Trans>Back</Trans>,
-					onClick: () => navigate("/w"),
+					onClick: () => navigate("/o"),
 				}}
 			/>
 		);
@@ -608,7 +608,7 @@ export const OrganisationRoute = () => {
 					<Title order={3} fw={400}>
 						<Trans>Organisation not found</Trans>
 					</Title>
-					<Button variant="outline" onClick={() => navigate("/w")}>
+					<Button variant="outline" onClick={() => navigate("/o")}>
 						<Trans>Back</Trans>
 					</Button>
 				</Stack>
@@ -618,7 +618,9 @@ export const OrganisationRoute = () => {
 
 	return (
 		<Container size="xl" py="xl" px="lg">
-			{organisationId && (
+			{/* Skipped on overview (cards + top SeatCapBanner already cover it);
+			    kept on other tabs where it's the only org-wide cap signal. */}
+			{organisationId && view !== "overview" && (
 				<OrganisationCapBanner
 					organisationId={organisationId}
 					workspaces={workspaces}
@@ -660,7 +662,7 @@ export const OrganisationRoute = () => {
 					{/* Back link top-right per the canonical header pattern
 					    (design review 2026-04-23). No gear icon — organisation-name
 					    + logo editing live inline in the Overview tab. */}
-					<Button variant="subtle" size="xs" onClick={() => navigate("/w")}>
+					<Button variant="subtle" size="xs" onClick={() => navigate("/o")}>
 						<Trans>Back to organisations</Trans>
 					</Button>
 				</Group>

--- a/echo/frontend/src/routes/project/CreateProjectRoute.tsx
+++ b/echo/frontend/src/routes/project/CreateProjectRoute.tsx
@@ -123,7 +123,7 @@ export const CreateProjectRoute = () => {
 		if (workspaceId) {
 			navigate(`/w/${workspaceId}/home`);
 		} else {
-			navigate("/w");
+			navigate("/o");
 		}
 	};
 

--- a/echo/frontend/src/routes/workspaces/CreateWorkspaceRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/CreateWorkspaceRoute.tsx
@@ -117,6 +117,11 @@ export const CreateWorkspaceRoute = () => {
 	const targetOrganisation =
 		adminOrganisations.find((o) => o.id === targetOrganisationId) ?? null;
 
+	// Launched from an org overview, so exiting returns there (not to /o home).
+	const backDestination = targetOrganisationId
+		? `/o/${targetOrganisationId}/overview`
+		: "/o";
+
 	const { data: workspacesData } = useQuery<{
 		workspaces: Array<{
 			id: string;
@@ -228,11 +233,11 @@ export const CreateWorkspaceRoute = () => {
 				),
 				confirmProps: { color: "red" },
 				labels: { cancel: t`Keep editing`, confirm: t`Discard` },
-				onConfirm: () => navigate("/w"),
+				onConfirm: () => navigate(backDestination),
 				title: t`Discard this request?`,
 			});
 		} else {
-			navigate("/w");
+			navigate(backDestination);
 		}
 	};
 
@@ -259,7 +264,7 @@ export const CreateWorkspaceRoute = () => {
 						</Trans>
 					</Text>
 					<Group>
-						<Button variant="default" onClick={() => navigate("/w")}>
+						<Button variant="default" onClick={() => navigate(backDestination)}>
 							<Trans>Back</Trans>
 						</Button>
 					</Group>
@@ -348,7 +353,7 @@ export const CreateWorkspaceRoute = () => {
 						</Trans>
 					</Text>
 
-					<Button variant="outline" onClick={() => navigate("/w")}>
+					<Button variant="outline" onClick={() => navigate(backDestination)}>
 						<Trans>Back to workspaces</Trans>
 					</Button>
 				</Stack>

--- a/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.tsx
@@ -16,7 +16,7 @@ import {
 import { useDocumentTitle } from "@mantine/hooks";
 import { IconChevronRight } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { Navigate } from "react-router";
 import { FetchErrorPanel } from "@/components/common/FetchErrorPanel";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
@@ -73,6 +73,78 @@ interface OrgListItem {
 	memberCount: number | null;
 	isExternal: boolean;
 }
+
+// External orgs are derived from external workspaces: they aren't in the
+// membership rollup but the user still needs a way into them.
+function deriveOrgList(
+	organisations: OrganisationRollup[],
+	workspaces: WorkspaceLite[],
+): OrgListItem[] {
+	const internalOrgs: OrgListItem[] = organisations.map((o) => ({
+		id: o.id,
+		isExternal: false,
+		logo_url: o.logo_url,
+		memberCount: o.total_members,
+		name: o.name,
+	}));
+
+	const internalOrgIds = new Set(internalOrgs.map((o) => o.id));
+	const externalOrgMap = new Map<string, OrgListItem>();
+	for (const w of workspaces) {
+		if (w.role !== "external" || !w.org_id) continue;
+		if (internalOrgIds.has(w.org_id)) continue;
+		if (!externalOrgMap.has(w.org_id)) {
+			externalOrgMap.set(w.org_id, {
+				id: w.org_id,
+				isExternal: true,
+				logo_url: w.org_logo_url,
+				memberCount: null,
+				name: w.org_name || t`Organisation`,
+			});
+		}
+	}
+
+	return [...internalOrgs, ...externalOrgMap.values()].sort((a, b) => {
+		if (a.isExternal !== b.isExternal) return a.isExternal ? 1 : -1;
+		return a.name.localeCompare(b.name);
+	});
+}
+
+// Entry decision: single-org users go straight to their org overview, everyone
+// else to the home list. Lives at the root (not inside /o) so the shortcut
+// fires once on entry and doesn't bounce single-org users off /o on every visit.
+export const RootRedirect = () => {
+	const { data, isLoading, isError } = useQuery({
+		queryFn: fetchWorkspaces,
+		queryKey: ["v2", "workspaces"],
+		staleTime: 30_000,
+	});
+
+	if (isLoading) {
+		return (
+			<Container size="sm" py="xl">
+				<Stack align="center" gap={16} mt="20vh">
+					<Loader size="sm" color="gray" />
+				</Stack>
+			</Container>
+		);
+	}
+
+	// On error fall through to the home list, which renders its own error panel.
+	// Relative targets keep any active /:language prefix intact.
+	if (isError || !data) {
+		return <Navigate to="o" replace />;
+	}
+
+	const orgList = deriveOrgList(
+		data.organisations ?? [],
+		data.workspaces ?? [],
+	);
+	if (orgList.length === 1) {
+		return <Navigate to={`o/${orgList[0].id}/overview`} replace />;
+	}
+	return <Navigate to="o" replace />;
+};
 
 function OrgRow({ org, onOpen }: { org: OrgListItem; onOpen: () => void }) {
 	const logo = resolveLogoUrl(org.logo_url);
@@ -162,46 +234,9 @@ export const WorkspaceSelectorRoute = () => {
 	const recentRemovals = data?.recent_removals ?? [];
 	const invites = pendingInvites ?? [];
 
-	// Internal orgs come from the rollup (the user is a member). External orgs
-	// are derived from external workspaces — those orgs aren't in the rollup but
-	// the user still needs a way into them.
-	const internalOrgs: OrgListItem[] = organisations.map((o) => ({
-		id: o.id,
-		isExternal: false,
-		logo_url: o.logo_url,
-		memberCount: o.total_members,
-		name: o.name,
-	}));
-
-	const internalOrgIds = new Set(internalOrgs.map((o) => o.id));
-	const externalOrgMap = new Map<string, OrgListItem>();
-	for (const w of workspaces) {
-		if (w.role !== "external" || !w.org_id) continue;
-		if (internalOrgIds.has(w.org_id)) continue;
-		if (!externalOrgMap.has(w.org_id)) {
-			externalOrgMap.set(w.org_id, {
-				id: w.org_id,
-				isExternal: true,
-				logo_url: w.org_logo_url,
-				memberCount: null,
-				name: w.org_name || t`Organisation`,
-			});
-		}
-	}
-
-	const orgList = [...internalOrgs, ...externalOrgMap.values()].sort((a, b) => {
-		if (a.isExternal !== b.isExternal) return a.isExternal ? 1 : -1;
-		return a.name.localeCompare(b.name);
-	});
-
-	// Single-org shortcut: a user who belongs to exactly one organisation
-	// shouldn't have to click through a one-item list. Route straight to it.
-	useEffect(() => {
-		if (isLoading || isError) return;
-		if (orgList.length === 1) {
-			navigate(`/o/${orgList[0].id}/overview`, { replace: true });
-		}
-	}, [isLoading, isError, orgList, navigate]);
+	// No single-org redirect here (it's in RootRedirect), so this list stays
+	// reachable for single-org users.
+	const orgList = deriveOrgList(organisations, workspaces);
 
 	if (isLoading) {
 		return (
@@ -227,9 +262,6 @@ export const WorkspaceSelectorRoute = () => {
 			/>
 		);
 	}
-
-	// About to redirect — render nothing to avoid a one-frame flash of the list.
-	if (orgList.length === 1) return null;
 
 	return (
 		<Container size="sm" py="xl" px="lg">

--- a/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
@@ -389,7 +389,7 @@ export const WorkspaceSettingsRoute = () => {
 			queryClient.invalidateQueries({ queryKey: ["v2", "workspaces"] });
 			queryClient.invalidateQueries({ queryKey: ["v2", "organisation"] });
 			toast.success(t`Workspace deleted`);
-			navigate("/w");
+			navigate("/o");
 		},
 	});
 
@@ -405,7 +405,7 @@ export const WorkspaceSettingsRoute = () => {
 			queryClient.invalidateQueries({ queryKey: ["v2", "workspaces"] });
 			queryClient.invalidateQueries({ queryKey: ["v2", "workspace-settings"] });
 			toast.success(t`You left the workspace`);
-			navigate("/w");
+			navigate("/o");
 		},
 	});
 
@@ -630,7 +630,7 @@ export const WorkspaceSettingsRoute = () => {
 							variant="subtle"
 							size="xs"
 							color="gray"
-							onClick={() => navigate("/w")}
+							onClick={() => navigate("/o")}
 						>
 							<Trans>Back to workspaces</Trans>
 						</Button>

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -1708,7 +1708,11 @@ def task_send_downgrade_email(
         downgraded_at_human = "today"
 
     base = (settings.urls.admin_base_url or "").rstrip("/")
-    workspace_url = f"{base}/w/{workspace_id}" if base else f"/w/{workspace_id}"
+    workspace_url = (
+        f"{base}/w/{workspace_id}/settings/billing"
+        if base
+        else f"/w/{workspace_id}/settings/billing"
+    )
 
     subject = f"{ws_name} moved to {to_tier}".replace("\r", " ").replace("\n", " ")
 
@@ -1902,7 +1906,11 @@ def _send_tier_expired_notifications(
 
     settings = get_settings()
     base = (settings.urls.admin_base_url or "").rstrip("/")
-    workspace_url = f"{base}/w/{workspace_id}" if base else f"/w/{workspace_id}"
+    workspace_url = (
+        f"{base}/w/{workspace_id}/settings/billing"
+        if base
+        else f"/w/{workspace_id}/settings/billing"
+    )
 
     freeze_items = [
         e["human"] for e in effects
@@ -2051,7 +2059,11 @@ def _send_tier_expiring_soon(
 
     settings = get_settings()
     base = (settings.urls.admin_base_url or "").rstrip("/")
-    workspace_url = f"{base}/w/{workspace_id}" if base else f"/w/{workspace_id}"
+    workspace_url = (
+        f"{base}/w/{workspace_id}/settings/billing"
+        if base
+        else f"/w/{workspace_id}/settings/billing"
+    )
 
     from dembrane.directus import directus
     with directus_client_context(directus) as client:


### PR DESCRIPTION
  Follow-up fixes on the org/workspace hierarchy pages.

  - Move the single-org "go to overview" shortcut from the /w home component into a root-level RootRedirect, so single-org users can still reach the home list instead of being bounced to overview on every visit.
  - Move the home list from /w to /o (/o = organisations, /w = workspaces). Repoint all internal "go home" navigations to /o; bare /w is retired and 404s; /w/new and /w/:workspaceId/* are unchanged.
  - Request-workspace flow: cancel/back/submit return to the launching org overview, add a Home > Org > Request workspace breadcrumb, and show the org context in the sidebar.
  - Hide the duplicate OrganisationCapBanner on the org overview tab (kept on people/usage/billing where it's the only org-wide signal).
  - Add the org crumb to workspace/project breadcrumbs (Home > Org > Workspace > Project).
  - Keep the /:language prefix when clicking the dembrane logo.
  - Point tier emails at /w/{id}/settings/billing instead of the now blank bare /w/{id}.