### PR TITLE
ECHO-858 fix(auth): scope cached user data per user to stop cross-user leaks

### DIFF
--- a/echo/frontend/src/components/auth/hooks/index.ts
+++ b/echo/frontend/src/components/auth/hooks/index.ts
@@ -194,23 +194,16 @@ export const useLoginMutation = () => {
 			);
 		},
 		onSuccess: async () => {
-			queryClient.removeQueries({ queryKey: ["users", "me"] });
-			queryClient.removeQueries({ queryKey: ["v2", "workspaces"] });
-			queryClient.removeQueries({ queryKey: ["v2", "workspaces-context"] });
+			// Clear everything, not an allowlist: a targeted list silently leaks
+			// any user-scoped query it forgets to the next user.
+			queryClient.clear();
 			if (typeof window !== "undefined") {
 				try {
 					sessionStorage.removeItem("dembrane_ws_selected");
 				} catch {}
 			}
 			emitAuthCacheBoundary();
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: ["auth", "session"] }),
-				queryClient.invalidateQueries({ queryKey: ["users", "me"] }),
-				queryClient.invalidateQueries({ queryKey: ["v2", "workspaces"] }),
-				queryClient.invalidateQueries({
-					queryKey: ["v2", "workspaces-context"],
-				}),
-			]);
+			await queryClient.invalidateQueries({ queryKey: ["auth", "session"] });
 		},
 	});
 };

--- a/echo/frontend/src/features/sidebar/hooks/useRecents.ts
+++ b/echo/frontend/src/features/sidebar/hooks/useRecents.ts
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
+import { useV2Me } from "@/hooks/useV2Me";
 
-const KEY = "dembrane.sidebar.recents";
+// Namespaced per user so one user never sees another's recents on a shared browser.
+const KEY_PREFIX = "dembrane.sidebar.recents";
+// Pre-namespacing global key, purged on load to drop any leaked cross-user entries.
+const LEGACY_KEY = "dembrane.sidebar.recents";
 const MAX = 8;
+
+function keyFor(userId: string): string {
+	return `${KEY_PREFIX}:${userId}`;
+}
 
 export interface RecentItem {
 	kind: "workspace" | "project";
@@ -13,10 +21,10 @@ export interface RecentItem {
 	lastVisited: number;
 }
 
-function read(): RecentItem[] {
-	if (typeof window === "undefined") return [];
+function read(userId: string | null): RecentItem[] {
+	if (typeof window === "undefined" || !userId) return [];
 	try {
-		const raw = window.localStorage.getItem(KEY);
+		const raw = window.localStorage.getItem(keyFor(userId));
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		return Array.isArray(parsed) ? parsed : [];
@@ -25,45 +33,62 @@ function read(): RecentItem[] {
 	}
 }
 
-function write(items: RecentItem[]): void {
-	if (typeof window === "undefined") return;
+function write(userId: string | null, items: RecentItem[]): void {
+	if (typeof window === "undefined" || !userId) return;
 	try {
-		window.localStorage.setItem(KEY, JSON.stringify(items));
+		window.localStorage.setItem(keyFor(userId), JSON.stringify(items));
 	} catch {
 		// quota / private mode — ignore
 	}
 }
 
 export function useRecents() {
-	const [items, setItems] = useState<RecentItem[]>(() => read());
+	const { data: me } = useV2Me();
+	const userId = me?.directus_user_id ?? null;
+
+	const [items, setItems] = useState<RecentItem[]>([]);
+
+	// Seeded here, not in useState, because the user id isn't known on first render.
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			try {
+				window.localStorage.removeItem(LEGACY_KEY);
+			} catch {}
+		}
+		setItems(read(userId));
+	}, [userId]);
 
 	useEffect(() => {
 		const onStorage = (e: StorageEvent) => {
-			if (e.key !== KEY) return;
-			setItems(read());
+			if (!userId || e.key !== keyFor(userId)) return;
+			setItems(read(userId));
 		};
 		window.addEventListener("storage", onStorage);
 		return () => window.removeEventListener("storage", onStorage);
-	}, []);
+	}, [userId]);
 
-	const record = useCallback((item: Omit<RecentItem, "lastVisited">) => {
-		setItems((prev) => {
-			const filtered = prev.filter(
-				(p) => !(p.kind === item.kind && p.id === item.id),
-			);
-			const next = [{ ...item, lastVisited: Date.now() }, ...filtered].slice(
-				0,
-				MAX,
-			);
-			write(next);
-			return next;
-		});
-	}, []);
+	const record = useCallback(
+		(item: Omit<RecentItem, "lastVisited">) => {
+			if (!userId) return;
+			setItems((prev) => {
+				const filtered = prev.filter(
+					(p) => !(p.kind === item.kind && p.id === item.id),
+				);
+				const next = [{ ...item, lastVisited: Date.now() }, ...filtered].slice(
+					0,
+					MAX,
+				);
+				write(userId, next);
+				return next;
+			});
+		},
+		[userId],
+	);
 
 	const clear = useCallback(() => {
 		setItems([]);
-		write([]);
-	}, []);
+		write(userId, []);
+	}, [userId]);
 
 	return { clear, items, record };
 }

