### PR TITLE
fix(sidebar): route home to org list and align org settings access

### DIFF
--- a/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
+++ b/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
@@ -96,7 +96,7 @@ export const AppBreadcrumbs = () => {
 	const crumbs: Crumb[] = useMemo(() => {
 		// Always start with Home so the trail is anchored to a real
 		// clickable parent.
-		const out: Crumb[] = [{ href: "/", label: "Home" }];
+		const out: Crumb[] = [{ href: "/o", label: "Home" }];
 		// Emit the org crumb before the workspace one, so workspace/project
 		// trails read Home › Org › Workspace › Project.
 		const pushWorkspaceCrumbs = (ws: NonNullable<typeof workspace>) => {

--- a/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
+++ b/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
@@ -8,7 +8,7 @@ export const SidebarHeader = () => {
 			style={{ borderColor: "rgba(45, 45, 44, 0.06)" }}
 		>
 			<I18nLink
-				to="/"
+				to="/o"
 				className="flex items-center gap-2 transition-opacity hover:opacity-80"
 				aria-label="dembrane home"
 			>

--- a/echo/frontend/src/features/sidebar/views/org/OrgSettingsView.tsx
+++ b/echo/frontend/src/features/sidebar/views/org/OrgSettingsView.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/react/macro";
-import { ChartLine, CreditCard, Gear, Users } from "@phosphor-icons/react";
+import { ChartLineIcon, CreditCardIcon, GearIcon, UsersIcon } from "@phosphor-icons/react";
 import { useParams } from "react-router";
+import { useV2Me } from "@/hooks/useV2Me";
 import { BackButton } from "../../primitives/BackButton";
 import { NavItem } from "../../primitives/NavItem";
 
@@ -10,6 +11,12 @@ export const OrgSettingsView = () => {
 		organisationId?: string;
 	}>();
 	const orgId = routeOrgId ?? organisationId;
+	const { data: me } = useV2Me();
+	// Mirror OrganisationRoute's `canSeeFinancials`; others get bounced off
+	// Usage/Billing to the Members panel, so don't offer those items.
+	const role = me?.orgs.find((o) => o.id === orgId)?.role;
+	const canSeeFinancials =
+		role === "owner" || role === "admin" || role === "billing";
 	if (!orgId) return null;
 
 	return (
@@ -18,23 +25,27 @@ export const OrgSettingsView = () => {
 			<NavItem
 				to={`/o/${orgId}/settings/general`}
 				label={<Trans>General</Trans>}
-				icon={Gear}
+				icon={GearIcon}
 			/>
-			<NavItem
-				to={`/o/${orgId}/settings/usage`}
-				label={<Trans>Usage and tier</Trans>}
-				icon={ChartLine}
-			/>
+			{canSeeFinancials && (
+				<NavItem
+					to={`/o/${orgId}/settings/usage`}
+					label={<Trans>Usage and tier</Trans>}
+					icon={ChartLineIcon}
+				/>
+			)}
 			<NavItem
 				to={`/o/${orgId}/settings/members`}
 				label={<Trans>Members</Trans>}
-				icon={Users}
+				icon={UsersIcon}
 			/>
-			<NavItem
-				to={`/o/${orgId}/settings/billing`}
-				label={<Trans>Billing</Trans>}
-				icon={CreditCard}
-			/>
+			{canSeeFinancials && (
+				<NavItem
+					to={`/o/${orgId}/settings/billing`}
+					label={<Trans>Billing</Trans>}
+					icon={CreditCardIcon}
+				/>
+			)}
 		</nav>
 	);
 };

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -1110,7 +1110,7 @@ function OrganisationOverviewPanel({
 		const navigate = useI18nNavigate();
 
 		const handlePeopleClick = () => {
-			navigate(`/o/${orgId}/people`);
+			navigate(`/o/${orgId}/settings/members`);
 		};
 
 		// The caller's own workspaces (direct memberships) + their pending

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -367,7 +367,11 @@ export const OrganisationRoute = () => {
 		queryKey: ["v2", "organisation", organisationId],
 		staleTime: 30_000,
 	});
-	const { data: membersData, error: membersError } = useQuery({
+	const {
+		data: membersData,
+		error: membersError,
+		isLoading: membersLoading,
+	} = useQuery({
 		enabled: Boolean(organisationId),
 		queryFn: () => fetchOrganisationMembers(organisationId as string),
 		queryKey: ["v2", "organisation", organisationId, "members"],
@@ -694,6 +698,7 @@ export const OrganisationRoute = () => {
 							<OrganisationOverviewPanel
 								organisation={organisation}
 								members={members}
+								membersLoading={membersLoading}
 								workspaces={workspaces}
 								isManager={isAdmin}
 								onOpenWorkspace={(id) => navigate(`/w/${id}/home`)}
@@ -1088,6 +1093,7 @@ interface WorkspaceCardModel {
 function OrganisationOverviewPanel({
 	organisation,
 	members,
+	membersLoading,
 	workspaces,
 	isManager,
 	onOpenWorkspace,
@@ -1096,6 +1102,7 @@ function OrganisationOverviewPanel({
 }: {
 	organisation: OrganisationDetail;
 	members: OrganisationMember[];
+	membersLoading: boolean;
 	// Org roster (manager view / People matrix). Only consulted here for
 	// per-workspace pinned projects + private flag — the cards themselves are
 	// driven by the caller's own membership list so we never show a workspace
@@ -1115,7 +1122,7 @@ function OrganisationOverviewPanel({
 
 		// The caller's own workspaces (direct memberships) + their pending
 	// new-workspace / upgrade requests. Same endpoint the home page used.
-	const { data: mine } = useQuery({
+	const { data: mine, isLoading: workspacesLoading } = useQuery({
 		queryFn: fetchMyWorkspaces,
 		queryKey: ["v2", "workspaces"],
 		staleTime: 30_000,
@@ -1185,11 +1192,15 @@ function OrganisationOverviewPanel({
 					<Title order={4} fw={500}>
 						<Trans>People</Trans>
 					</Title>
-					<Text size="sm" c="dimmed">
-						{people.length}
-					</Text>
+					{!membersLoading && (
+						<Text size="sm" c="dimmed">
+							{people.length}
+						</Text>
+					)}
 				</Group>
-					{people.length === 0 ? (
+					{membersLoading && people.length === 0 ? (
+						<Loader size="sm" color="gray" />
+					) : people.length === 0 ? (
 						<Text size="sm" c="dimmed">
 							<Trans>No one on this organisation yet.</Trans>
 						</Text>
@@ -1252,9 +1263,11 @@ function OrganisationOverviewPanel({
 						<Title order={4} fw={500}>
 							<Trans>Workspaces</Trans>
 						</Title>
-						<Text size="sm" c="dimmed">
-							{myCards.length}
-						</Text>
+						{!workspacesLoading && (
+							<Text size="sm" c="dimmed">
+								{myCards.length}
+							</Text>
+						)}
 					</Group>
 					{isManager && (
 						<Button
@@ -1267,7 +1280,9 @@ function OrganisationOverviewPanel({
 						</Button>
 					)}
 				</Group>
-				{myCards.length === 0 && pendingRequests.length === 0 ? (
+				{workspacesLoading && myCards.length === 0 && pendingRequests.length === 0 ? (
+					<Loader size="sm" color="gray" />
+				) : myCards.length === 0 && pendingRequests.length === 0 ? (
 					<Text size="sm" c="dimmed">
 						<Trans>
 							You haven't joined any workspace in this organisation yet.


### PR DESCRIPTION
  - Point the dembrane logo and Home breadcrumb at /o instead of / so they always land on the organisations list, regardless of org count
  - Navigate org overview member bubbles to /o/:id/settings/members so the sidebar resolves to org-settings instead of staying at org-home
  - Gate Usage and Billing in OrgSettingsView behind canSeeFinancials, so members/externals no longer see items that bounce them to the Members panel