### PR TITLE
fix(seats): count only direct workspace members

### DIFF
--- a/echo/server/dembrane/api/v2/workspaces.py
+++ b/echo/server/dembrane/api/v2/workspaces.py
@@ -12,7 +12,6 @@ from dembrane.utils import generate_uuid
 from dembrane.app_user import resolve_app_user, get_app_user_or_raise
 from dembrane.policies import TIER_ORDER
 from dembrane.settings import get_settings
-from dembrane.inheritance import get_effective_members
 from dembrane.seat_capacity import tier_hard_blocks_seats
 from dembrane.api.v2.schemas import (
     MemberPreview,
@@ -1239,24 +1238,12 @@ async def get_workspace_usage(
 
     audio_hours = round(total_seconds / 3600, 2)
 
-    # Seat breakdown. Reuses inheritance.get_effective_members so the
-    # count includes derived org admins/owners — they consume a seat just
-    # like direct members. get_effective_members dedups by user_id with
-    # direct-wins-over-derived precedence, so we just bucket on role here.
-    # member + external counts always sum to the unified seat_count
-    # surfaced on the API (the bar numerator).
-    effective_members = await get_effective_members(ctx.workspace_id)
+    # Seat breakdown via the shared counter so this matches /v2/orgs/:id/usage.
+    from dembrane.seat_capacity import compute_effective_seat_state
 
-    member_count = 0
-    external_count = 0
-    member_roles = {"owner", "admin", "member", "billing"}
-    for m in effective_members:
-        role = m.get("role")
-        if role == "external":
-            external_count += 1
-        elif role in member_roles:
-            member_count += 1
-    seat_count = member_count + external_count
+    seat_count, member_count, external_count = await compute_effective_seat_state(
+        ctx.workspace_id
+    )
 
     # Tier capacity lookup. Legacy rows with NULL tier fall through to the
     # unknown-tier path below (unlimited / no block) rather than silently

--- a/echo/server/dembrane/seat_capacity.py
+++ b/echo/server/dembrane/seat_capacity.py
@@ -1,8 +1,8 @@
 """Workspace seat capacity enforcement (unified model).
 
 Single source of truth for "is there room on this workspace for one more
-user?" Builds on inheritance.get_effective_members so the count includes
-derived org admins/owners — they count toward seats just like direct members.
+user?" Only direct workspace members consume a seat; derived org-admin/owner
+access does not (ADR-0004).
 
 Externals (role='external') share the same seat pool as members. There is
 no separate external cap — only `included_seats` matters. The `external`
@@ -65,15 +65,17 @@ async def compute_effective_seat_state(workspace_id: str) -> tuple[int, int, int
         (owner/admin/member/billing).
     external_count: distinct users with role='external'.
 
-    Includes derived org admins/owners (via get_effective_members). A user
-    with both a direct row and a derived path counts once. Derived rows
-    are never external (inheritance.get_effective_members enforces).
+    Only direct members occupy a seat; derived org-admin/owner access
+    (source='inherited') grants oversight but does not (ADR-0004).
     """
     members = await get_effective_members(workspace_id)
 
     member_users: set[str] = set()
     external_users: set[str] = set()
     for m in members:
+        # Derived oversight access doesn't consume a seat.
+        if m.get("source") != "direct":
+            continue
         uid = m.get("user_id")
         if not uid:
             continue

--- a/echo/server/tests/test_seat_capacity.py
+++ b/echo/server/tests/test_seat_capacity.py
@@ -74,30 +74,32 @@ def patch_pending(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_seat_state_counts_members_and_externals_unified(patch_members):
+async def test_seat_state_counts_direct_members_and_externals_unified(patch_members):
+    """Direct members + externals share one seat pool. A derived org admin is
+    present for access but does not add to the count."""
     patch_members(
         [
             _direct_member("u-owner", role="owner"),
-            _derived_admin("u-org-admin"),
+            _derived_admin("u-org-admin"),  # oversight only, no seat
             _direct_external("u-ext"),
         ]
     )
     seats_used, member_count, external_count = await seat_capacity.compute_effective_seat_state(
         "w-1"
     )
-    assert member_count == 2  # owner (direct) + org-admin (derived)
+    assert member_count == 1  # only the direct owner
     assert external_count == 1
-    assert seats_used == 3  # unified: members + externals
+    assert seats_used == 2  # unified: direct members + externals
 
 
 @pytest.mark.asyncio
 async def test_seat_state_dedups_by_user(patch_members):
-    """A user with both a direct row and a derived path counts once."""
+    """A user with a direct row counts once even if also present as derived."""
     patch_members(
         [
             _direct_member("u-1", role="owner"),
-            _derived_admin("u-2"),
-            _derived_admin("u-2"),
+            _direct_member("u-2", role="member"),
+            _derived_admin("u-2"),  # same user, derived — already direct, no double count
         ]
     )
     seats_used, member_count, external_count = await seat_capacity.compute_effective_seat_state(
@@ -124,6 +126,40 @@ async def test_seat_state_externals_count_toward_seats_used(patch_members):
     assert member_count == 1
     assert external_count == 2
     assert seats_used == 3
+
+
+@pytest.mark.asyncio
+async def test_derived_org_admins_do_not_consume_seats(patch_members):
+    """Org-only admins/owners derive workspace access for oversight but must
+    NOT consume a seat — a seat is taken only when someone joins a workspace
+    directly. Reproduces the 'free tier shows 2/1' bug: the org owner is a
+    direct member and an org-only admin is derived; seats must stay at 1.
+    """
+    patch_members(
+        [
+            _direct_member("u-owner", role="owner"),
+            _derived_admin("u-org-only-admin"),
+        ]
+    )
+    seats_used, member_count, external_count = await seat_capacity.compute_effective_seat_state(
+        "w-1"
+    )
+    assert member_count == 1  # only the direct owner occupies a seat
+    assert external_count == 0
+    assert seats_used == 1  # derived org admin does NOT count
+
+
+@pytest.mark.asyncio
+async def test_derived_only_workspace_has_zero_seats(patch_members):
+    """A workspace whose only effective members are derived org admins/owners
+    (no direct rows) consumes zero seats."""
+    patch_members([_derived_admin("u-a"), _derived_admin("u-b")])
+    seats_used, member_count, external_count = await seat_capacity.compute_effective_seat_state(
+        "w-1"
+    )
+    assert member_count == 0
+    assert external_count == 0
+    assert seats_used == 0
 
 
 # ── assert_can_add_seat (unified gate) ──────────────────────────────────
@@ -219,12 +255,12 @@ async def test_unknown_tier_unlimited(patch_members):
 
 
 @pytest.mark.asyncio
-async def test_derived_admins_count_toward_cap(patch_members):
-    """Org admins (derived) count toward pilot's seat cap."""
+async def test_derived_admins_do_not_count_toward_cap(patch_members):
+    """Org admins with only derived (oversight) access do NOT consume seats,
+    so they never push a workspace to its cap. A pilot workspace whose only
+    effective members are two derived org admins is 0/2 — an invite passes."""
     patch_members([_derived_admin("u-org-admin-1"), _derived_admin("u-org-admin-2")])
-    with pytest.raises(HTTPException) as exc:
-        await seat_capacity.assert_can_add_seat(_ws("pilot"))
-    assert exc.value.status_code == 402
+    await seat_capacity.assert_can_add_seat(_ws("pilot"))  # no raise
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
  Org-only members/admins derived into open workspaces were consuming a
  seat (free tier showed 2/1). compute_effective_seat_state now counts
  only direct workspace_membership rows; derived oversight access is free.
  Route workspace usage through the same counter so the org and workspace
  views agree. See ADR-0004.