### PR TITLE
ECHO-847 fix(breadcrumbs): middle-truncate long labels with full title on hover

### DIFF
--- a/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
+++ b/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 import { useMemo } from "react";
 import { useParams } from "react-router";
 import { I18nLink } from "@/components/common/i18nLink";
@@ -11,6 +11,17 @@ interface Crumb {
 	label: string;
 	href?: string;
 }
+
+const MAX_CRUMB_LABEL_LENGTH = 30;
+
+const truncateMiddle = (text: string, maxLength = MAX_CRUMB_LABEL_LENGTH) => {
+	if (text.length <= maxLength) return text;
+	const ellipsis = "...";
+	const visible = maxLength - ellipsis.length;
+	const head = Math.ceil(visible / 2);
+	const tail = Math.floor(visible / 2);
+	return `${text.slice(0, head)}${ellipsis}${text.slice(text.length - tail)}`;
+};
 
 const ADMIN_TAB_LABELS: Record<string, string> = {
 	partners: "Partners",
@@ -244,16 +255,18 @@ export const AppBreadcrumbs = () => {
 		>
 			{crumbs.map((c, i) => {
 				const isLast = i === crumbs.length - 1;
+				const displayLabel = truncateMiddle(c.label);
 				return (
 					<span key={`${c.label}-${i}`} className="flex items-center gap-1">
-						{i > 0 && <CaretRight size={10} opacity={0.5} />}
+						{i > 0 && <CaretRightIcon size={10} opacity={0.5} />}
 						{c.href && !isLast ? (
 							<I18nLink
 								to={c.href}
 								className="truncate hover:underline"
 								style={{ color: "rgba(45, 45, 44, 0.75)" }}
+								title={c.label}
 							>
-								{c.label}
+								{displayLabel}
 							</I18nLink>
 						) : (
 							<span
@@ -261,8 +274,9 @@ export const AppBreadcrumbs = () => {
 								style={{
 									color: isLast ? "#2d2d2c" : "rgba(45, 45, 44, 0.55)",
 								}}
+								title={c.label}
 							>
-								{c.label}
+								{displayLabel}
 							</span>
 						)}
 					</span>


### PR DESCRIPTION
  Long breadcrumb titles (e.g. uploaded audio file names) were end-clipped
  by CSS truncate, hiding the file extension and trailing id. Add a
  truncateMiddle helper that collapses the middle with "..." for labels
  over 30 characters, keeping the start and end readable, and expose the
  full label via the title attribute on hover.