--- a/echo/frontend/src/hooks/useWorkspace.ts
+++ b/echo/frontend/src/hooks/useWorkspace.ts
@@ -8,7 +8,13 @@ import {
 	useState,
 } from "react";
 import { API_BASE_URL } from "@/config";
+import { useV2Me } from "@/hooks/useV2Me";
 import { AUTH_CACHE_BOUNDARY_EVENT } from "@/lib/authCacheBoundary";
+
+// Per-user so login routing never sends a user to the previous user's workspace.
+export function lastWorkspaceKey(userId: string): string {
+	return `dembrane_last_workspace_id:${userId}`;
+}
 
 // ── Types ──
 
@@ -115,6 +121,8 @@ function readWorkspaceIdFromPath(): string | null {
 
 export function useWorkspaceProvider(enabled: boolean): WorkspaceContextValue {
 	const [authEpoch, setAuthEpoch] = useState(0);
+	const { data: me } = useV2Me({ enabled });
+	const userId = me?.directus_user_id ?? null;
 
 	useEffect(() => {
 		const onAuthBoundary = () => setAuthEpoch((epoch) => epoch + 1);
@@ -168,12 +176,17 @@ export function useWorkspaceProvider(enabled: boolean): WorkspaceContextValue {
 		return null;
 	}, [workspaces, selectedId]);
 
-	const setWorkspace = useCallback((id: string) => {
-		sessionStorage.setItem(SESSION_KEY, id);
-		// Also persist across sessions so login can route back to last-used
-		localStorage.setItem("dembrane_last_workspace_id", id);
-		setSelectedId(id); // triggers re-render
-	}, []);
+	const setWorkspace = useCallback(
+		(id: string) => {
+			sessionStorage.setItem(SESSION_KEY, id);
+			// Persist across sessions so login can route back to last-used.
+			if (userId) {
+				localStorage.setItem(lastWorkspaceKey(userId), id);
+			}
+			setSelectedId(id); // triggers re-render
+		},
+		[userId],
+	);
 
 	const clearWorkspace = useCallback(() => {
 		sessionStorage.removeItem(SESSION_KEY);

--- a/echo/frontend/src/routes/auth/Login.tsx
+++ b/echo/frontend/src/routes/auth/Login.tsx
@@ -24,6 +24,7 @@ import { I18nLink } from "@/components/common/i18nLink";
 import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
+import { lastWorkspaceKey } from "@/hooks/useWorkspace";
 import { testId } from "@/lib/testUtils";
 
 // Same-origin path guard against open-redirect via ?next=//evil.com.
@@ -150,6 +151,7 @@ export const LoginRoute = () => {
 			let firstWorkspaceId: string | null = null;
 			let isOrganisationAdmin = false;
 			let wsList: { id: string }[] = [];
+			let currentUserId: string | null = null;
 			try {
 				await new Promise((r) => setTimeout(r, 300));
 				const meResponse = await fetch(`${API_BASE_URL}/v2/me`, {
@@ -158,6 +160,7 @@ export const LoginRoute = () => {
 				if (meResponse.ok) {
 					const meData = await meResponse.json();
 					needsOnboarding = meData.onboarding_completed === false;
+					currentUserId = meData.directus_user_id ?? null;
 					isOrganisationAdmin = (meData.orgs ?? []).some(
 						(o: { role: string }) => o.role === "owner" || o.role === "admin",
 					);
@@ -202,7 +205,9 @@ export const LoginRoute = () => {
 			// - Solo user (1 workspace) → straight to workspace home
 			// - Returning multi-workspace user → last-used workspace (if still valid)
 			// - First-time multi-workspace user → selector
-			const lastUsedId = localStorage.getItem("dembrane_last_workspace_id");
+			const lastUsedId = currentUserId
+				? localStorage.getItem(lastWorkspaceKey(currentUserId))
+				: null;
 			const lastStillValid =
 				!!lastUsedId && wsList.some((w) => w.id === lastUsedId);
 


### PR DESCRIPTION
…n re-login

  The redesigned /o home page showed the previous user's workspaces, projects,
  and recents after logging out and back in as a different user. Two layers were
  leaking identity-agnostic data across sessions:

  - localStorage (survived a refresh): recents and last-used-workspace were stored under global keys, so the next user read the previous user's entries.
  - React Query (cleared by a refresh): login cleared a hand-maintained allowlist of query keys that missed the new page's keys (v2/me, invites, home-search).

  Fixes:
  - Namespace recents (dembrane.sidebar.recents:<userId>) and last-used-workspace by the logged-in user's id; purge the legacy global recents key on load.
  - Replace login's allowlist with queryClient.clear() so no user-scoped query can survive into the next session.