### PR TITLE
fix: return 404 (not 500) for missing Directus records

### DIFF
--- a/echo/server/dembrane/api/template.py
+++ b/echo/server/dembrane/api/template.py
@@ -5,7 +5,7 @@ from fastapi import Query, APIRouter, HTTPException
 from pydantic import Field, BaseModel
 
 from dembrane.app_user import resolve_app_user
-from dembrane.directus import directus
+from dembrane.directus import DirectusBadRequest, directus
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.directus_async import async_directus
 from dembrane.api.dependency_auth import DependencyDirectusSession
@@ -271,6 +271,9 @@ async def update_prompt_template(
     """
     try:
         existing = directus.get_item("prompt_template", template_id)
+    except DirectusBadRequest:
+        # Missing/forbidden single item -> Directus 403; treat as 404.
+        existing = None
     except Exception:
         logger.exception("Failed to fetch template for update")
         raise HTTPException(status_code=500, detail="Failed to update template") from None
@@ -315,6 +318,9 @@ async def delete_prompt_template(
     """Delete a template. Same role rules as update."""
     try:
         existing = directus.get_item("prompt_template", template_id)
+    except DirectusBadRequest:
+        # Missing/forbidden single item -> Directus 403; treat as 404.
+        existing = None
     except Exception:
         logger.exception("Failed to fetch template for delete")
         raise HTTPException(status_code=500, detail="Failed to delete template") from None

--- a/echo/server/dembrane/directus_async.py
+++ b/echo/server/dembrane/directus_async.py
@@ -46,6 +46,23 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 1.0
 
 
+def _is_forbidden_record(response: "httpx.Response") -> bool:
+    """Directus returns 403 FORBIDDEN (not 404) for a missing/inaccessible
+    single item. Matches only that, never a 401/token failure."""
+    if response.status_code != 403:
+        return False
+    try:
+        body = response.json()
+    except Exception:
+        return False
+    if not isinstance(body, dict):
+        return False
+    errors = body.get("errors") or []
+    first = errors[0] if errors else {}
+    code = (first.get("extensions") or {}).get("code")
+    return code == "FORBIDDEN"
+
+
 class AsyncDirectusClient:
     """Async Directus HTTP client using httpx.AsyncClient."""
 
@@ -88,6 +105,7 @@ class AsyncDirectusClient:
         *,
         max_retries: int = DEFAULT_MAX_RETRIES,
         retry_delay: float = DEFAULT_RETRY_DELAY,
+        recoverable_status_codes: "set[int] | None" = None,
         **kwargs: Any,
     ) -> httpx.Response:
         """Make an HTTP request with retry logic for recoverable errors.
@@ -98,6 +116,11 @@ class AsyncDirectusClient:
         envelope; transport errors raise once retries are exhausted.
         """
         client = self._get_client()
+        recoverable = (
+            recoverable_status_codes
+            if recoverable_status_codes is not None
+            else RECOVERABLE_STATUS_CODES
+        )
         retries = 0
 
         while True:
@@ -110,7 +133,7 @@ class AsyncDirectusClient:
                 await asyncio.sleep(retry_delay * (2 ** (retries - 1)))
                 continue
 
-            if response.status_code in RECOVERABLE_STATUS_CODES:
+            if response.status_code in recoverable:
                 retries += 1
                 if retries >= max_retries:
                     return response
@@ -123,10 +146,19 @@ class AsyncDirectusClient:
     # HTTP verbs (match sync client return semantics)
     # ------------------------------------------------------------------
 
-    async def get(self, path: str, **kwargs: Any) -> Any:
-        """GET request. Returns response.json()["data"]."""
+    async def get(self, path: str, none_on_forbidden: bool = False, **kwargs: Any) -> Any:
+        """GET request. Returns response.json()["data"].
+
+        none_on_forbidden: return None (not raise, not retried) on a record-level
+        403 FORBIDDEN, so callers can do ``if not item: raise 404``.
+        """
+        recoverable = RECOVERABLE_STATUS_CODES - {403} if none_on_forbidden else None
         try:
-            response = await self._request("GET", path, **kwargs)
+            response = await self._request(
+                "GET", path, recoverable_status_codes=recoverable, **kwargs
+            )
+            if none_on_forbidden and _is_forbidden_record(response):
+                return None
             try:
                 data = response.json()
             except json.JSONDecodeError:
@@ -233,8 +265,11 @@ class AsyncDirectusClient:
         return await self.search(f"/items/{collection}", query=params, **kwargs)
 
     async def get_item(self, collection: str, item_id: str, **kwargs: Any) -> Any:
-        """Get a single item. Returns dict directly."""
-        return await self.get(f"/items/{collection}/{item_id}", **kwargs)
+        """Get a single item, or None when it doesn't exist / isn't accessible
+        (Directus answers 403 FORBIDDEN for both)."""
+        return await self.get(
+            f"/items/{collection}/{item_id}", none_on_forbidden=True, **kwargs
+        )
 
     async def create_item(
         self, collection: str, data: dict[str, Any] | list[dict[str, Any]], **kwargs: Any

--- a/echo/server/tests/test_directus_retry.py
+++ b/echo/server/tests/test_directus_retry.py
@@ -152,3 +152,78 @@ def test_sync_persistent_transport_error_raises_after_3_attempts():
 
     assert calls["n"] == 3
     assert sleeps == [1.0, 2.0]
+
+
+# --- get_item record-level 403 FORBIDDEN handling ---
+# Directus answers a missing single item with 403; get_item maps that to None
+# (so `if not item: raise 404` fires) but still raises on a 401 token failure.
+
+from dembrane.directus import DirectusBadRequest  # noqa: E402
+
+
+class _BodyTransport(httpx.AsyncBaseTransport):
+    def __init__(self, status_code: int, body: dict):
+        self.requests = 0
+        self.status_code = status_code
+        self.body = body
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:  # noqa: ARG002
+        self.requests += 1
+        return httpx.Response(self.status_code, json=self.body)
+
+
+def _client_with(transport: httpx.AsyncBaseTransport) -> AsyncDirectusClient:
+    client = AsyncDirectusClient(url="http://directus.test", token="t")
+    client._client = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://directus.test", transport=transport
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_get_item_returns_none_on_forbidden_record():
+    transport = _BodyTransport(403, {"errors": [{"extensions": {"code": "FORBIDDEN"}}]})
+    client = _client_with(transport)
+
+    with patch("dembrane.directus_async.asyncio.sleep") as sleep_mock:
+        result = await client.get_item("conversation", "does-not-exist")
+
+    assert result is None
+    assert transport.requests == 1  # no retry tail on a deterministic FORBIDDEN
+    sleep_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_item_returns_data_on_success():
+    transport = _BodyTransport(200, {"data": {"id": "abc"}})
+    client = _client_with(transport)
+
+    result = await client.get_item("conversation", "abc")
+
+    assert result == {"id": "abc"}
+    assert transport.requests == 1
+
+
+@pytest.mark.asyncio
+async def test_get_item_raises_on_token_failure_not_treated_as_not_found():
+    # A 401 (bad/expired admin token) must NOT be silently turned into None;
+    # otherwise an auth outage would mask every record as "not found".
+    transport = _BodyTransport(401, {"errors": [{"extensions": {"code": "INVALID_CREDENTIALS"}}]})
+    client = _client_with(transport)
+
+    with patch("dembrane.directus_async.asyncio.sleep"):
+        with pytest.raises(DirectusBadRequest):
+            await client.get_item("conversation", "abc")
+
+    assert transport.requests == 3  # 401 stays recoverable -> retried, then raises
+
+
+@pytest.mark.asyncio
+async def test_get_item_raises_on_non_forbidden_403():
+    # A 403 whose code is not FORBIDDEN is a real error, not existence-hiding.
+    transport = _BodyTransport(403, {"errors": [{"extensions": {"code": "SOMETHING_ELSE"}}]})
+    client = _client_with(transport)
+
+    with patch("dembrane.directus_async.asyncio.sleep"):
+        with pytest.raises(DirectusBadRequest):
+            await client.get_item("conversation", "abc")


### PR DESCRIPTION
  Single-item Directus GETs answer 403 FORBIDDEN for a row that is missing
  or filtered out (it never leaks existence). The async client's get_item
  raised on that envelope, so the `if not item: raise 404` guards in the v2
  BFF access resolvers were dead code and every missing-id detail route 500'd
  after a 3s retry tail. The same swallowed-exception turned missing prompt
  templates into 500s on update/delete.

  - directus_async: get_item returns None on a record-level 403 FORBIDDEN and skips the retry; 401/token failures still raise loudly
  - api/template: map DirectusBadRequest to the existing 404 path on update/delete (status fixed; sync-client retry tail left as-is)
  - tests: cover FORBIDDEN->None, success, and 401/non-FORBIDDEN still raise