### PR TITLE
ECHO-858 fix(search): scope /home/search results for admin sessions

### DIFF
--- a/echo/server/dembrane/api/search.py
+++ b/echo/server/dembrane/api/search.py
@@ -394,9 +394,8 @@ async def search_home(
     limit = max(1, min(limit, 25))
     # Post-lockdown the user token can't read app collections, so search
     # runs with the admin client and results are scoped in the app layer.
-    # Over-fetch for non-staff so access filtering doesn't starve the
-    # visible result count.
-    fetch_limit = limit if auth.is_admin else limit * 3
+    # Over-fetch so access filtering doesn't starve the visible result count.
+    fetch_limit = limit * 3
 
     projects_raw, conversations_raw, chunks_raw, chats_raw = await gather(
         run_in_thread_pool(_fetch_projects, directus, term, fetch_limit),
@@ -405,46 +404,48 @@ async def search_home(
         run_in_thread_pool(_fetch_chats, directus, term, fetch_limit),
     )
 
-    if not auth.is_admin:
-        from dembrane.app_user import resolve_app_user
-        from dembrane.inheritance import get_user_project_access
+    # Scope every session, including is_admin (Directus staff). The
+    # click-time guard (GET /v2/projects/{id}) has no staff bypass, so an
+    # unscoped staff search returns hits that 404 on click.
+    from dembrane.app_user import resolve_app_user
+    from dembrane.inheritance import get_user_project_access
 
-        app_user = await resolve_app_user(auth.user_id)
-        if not app_user:
-            # Not onboarded: nothing is accessible; mirror the old
-            # empty-results behavior instead of erroring the palette.
-            return SearchResponse()
-        app_user_id = app_user["id"]
+    app_user = await resolve_app_user(auth.user_id)
+    if not app_user:
+        # Not onboarded: nothing is accessible; mirror the old
+        # empty-results behavior instead of erroring the palette.
+        return SearchResponse()
+    app_user_id = app_user["id"]
 
-        allowed: Dict[str, bool] = {}
+    allowed: Dict[str, bool] = {}
 
-        async def _can_access(project_id: Optional[str]) -> bool:
-            if not project_id:
-                return False
-            if project_id not in allowed:
-                access = await get_user_project_access(
-                    project_id=project_id,
-                    user_id=app_user_id,
-                    directus_user_id=auth.user_id,
-                )
-                allowed[project_id] = access is not None
-            return allowed[project_id]
+    async def _can_access(project_id: Optional[str]) -> bool:
+        if not project_id:
+            return False
+        if project_id not in allowed:
+            access = await get_user_project_access(
+                project_id=project_id,
+                user_id=app_user_id,
+                directus_user_id=auth.user_id,
+            )
+            allowed[project_id] = access is not None
+        return allowed[project_id]
 
-        async def _scope(
-            rows: List[dict], project_id_of: Callable[[Dict[str, Any]], Optional[str]]
-        ) -> List[dict]:
-            out: List[dict] = []
-            for row in rows:
-                if await _can_access(project_id_of(row)):
-                    out.append(row)
-                    if len(out) >= limit:
-                        break
-            return out
+    async def _scope(
+        rows: List[dict], project_id_of: Callable[[Dict[str, Any]], Optional[str]]
+    ) -> List[dict]:
+        out: List[dict] = []
+        for row in rows:
+            if await _can_access(project_id_of(row)):
+                out.append(row)
+                if len(out) >= limit:
+                    break
+        return out
 
-        projects_raw = await _scope(projects_raw, lambda r: _safe_str(r.get("id")))
-        conversations_raw = await _scope(conversations_raw, _project_id_of_row)
-        chunks_raw = await _scope(chunks_raw, _project_id_of_chunk)
-        chats_raw = await _scope(chats_raw, _project_id_of_row)
+    projects_raw = await _scope(projects_raw, lambda r: _safe_str(r.get("id")))
+    conversations_raw = await _scope(conversations_raw, _project_id_of_row)
+    chunks_raw = await _scope(chunks_raw, _project_id_of_chunk)
+    chats_raw = await _scope(chats_raw, _project_id_of_row)
 
     return SearchResponse(
         projects=[

--- a/echo/server/tests/api/test_home_search_scoping.py
+++ b/echo/server/tests/api/test_home_search_scoping.py
@@ -1,0 +1,101 @@
+"""GET /home/search must only return results the caller can open.
+
+The selector home page navigates straight to a hit's URL, where
+ProjectAccessGuard re-checks via get_user_project_access (no staff
+exception). Search must apply the same ladder for every session —
+including Directus-admin (is_admin) sessions — or the palette shows
+rows that 404 on click ("This isn't available to you").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+from dembrane.api.search import SearchRouter
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+
+_DIRECTUS_USER_ID = "du-001"
+_APP_USER = {"id": "au-001"}
+_ALLOWED_PROJECT = {
+    "id": "proj-allowed",
+    "name": "test allowed",
+    "workspace_id": "ws-mine",
+    "updated_at": None,
+}
+_FORBIDDEN_PROJECT = {
+    "id": "proj-forbidden",
+    "name": "test forbidden",
+    "workspace_id": "ws-other",
+    "updated_at": None,
+}
+
+
+def _build_app(*, is_admin: bool) -> FastAPI:
+    app = FastAPI()
+
+    async def _fake_auth() -> DirectusSession:
+        return DirectusSession(_DIRECTUS_USER_ID, is_admin)
+
+    app.dependency_overrides[require_directus_session] = _fake_auth
+    app.include_router(SearchRouter)
+    return app
+
+
+def _fake_sync_directus() -> MagicMock:
+    def get_items(collection: str, _params: dict[str, Any]) -> list[dict[str, Any]]:
+        if collection == "project":
+            return [_ALLOWED_PROJECT, _FORBIDDEN_PROJECT]
+        return []
+
+    client = MagicMock()
+    client.get_items.side_effect = get_items
+    return client
+
+
+async def _fake_project_access(*, project_id: str, **_kwargs: Any) -> tuple[str, str] | None:
+    if project_id == _ALLOWED_PROJECT["id"]:
+        return "member", "direct"
+    return None
+
+
+async def _run_search(*, is_admin: bool) -> dict[str, Any]:
+    app = _build_app(is_admin=is_admin)
+    with (
+        patch("dembrane.api.search.directus", _fake_sync_directus()),
+        patch("dembrane.api.search.search_rate_limiter.check", new=AsyncMock()),
+        patch(
+            "dembrane.app_user.resolve_app_user",
+            new=AsyncMock(return_value=_APP_USER),
+        ),
+        patch(
+            "dembrane.inheritance.get_user_project_access",
+            new=AsyncMock(side_effect=_fake_project_access),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            res = await client.get("/home/search", params={"query": "test", "limit": 5})
+    assert res.status_code == 200
+    return res.json()
+
+
+@pytest.mark.asyncio
+async def test_search_scopes_results_for_regular_users():
+    body = await _run_search(is_admin=False)
+    assert [p["id"] for p in body["projects"]] == [_ALLOWED_PROJECT["id"]]
+
+
+@pytest.mark.asyncio
+async def test_search_scopes_results_for_directus_admin_sessions():
+    """is_admin sessions get the same scoping as everyone else.
+
+    The click-time guard (GET /v2/projects/{id}) has no staff bypass, so
+    an unscoped admin search produces dead results.
+    """
+    body = await _run_search(is_admin=True)
+    assert [p["id"] for p in body["projects"]] == [_ALLOWED_PROJECT["id"]]


### PR DESCRIPTION
  Directus-admin (admin_access) sessions skipped access filtering in
  /home/search, so the selector palette showed every project,
  conversation, transcript, and chat in the system. The click-time guard
  (GET /v2/projects/{id}) has no staff bypass and 404s, so every leaked
  hit landed on "This isn't available to you".

  Scope every session through resolve_app_user + get_user_project_access,
  mirroring the click-time guard. Staff data access stays in /v2/admin.