### PR TITLE
  refactor(search): move row hover to CSS, highlight first result onl…

### DIFF
--- a/echo/frontend/src/features/sidebar/blocks/SearchBlock.module.css
+++ b/echo/frontend/src/features/sidebar/blocks/SearchBlock.module.css
@@ -1,0 +1,31 @@
+/* Layout stays in Tailwind; this module owns the highlight states so a `:has`
+   rule can let the hovered row win over the keyboard highlight. */
+.row {
+	color: var(--app-text);
+	background-color: transparent;
+}
+
+.row:hover,
+.rowActive {
+	color: var(--mantine-primary-color-filled);
+	background-color: var(--mantine-primary-color-light);
+}
+
+.subtitle {
+	color: var(--mantine-color-dimmed);
+}
+
+.row:hover .subtitle,
+.rowActive .subtitle {
+	color: var(--mantine-primary-color-filled);
+}
+
+/* While hovering, the hovered row wins; the keyboard highlight yields. */
+.list:has(.row:hover) .rowActive:not(:hover) {
+	color: var(--app-text);
+	background-color: transparent;
+}
+
+.list:has(.row:hover) .rowActive:not(:hover) .subtitle {
+	color: var(--mantine-color-dimmed);
+}

--- a/echo/frontend/src/features/sidebar/blocks/SearchBlock.tsx
+++ b/echo/frontend/src/features/sidebar/blocks/SearchBlock.tsx
@@ -1,102 +1,36 @@
+import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { Modal, TextInput, UnstyledButton } from "@mantine/core";
-import { useDebouncedValue, useDisclosure } from "@mantine/hooks";
-import {
-	Buildings,
-	ChatCircle,
-	ChatsCircle,
-	FileText,
-	FolderOpen,
-	Folders,
-	Gear,
-	MagnifyingGlass,
-} from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
-import { type ComponentType, useEffect, useMemo, useState } from "react";
+import { CloseButton, Modal, TextInput, UnstyledButton } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import { API_BASE_URL } from "@/config";
 import { useWorkspace } from "@/hooks/useWorkspace";
-import { useV2Me } from "@/hooks/useV2Me";
-import { useRecents } from "../hooks/useRecents";
+import { type SearchHit, useSearchHits } from "../hooks/useSearchHits";
+import classes from "./SearchBlock.module.css";
 
-interface Hit {
-	id: string;
-	icon: ComponentType<{ size?: number }>;
-	label: string;
-	subtitle?: string;
-	href: string;
-}
+export const SearchBlock = () => {
+	const [opened, { open, close }] = useDisclosure(false);
+	const [q, setQ] = useState("");
+	// Keyboard highlight: first result while searching, -1 (none) when empty.
+	const [activeIndex, setActiveIndex] = useState(-1);
+	const { workspaces } = useWorkspace();
+	const navigate = useNavigate();
+	const [shortcut, setShortcut] = useState("⌘K");
+	const searchInputRef = useRef<HTMLInputElement>(null);
 
-// GET /api/home/search — deep search over projects, conversations,
-// transcripts and chats, access-scoped server-side.
-interface HomeSearchResponse {
-	projects: {
-		id: string;
-		name: string | null;
-		workspaceId: string | null;
-	}[];
-	conversations: {
-		id: string;
-		projectId: string | null;
-		projectName: string | null;
-		workspaceId: string | null;
-		displayLabel: string;
-	}[];
-	transcripts: {
-		id: string;
-		conversationId: string | null;
-		conversationLabel: string | null;
-		projectId: string | null;
-		workspaceId: string | null;
-		excerpt: string | null;
-	}[];
-	chats: {
-		id: string;
-		projectId: string | null;
-		projectName: string | null;
-		workspaceId: string | null;
-		name: string | null;
-	}[];
-}
+	useEffect(() => {
+		const isMac =
+			typeof window !== "undefined" &&
+			/Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+		if (!isMac) {
+			setShortcut("Ctrl K");
+		}
+	}, []);
 
-const EMPTY_SEARCH: HomeSearchResponse = {
-	chats: [],
-	conversations: [],
-	projects: [],
-	transcripts: [],
-};
-
-	export const SearchBlock = () => {
-		const [opened, { open, close }] = useDisclosure(false);
-		const [q, setQ] = useState("");
-		const [activeIndex, setActiveIndex] = useState(0);
-		const { workspaces } = useWorkspace();
-		const { items: recents } = useRecents();
-		const { data: me } = useV2Me();
-		const navigate = useNavigate();
-		const [shortcut, setShortcut] = useState("⌘K");
-
-		useEffect(() => {
-			const isMac = typeof window !== "undefined" && 
-				/Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
-			if (!isMac) {
-				setShortcut("Ctrl K");
-			}
-		}, []);
-
-	const [debouncedQ] = useDebouncedValue(q.trim(), 250);
-	const deepSearch = useQuery({
-		enabled: opened && debouncedQ.length >= 2,
-		queryFn: async (): Promise<HomeSearchResponse> => {
-			const res = await fetch(
-				`${API_BASE_URL}/home/search?query=${encodeURIComponent(debouncedQ)}&limit=5`,
-				{ credentials: "include" },
-			);
-			if (!res.ok) return EMPTY_SEARCH;
-			return res.json();
-		},
-		queryKey: ["home-search", debouncedQ],
-		staleTime: 30_000,
+	// Deep search only runs while the palette is open.
+	const { hits, isFetching } = useSearchHits(q, workspaces, {
+		enabled: opened,
 	});
 
 	// Global ⌘K / Ctrl+K — open palette anywhere.
@@ -111,172 +45,21 @@ const EMPTY_SEARCH: HomeSearchResponse = {
 		return () => window.removeEventListener("keydown", onKey);
 	}, [open]);
 
-	useEffect(() => {
-		if (!opened) {
-			setQ("");
-			setActiveIndex(0);
-		}
-	}, [opened]);
+	// Clear after the exit animation, not on close, to avoid flashing the unfiltered list.
+	const onClosed = () => {
+		setQ("");
+		setActiveIndex(-1);
+	};
 
-		const hits = useMemo<Hit[]>(() => {
-			const query = q.trim().toLowerCase();
-			const orgs = new Map<string, { name: string }>();
-			for (const ws of workspaces) {
-				if (ws.org_id && !orgs.has(ws.org_id)) {
-					orgs.set(ws.org_id, { name: ws.org_name || "" });
-				}
-			}
-
-			const all: Hit[] = [];
-			for (const [id, o] of orgs) {
-				all.push({
-					href: `/o/${id}/overview`,
-					icon: Buildings,
-					id: `org-${id}`,
-					label: o.name,
-					subtitle: `Organisation / ${o.name}`,
-				});
-			}
-			for (const ws of workspaces) {
-				all.push({
-					href: `/w/${ws.id}/home`,
-					icon: Folders,
-					id: `ws-${ws.id}`,
-					label: ws.name,
-					subtitle: `${ws.org_name} / ${ws.name}`,
-				});
-			}
-			// Settings as quick shortcuts
-			const settings = [
-				{ href: "/settings/account", label: "Account & security" },
-				{ href: "/settings/access", label: "My access" },
-				{ href: "/settings/appearance", label: "Appearance" },
-			];
-			const userName = me?.display_name || "User";
-			for (const s of settings) {
-				all.push({
-					href: s.href,
-					icon: Gear,
-					id: `setting-${s.href}`,
-					label: s.label,
-					subtitle: `${userName} / ${s.label}`,
-				});
-			}
-
-			if (!query) {
-				// No query → show recents (translated to Hits) then everything
-				const recentHits: Hit[] = recents.map((r) => {
-					const match = r.href.match(/\/w\/([^/]+)/);
-					const wsId = match ? match[1] : null;
-					const ws = workspaces.find((w) => w.id === wsId);
-					let subtitle = r.parent ?? (r.kind === "project" ? "Project" : "Workspace");
-					if (ws) {
-						if (r.kind === "project") {
-							subtitle = `${ws.org_name} / ${ws.name} / ${r.label}`;
-						} else {
-							subtitle = `${ws.org_name} / ${ws.name}`;
-						}
-					}
-					return {
-						href: r.href,
-						icon: r.kind === "project" ? FolderOpen : Folders,
-						id: `recent-${r.kind}-${r.id}`,
-						label: r.label,
-						subtitle,
-					};
-				});
-				const seen = new Set(recentHits.map((h) => h.label.toLowerCase()));
-				const rest = all.filter((h) => !seen.has(h.label.toLowerCase()));
-				return [...recentHits, ...rest].slice(0, 40);
-			}
-
-			const clientHits = all.filter((h) => {
-				const hay = `${h.label} ${h.subtitle ?? ""}`.toLowerCase();
-				return hay.includes(query);
-			});
-
-			// Deep results from /home/search, deduped by destination so the
-			// same page never shows twice (e.g. a recents row + a project hit,
-			// or a conversation hit + its own transcript hit).
-			const merged: Hit[] = [...clientHits];
-			const seenHrefs = new Set(clientHits.map((h) => h.href));
-			const push = (hit: Hit) => {
-				if (seenHrefs.has(hit.href)) return;
-				seenHrefs.add(hit.href);
-				merged.push(hit);
-			};
-
-			const deep = deepSearch.data ?? EMPTY_SEARCH;
-			for (const p of deep.projects) {
-				if (!p.workspaceId) continue;
-				const ws = workspaces.find((w) => w.id === p.workspaceId);
-				const subtitle = ws
-					? `${ws.org_name} / ${ws.name} / ${p.name ?? "Project"}`
-					: "Project";
-				push({
-					href: `/w/${p.workspaceId}/projects/${p.id}/home`,
-					icon: FolderOpen,
-					id: `proj-${p.id}`,
-					label: p.name ?? "Project",
-					subtitle,
-				});
-			}
-			for (const c of deep.conversations) {
-				if (!c.workspaceId || !c.projectId) continue;
-				const ws = workspaces.find((w) => w.id === c.workspaceId);
-				const subtitle = ws
-					? `${ws.org_name} / ${ws.name} / ${c.projectName || "Project"} / ${c.displayLabel}`
-					: c.projectName
-						? `${c.projectName} / ${c.displayLabel}`
-						: "Conversation";
-				push({
-					href: `/w/${c.workspaceId}/projects/${c.projectId}/conversation/${c.id}`,
-					icon: ChatCircle,
-					id: `conv-${c.id}`,
-					label: c.displayLabel,
-					subtitle,
-				});
-			}
-			for (const t of deep.transcripts) {
-				if (!t.workspaceId || !t.projectId || !t.conversationId) continue;
-				const ws = workspaces.find((w) => w.id === t.workspaceId);
-				const path = ws
-					? `${ws.org_name} / ${ws.name} / ${t.conversationLabel ?? "Transcript"}`
-					: "Transcript";
-				const subtitle = t.excerpt
-					? `${path} — "${t.excerpt.slice(0, 60)}..."`
-					: path;
-				push({
-					href: `/w/${t.workspaceId}/projects/${t.projectId}/conversation/${t.conversationId}`,
-					icon: FileText,
-					id: `chunk-${t.id}`,
-					label: t.conversationLabel ?? "Transcript",
-					subtitle,
-				});
-			}
-			for (const ch of deep.chats) {
-				if (!ch.workspaceId || !ch.projectId) continue;
-				const ws = workspaces.find((w) => w.id === ch.workspaceId);
-				const subtitle = ws
-					? `${ws.org_name} / ${ws.name} / ${ch.projectName || "Project"} / ${ch.name ?? "Chat"}`
-					: ch.projectName
-						? `${ch.projectName} / ${ch.name ?? "Chat"}`
-						: "Chat";
-				push({
-					href: `/w/${ch.workspaceId}/projects/${ch.projectId}/chats/${ch.id}`,
-					icon: ChatsCircle,
-					id: `chat-${ch.id}`,
-					label: ch.name ?? "Chat",
-					subtitle,
-				});
-			}
-
-			return merged.slice(0, 40);
-		}, [q, workspaces, recents, deepSearch.data, me]);
-
-	const onSelect = (hit: Hit) => {
+	const onSelect = (hit: SearchHit) => {
 		close();
 		navigate(hit.href);
+	};
+
+	const onClear = () => {
+		setQ("");
+		setActiveIndex(-1);
+		searchInputRef.current?.focus();
 	};
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -301,19 +84,19 @@ const EMPTY_SEARCH: HomeSearchResponse = {
 				style={{ color: "#2d2d2c", width: "100%" }}
 				aria-label="Search"
 			>
-				<MagnifyingGlass size={16} />
+				<MagnifyingGlassIcon size={16} />
 				<span>
 					<Trans>Search</Trans>
 				</span>
-					<span
-						className="ml-auto rounded px-1.5 py-0.5 text-[10px]"
-						style={{
-							backgroundColor: "rgba(45, 45, 44, 0.06)",
-							color: "rgba(45, 45, 44, 0.55)",
-						}}
-					>
-						{shortcut}
-					</span>
+				<span
+					className="ml-auto rounded px-1.5 py-0.5 text-[10px]"
+					style={{
+						backgroundColor: "rgba(45, 45, 44, 0.06)",
+						color: "rgba(45, 45, 44, 0.55)",
+					}}
+				>
+					{shortcut}
+				</span>
 			</UnstyledButton>
 
 			<Modal
@@ -324,6 +107,7 @@ const EMPTY_SEARCH: HomeSearchResponse = {
 				padding={0}
 				centered
 				styles={{ body: { padding: 0 } }}
+				transitionProps={{ onExited: onClosed }}
 			>
 				<div className="flex flex-col">
 					<div
@@ -331,26 +115,42 @@ const EMPTY_SEARCH: HomeSearchResponse = {
 						style={{ borderColor: "rgba(45, 45, 44, 0.08)" }}
 					>
 						<TextInput
+							ref={searchInputRef}
 							autoFocus
 							value={q}
 							onChange={(e) => {
-								setQ(e.currentTarget.value);
-								setActiveIndex(0);
+								const value = e.currentTarget.value;
+								setQ(value);
+								setActiveIndex(value ? 0 : -1);
 							}}
 							onKeyDown={onKeyDown}
-							leftSection={<MagnifyingGlass size={16} />}
+							leftSection={<MagnifyingGlassIcon size={16} />}
 							placeholder="Search projects, conversations, transcripts…"
 							variant="unstyled"
 							styles={{ input: { fontSize: 14 } }}
+							rightSectionPointerEvents="auto"
+							rightSection={
+								q ? (
+									<CloseButton
+										size="sm"
+										aria-label={t`Clear search`}
+										onClick={onClear}
+									/>
+								) : undefined
+							}
 						/>
 					</div>
-					<div className="max-h-[400px] overflow-auto p-1">
+					<div
+						className={`${classes.list} max-h-[400px] overflow-auto p-1`}
+						role="listbox"
+						aria-label={t`Search results`}
+					>
 						{hits.length === 0 ? (
 							<div
 								className="px-3 py-6 text-center text-[12px]"
 								style={{ color: "rgba(45, 45, 44, 0.55)" }}
 							>
-								{deepSearch.isFetching ? (
+								{isFetching ? (
 									<Trans>Searching…</Trans>
 								) : (
 									<Trans>No matches</Trans>
@@ -364,22 +164,18 @@ const EMPTY_SEARCH: HomeSearchResponse = {
 									<button
 										type="button"
 										key={hit.id}
+										role="option"
+										aria-selected={active}
 										onClick={() => onSelect(hit)}
-										onMouseEnter={() => setActiveIndex(i)}
-										className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-[13px]"
-										style={{
-											backgroundColor: active
-												? "rgba(65, 105, 225, 0.08)"
-												: "transparent",
-											color: active ? "#4169e1" : "#2d2d2c",
-										}}
+										className={`${classes.row} ${
+											active ? classes.rowActive : ""
+										} flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-[13px]`}
 									>
 										<Icon size={16} />
 										<span className="flex-1 truncate">{hit.label}</span>
 										{hit.subtitle && (
 											<span
-												className="truncate text-[11px]"
-												style={{ color: "rgba(45, 45, 44, 0.5)" }}
+												className={`${classes.subtitle} truncate text-[11px]`}
 											>
 												{hit.subtitle}
 											</span>

--- a/echo/frontend/src/features/sidebar/hooks/useSearchHits.ts
+++ b/echo/frontend/src/features/sidebar/hooks/useSearchHits.ts
@@ -1,0 +1,269 @@
+import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { useDebouncedValue } from "@mantine/hooks";
+import {
+	BuildingsIcon,
+	ChatCircleIcon,
+	ChatsCircleIcon,
+	FileTextIcon,
+	FolderOpenIcon,
+	FoldersIcon,
+	GearIcon,
+	type Icon,
+} from "@phosphor-icons/react";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { API_BASE_URL } from "@/config";
+import { useV2Me } from "@/hooks/useV2Me";
+import { useRecents } from "./useRecents";
+
+// Shared search-hit builder for the command palette (SearchBlock) and the
+// organisations home page (WorkspaceSelectorRoute), which show the same results.
+
+// Both WorkspaceLite (/v2/workspaces) and WorkspaceSummary satisfy this
+// structurally, so either source can feed the hook.
+export interface SearchWorkspace {
+	id: string;
+	name: string;
+	org_id: string;
+	org_name: string;
+}
+
+export interface SearchHit {
+	id: string;
+	icon: Icon;
+	label: string;
+	subtitle?: string;
+	href: string;
+}
+
+// GET /api/home/search — deep search over projects, conversations,
+// transcripts and chats, access-scoped server-side.
+interface HomeSearchResponse {
+	projects: {
+		id: string;
+		name: string | null;
+		workspaceId: string | null;
+	}[];
+	conversations: {
+		id: string;
+		projectId: string | null;
+		projectName: string | null;
+		workspaceId: string | null;
+		displayLabel: string;
+	}[];
+	transcripts: {
+		id: string;
+		conversationId: string | null;
+		conversationLabel: string | null;
+		projectId: string | null;
+		workspaceId: string | null;
+		excerpt: string | null;
+	}[];
+	chats: {
+		id: string;
+		projectId: string | null;
+		projectName: string | null;
+		workspaceId: string | null;
+		name: string | null;
+	}[];
+}
+
+const EMPTY_SEARCH: HomeSearchResponse = {
+	chats: [],
+	conversations: [],
+	projects: [],
+	transcripts: [],
+};
+
+const MAX_HITS = 40;
+const EXCERPT_LENGTH = 60;
+
+// Settings shortcuts surfaced in search. Labels are translated at build time.
+const SETTINGS_LINKS: { href: string; label: () => string }[] = [
+	{ href: "/settings/account", label: () => t`Account & security` },
+	{ href: "/settings/access", label: () => t`My access` },
+	{ href: "/settings/appearance", label: () => t`Appearance` },
+];
+
+export function useSearchHits(
+	query: string,
+	workspaces: SearchWorkspace[],
+	options: { enabled?: boolean } = {},
+): { hits: SearchHit[]; isFetching: boolean } {
+	const { enabled = true } = options;
+	const { i18n } = useLingui();
+	const { items: recents } = useRecents();
+	const { data: me } = useV2Me();
+
+	const [debouncedQ] = useDebouncedValue(query.trim(), 250);
+	const deepSearch = useQuery({
+		enabled: enabled && debouncedQ.length >= 2,
+		queryFn: async (): Promise<HomeSearchResponse> => {
+			const res = await fetch(
+				`${API_BASE_URL}/home/search?query=${encodeURIComponent(debouncedQ)}&limit=5`,
+				{ credentials: "include" },
+			);
+			if (!res.ok) return EMPTY_SEARCH;
+			return res.json();
+		},
+		queryKey: ["home-search", debouncedQ],
+		staleTime: 30_000,
+	});
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: `t` macro reads the active locale, so labels must recompute on language switch.
+	const hits = useMemo<SearchHit[]>(() => {
+		const needle = query.trim().toLowerCase();
+		// O(1) workspace lookups for the deep-result loops below.
+		const wsById = new Map(workspaces.map((w) => [w.id, w]));
+
+		const orgs = new Map<string, { name: string }>();
+		for (const ws of workspaces) {
+			if (ws.org_id && !orgs.has(ws.org_id)) {
+				orgs.set(ws.org_id, { name: ws.org_name || "" });
+			}
+		}
+
+		const all: SearchHit[] = [];
+		for (const [id, o] of orgs) {
+			all.push({
+				href: `/o/${id}/overview`,
+				icon: BuildingsIcon,
+				id: `org-${id}`,
+				label: o.name,
+				subtitle: `${t`Organisation`} / ${o.name}`,
+			});
+		}
+		for (const ws of workspaces) {
+			all.push({
+				href: `/w/${ws.id}/home`,
+				icon: FoldersIcon,
+				id: `ws-${ws.id}`,
+				label: ws.name,
+				subtitle: `${ws.org_name} / ${ws.name}`,
+			});
+		}
+		const userName = me?.display_name || t`Account`;
+		for (const s of SETTINGS_LINKS) {
+			const label = s.label();
+			all.push({
+				href: s.href,
+				icon: GearIcon,
+				id: `setting-${s.href}`,
+				label,
+				subtitle: `${userName} / ${label}`,
+			});
+		}
+
+		if (!needle) {
+			// No query → show recents (translated to hits) then everything.
+			const recentHits: SearchHit[] = recents.map((r) => {
+				const match = r.href.match(/\/w\/([^/]+)/);
+				const ws = match ? wsById.get(match[1]) : undefined;
+				let subtitle =
+					r.parent ?? (r.kind === "project" ? t`Project` : t`Workspace`);
+				if (ws) {
+					subtitle =
+						r.kind === "project"
+							? `${ws.org_name} / ${ws.name} / ${r.label}`
+							: `${ws.org_name} / ${ws.name}`;
+				}
+				return {
+					href: r.href,
+					icon: r.kind === "project" ? FolderOpenIcon : FoldersIcon,
+					id: `recent-${r.kind}-${r.id}`,
+					label: r.label,
+					subtitle,
+				};
+			});
+			const seen = new Set(recentHits.map((h) => h.label.toLowerCase()));
+			const rest = all.filter((h) => !seen.has(h.label.toLowerCase()));
+			return [...recentHits, ...rest].slice(0, MAX_HITS);
+		}
+
+		const clientHits = all.filter((h) => {
+			const hay = `${h.label} ${h.subtitle ?? ""}`.toLowerCase();
+			return hay.includes(needle);
+		});
+
+		// Deep results from /home/search, deduped by destination so the same
+		// page never shows twice (e.g. a recents row + a project hit, or a
+		// conversation hit + its own transcript hit).
+		const merged: SearchHit[] = [...clientHits];
+		const seenHrefs = new Set(clientHits.map((h) => h.href));
+		const push = (hit: SearchHit) => {
+			if (seenHrefs.has(hit.href)) return;
+			seenHrefs.add(hit.href);
+			merged.push(hit);
+		};
+
+		const deep = deepSearch.data ?? EMPTY_SEARCH;
+		for (const p of deep.projects) {
+			if (!p.workspaceId) continue;
+			const ws = wsById.get(p.workspaceId);
+			const subtitle = ws
+				? `${ws.org_name} / ${ws.name} / ${p.name ?? t`Project`}`
+				: t`Project`;
+			push({
+				href: `/w/${p.workspaceId}/projects/${p.id}/home`,
+				icon: FolderOpenIcon,
+				id: `proj-${p.id}`,
+				label: p.name ?? t`Project`,
+				subtitle,
+			});
+		}
+		for (const c of deep.conversations) {
+			if (!c.workspaceId || !c.projectId) continue;
+			const ws = wsById.get(c.workspaceId);
+			const subtitle = ws
+				? `${ws.org_name} / ${ws.name} / ${c.projectName || t`Project`} / ${c.displayLabel}`
+				: c.projectName
+					? `${c.projectName} / ${c.displayLabel}`
+					: t`Conversation`;
+			push({
+				href: `/w/${c.workspaceId}/projects/${c.projectId}/conversation/${c.id}`,
+				icon: ChatCircleIcon,
+				id: `conv-${c.id}`,
+				label: c.displayLabel,
+				subtitle,
+			});
+		}
+		for (const tr of deep.transcripts) {
+			if (!tr.workspaceId || !tr.projectId || !tr.conversationId) continue;
+			const ws = wsById.get(tr.workspaceId);
+			const path = ws
+				? `${ws.org_name} / ${ws.name} / ${tr.conversationLabel ?? t`Transcript`}`
+				: t`Transcript`;
+			const subtitle = tr.excerpt
+				? `${path}: "${tr.excerpt.slice(0, EXCERPT_LENGTH)}..."`
+				: path;
+			push({
+				href: `/w/${tr.workspaceId}/projects/${tr.projectId}/conversation/${tr.conversationId}`,
+				icon: FileTextIcon,
+				id: `chunk-${tr.id}`,
+				label: tr.conversationLabel ?? t`Transcript`,
+				subtitle,
+			});
+		}
+		for (const ch of deep.chats) {
+			if (!ch.workspaceId || !ch.projectId) continue;
+			const ws = wsById.get(ch.workspaceId);
+			const subtitle = ws
+				? `${ws.org_name} / ${ws.name} / ${ch.projectName || t`Project`} / ${ch.name ?? t`Chat`}`
+				: ch.projectName
+					? `${ch.projectName} / ${ch.name ?? t`Chat`}`
+					: t`Chat`;
+			push({
+				href: `/w/${ch.workspaceId}/projects/${ch.projectId}/chats/${ch.id}`,
+				icon: ChatsCircleIcon,
+				id: `chat-${ch.id}`,
+				label: ch.name ?? t`Chat`,
+				subtitle,
+			});
+		}
+
+		return merged.slice(0, MAX_HITS);
+	}, [query, workspaces, recents, deepSearch.data, me, i18n.locale]);
+
+	return { hits, isFetching: deepSearch.isFetching };
+}

--- a/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.module.css
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.module.css
@@ -1,0 +1,86 @@
+/* In CSS because Mantine v7 `styles` does not support the :focus selector. */
+.searchInput {
+	height: 52px;
+	font-size: 16px;
+	border-radius: 8px;
+	border: 1px solid var(--mantine-color-gray-3);
+	background-color: transparent;
+}
+
+.searchInput:focus {
+	border-color: var(--mantine-primary-color-filled);
+}
+
+.resultRow {
+	display: flex;
+	width: 100%;
+	align-items: center;
+	gap: 16px;
+	padding: 16px 20px;
+	border-radius: 4px;
+	text-align: left;
+	cursor: pointer;
+	color: var(--app-text);
+	background-color: transparent;
+	border: 1px solid var(--mantine-color-gray-3);
+	transition:
+		border-color 0.15s ease,
+		background-color 0.15s ease;
+}
+
+/* Hover is CSS; `.resultRowActive` is the keyboard highlight. */
+.resultRow:hover,
+.resultRowActive {
+	border-color: var(--mantine-primary-color-filled);
+	background-color: var(--mantine-primary-color-light);
+}
+
+.resultIcon {
+	flex-shrink: 0;
+	color: var(--mantine-color-dimmed);
+}
+
+.resultRow:hover .resultIcon,
+.resultRowActive .resultIcon {
+	color: var(--mantine-primary-color-filled);
+}
+
+.resultLabel {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.resultTitle {
+	font-size: 16px;
+	font-weight: 500;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.resultSubtitle {
+	margin-top: 2px;
+	font-size: 12px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--mantine-color-dimmed);
+}
+
+.resultRow:hover .resultSubtitle,
+.resultRowActive .resultSubtitle {
+	color: var(--mantine-primary-color-filled);
+}
+
+/* While hovering, the hovered row wins; the keyboard highlight yields. */
+.resultList:has(.resultRow:hover) .resultRowActive:not(:hover) {
+	border-color: var(--mantine-color-gray-3);
+	background-color: transparent;
+}
+
+.resultList:has(.resultRow:hover) .resultRowActive:not(:hover) .resultIcon,
+.resultList:has(.resultRow:hover) .resultRowActive:not(:hover) .resultSubtitle {
+	color: var(--mantine-color-dimmed);
+}

--- a/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSelectorRoute.tsx
@@ -1,7 +1,9 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import {
+	Box,
 	Button,
+	CloseButton,
 	Container,
 	Loader,
 	Stack,
@@ -9,31 +11,28 @@ import {
 	TextInput,
 	Title,
 } from "@mantine/core";
-import { useDebouncedValue, useDocumentTitle } from "@mantine/hooks";
+import { useDocumentTitle } from "@mantine/hooks";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { type ComponentType, useEffect, useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Navigate } from "react-router";
-import {
-	Buildings,
-	ChatCircle,
-	ChatsCircle,
-	FileText,
-	FolderOpen,
-	Folders,
-	Gear,
-	MagnifyingGlass,
-} from "@phosphor-icons/react";
 import { FetchErrorPanel } from "@/components/common/FetchErrorPanel";
 import { API_BASE_URL } from "@/config";
-import { useRecents } from "@/features/sidebar/hooks/useRecents";
+import {
+	type SearchHit,
+	useSearchHits,
+} from "@/features/sidebar/hooks/useSearchHits";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useMyInvites } from "@/hooks/useMyInvites";
 import { useV2Me } from "@/hooks/useV2Me";
-import { logoUrl as resolveLogoUrl } from "@/lib/avatar";
+import classes from "./WorkspaceSelectorRoute.module.css";
 
-// The home page is now a plain list of organisations the user belongs to.
-// Rich workspace cards (members, stats, pinned projects) moved down a level to
-// the org overview (/o/:id). No workspace cards, stats rollups, or widgets here.
+// Full-page search over the orgs, workspaces, projects and settings the user
+// can reach. Rich workspace cards live a level down at the org overview.
+
+// Centered frame shared by every state on this page.
+const FRAME_MAX_WIDTH = 580;
+const FRAME_TOP_MARGIN = "20vh";
 
 interface OrganisationRollup {
 	id: string;
@@ -52,51 +51,6 @@ interface WorkspaceLite {
 	org_logo_url: string | null;
 	role: string;
 }
-
-interface Hit {
-	id: string;
-	icon: ComponentType<{ size: number; style?: any }>;
-	label: string;
-	subtitle?: string;
-	href: string;
-}
-
-interface HomeSearchResponse {
-	projects: {
-		id: string;
-		name: string | null;
-		workspaceId: string | null;
-	}[];
-	conversations: {
-		id: string;
-		projectId: string | null;
-		projectName: string | null;
-		workspaceId: string | null;
-		displayLabel: string;
-	}[];
-	transcripts: {
-		id: string;
-		conversationId: string | null;
-		conversationLabel: string | null;
-		projectId: string | null;
-		workspaceId: string | null;
-		excerpt: string | null;
-	}[];
-	chats: {
-		id: string;
-		projectId: string | null;
-		projectName: string | null;
-		workspaceId: string | null;
-		name: string | null;
-	}[];
-}
-
-const EMPTY_SEARCH: HomeSearchResponse = {
-	chats: [],
-	conversations: [],
-	projects: [],
-	transcripts: [],
-};
 
 interface RecentRemoval {
 	workspace_id: string;
@@ -164,6 +118,14 @@ function deriveOrgList(
 	});
 }
 
+const CenteredLoader = () => (
+	<Container size="sm" py="xl">
+		<Stack align="center" gap={16} mt={FRAME_TOP_MARGIN}>
+			<Loader size="sm" color="gray" />
+		</Stack>
+	</Container>
+);
+
 // Entry decision: single-org users go straight to their org overview, everyone
 // else to the home list. Lives at the root (not inside /o) so the shortcut
 // fires once on entry and doesn't bounce single-org users off /o on every visit.
@@ -175,13 +137,7 @@ export const RootRedirect = () => {
 	});
 
 	if (isLoading) {
-		return (
-			<Container size="sm" py="xl">
-				<Stack align="center" gap={16} mt="20vh">
-					<Loader size="sm" color="gray" />
-				</Stack>
-			</Container>
-		);
+		return <CenteredLoader />;
 	}
 
 	// On error fall through to the home list, which renders its own error panel.
@@ -200,16 +156,15 @@ export const RootRedirect = () => {
 	return <Navigate to="o" replace />;
 };
 
-
-
 export const WorkspaceSelectorRoute = () => {
 	const navigate = useI18nNavigate();
 
 	useDocumentTitle(t`Organisations | dembrane`);
 
 	const [q, setQ] = useState("");
-	const [activeIndex, setActiveIndex] = useState(0);
-	const { items: recents } = useRecents();
+	// Keyboard highlight: first result while searching, -1 (none) when empty.
+	const [activeIndex, setActiveIndex] = useState(-1);
+	const searchInputRef = useRef<HTMLInputElement>(null);
 
 	const { data, isLoading, isError, refetch } = useQuery({
 		queryFn: fetchWorkspaces,
@@ -217,7 +172,7 @@ export const WorkspaceSelectorRoute = () => {
 		staleTime: 30_000,
 	});
 
-	// Load logged-in user for greeting
+	// Logged-in user, for the greeting.
 	const { data: me } = useV2Me();
 
 	// Pending invites for this user. Used by the empty state so a guest who got
@@ -232,180 +187,21 @@ export const WorkspaceSelectorRoute = () => {
 
 	// No single-org redirect here (it's in RootRedirect), so this list stays
 	// reachable for single-org users.
-	const orgList = deriveOrgList(organisations, workspaces);
+	const orgList = useMemo(
+		() => deriveOrgList(organisations, workspaces),
+		[organisations, workspaces],
+	);
 
-	const [debouncedQ] = useDebouncedValue(q.trim(), 250);
-	const deepSearch = useQuery({
-		enabled: debouncedQ.length >= 2,
-		queryFn: async (): Promise<HomeSearchResponse> => {
-			const res = await fetch(
-				`${API_BASE_URL}/home/search?query=${encodeURIComponent(debouncedQ)}&limit=5`,
-				{ credentials: "include" },
-			);
-			if (!res.ok) return EMPTY_SEARCH;
-			return res.json();
-		},
-		queryKey: ["home-search", debouncedQ],
-		staleTime: 30_000,
-	});
+	const { hits, isFetching } = useSearchHits(q, workspaces);
 
-	const hits = useMemo<Hit[]>(() => {
-		const query = q.trim().toLowerCase();
-		const orgs = new Map<string, { name: string }>();
-		for (const ws of workspaces) {
-			if (ws.org_id && !orgs.has(ws.org_id)) {
-				orgs.set(ws.org_id, { name: ws.org_name || "" });
-			}
-		}
-
-		const all: Hit[] = [];
-		for (const [id, o] of orgs) {
-			all.push({
-				href: `/o/${id}/overview`,
-				icon: Buildings,
-				id: `org-${id}`,
-				label: o.name,
-				subtitle: `Organisation / ${o.name}`,
-			});
-		}
-		for (const ws of workspaces) {
-			all.push({
-				href: `/w/${ws.id}/home`,
-				icon: Folders,
-				id: `ws-${ws.id}`,
-				label: ws.name,
-				subtitle: `${ws.org_name} / ${ws.name}`,
-			});
-		}
-		// Settings as quick shortcuts
-		const settings = [
-			{ href: "/settings/account", label: "Account & security" },
-			{ href: "/settings/access", label: "My access" },
-			{ href: "/settings/appearance", label: "Appearance" },
-		];
-		const userName = me?.display_name || "User";
-		for (const s of settings) {
-			all.push({
-				href: s.href,
-				icon: Gear,
-				id: `setting-${s.href}`,
-				label: s.label,
-				subtitle: `${userName} / ${s.label}`,
-			});
-		}
-
-		if (!query) {
-			// No query → show recents (translated to Hits) then everything
-			const recentHits: Hit[] = recents.map((r) => {
-				const match = r.href.match(/\/w\/([^/]+)/);
-				const wsId = match ? match[1] : null;
-				const ws = workspaces.find((w) => w.id === wsId);
-				let subtitle = r.parent ?? (r.kind === "project" ? "Project" : "Workspace");
-				if (ws) {
-					if (r.kind === "project") {
-						subtitle = `${ws.org_name} / ${ws.name} / ${r.label}`;
-					} else {
-						subtitle = `${ws.org_name} / ${ws.name}`;
-					}
-				}
-				return {
-					href: r.href,
-					icon: r.kind === "project" ? FolderOpen : Folders,
-					id: `recent-${r.kind}-${r.id}`,
-					label: r.label,
-					subtitle,
-				};
-			});
-			const seen = new Set(recentHits.map((h) => h.label.toLowerCase()));
-			const rest = all.filter((h) => !seen.has(h.label.toLowerCase()));
-			return [...recentHits, ...rest].slice(0, 40);
-		}
-
-		const clientHits = all.filter((h) => {
-			const hay = `${h.label} ${h.subtitle ?? ""}`.toLowerCase();
-			return hay.includes(query);
-		});
-
-		// Deep results from /home/search, deduped by destination so the
-		// same page never shows twice
-		const merged: Hit[] = [...clientHits];
-		const seenHrefs = new Set(clientHits.map((h) => h.href));
-		const push = (hit: Hit) => {
-			if (seenHrefs.has(hit.href)) return;
-			seenHrefs.add(hit.href);
-			merged.push(hit);
-		};
-
-		const deep = deepSearch.data ?? EMPTY_SEARCH;
-		for (const p of deep.projects) {
-			if (!p.workspaceId) continue;
-			const ws = workspaces.find((w) => w.id === p.workspaceId);
-			const subtitle = ws
-				? `${ws.org_name} / ${ws.name} / ${p.name ?? "Project"}`
-				: "Project";
-			push({
-				href: `/w/${p.workspaceId}/projects/${p.id}/home`,
-				icon: FolderOpen,
-				id: `proj-${p.id}`,
-				label: p.name ?? "Project",
-				subtitle,
-			});
-		}
-		for (const c of deep.conversations) {
-			if (!c.workspaceId || !c.projectId) continue;
-			const ws = workspaces.find((w) => w.id === c.workspaceId);
-			const subtitle = ws
-				? `${ws.org_name} / ${ws.name} / ${c.projectName || "Project"} / ${c.displayLabel}`
-				: c.projectName
-					? `${c.projectName} / ${c.displayLabel}`
-					: "Conversation";
-			push({
-				href: `/w/${c.workspaceId}/projects/${c.projectId}/conversation/${c.id}`,
-				icon: ChatCircle,
-				id: `conv-${c.id}`,
-				label: c.displayLabel,
-				subtitle,
-			});
-		}
-		for (const t of deep.transcripts) {
-			if (!t.workspaceId || !t.projectId || !t.conversationId) continue;
-			const ws = workspaces.find((w) => w.id === t.workspaceId);
-			const path = ws
-				? `${ws.org_name} / ${ws.name} / ${t.conversationLabel ?? "Transcript"}`
-				: "Transcript";
-			const subtitle = t.excerpt
-				? `${path} — "${t.excerpt.slice(0, 60)}..."`
-				: path;
-			push({
-				href: `/w/${t.workspaceId}/projects/${t.projectId}/conversation/${t.conversationId}`,
-				icon: FileText,
-				id: `chunk-${t.id}`,
-				label: t.conversationLabel ?? "Transcript",
-				subtitle,
-			});
-		}
-		for (const ch of deep.chats) {
-			if (!ch.workspaceId || !ch.projectId) continue;
-			const ws = workspaces.find((w) => w.id === ch.workspaceId);
-			const subtitle = ws
-				? `${ws.org_name} / ${ws.name} / ${ch.projectName || "Project"} / ${ch.name ?? "Chat"}`
-				: ch.projectName
-					? `${ch.projectName} / ${ch.name ?? "Chat"}`
-					: "Chat";
-			push({
-				href: `/w/${ch.workspaceId}/projects/${ch.projectId}/chats/${ch.id}`,
-				icon: ChatsCircle,
-				id: `chat-${ch.id}`,
-				label: ch.name ?? "Chat",
-				subtitle,
-			});
-		}
-
-		return merged.slice(0, 40);
-	}, [q, workspaces, recents, deepSearch.data, me]);
-
-	const onSelect = (hit: Hit) => {
+	const onSelect = (hit: SearchHit) => {
 		navigate(hit.href);
+	};
+
+	const onClear = () => {
+		setQ("");
+		setActiveIndex(-1);
+		searchInputRef.current?.focus();
 	};
 
 	const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -423,13 +219,7 @@ export const WorkspaceSelectorRoute = () => {
 	};
 
 	if (isLoading) {
-		return (
-			<Container size="sm" py="xl">
-				<Stack align="center" gap={16} mt="20vh">
-					<Loader size="sm" color="gray" />
-				</Stack>
-			</Container>
-		);
+		return <CenteredLoader />;
 	}
 
 	// Distinct from the empty-state branch below — a 5xx is not "no access."
@@ -449,195 +239,181 @@ export const WorkspaceSelectorRoute = () => {
 
 	const firstName = me?.display_name ? me.display_name.split(" ")[0] : "";
 
-	return (
-		<div style={{ display: "flex", flexDirection: "column", width: "100%", alignItems: "center", padding: "0 16px", position: "relative" }}>
-			{orgList.length > 0 ? (
-				<div style={{ display: "flex", flexDirection: "column", width: "100%", maxWidth: 580, marginTop: "20vh" }}>
-					{/* Component 4: Text */}
-					<div
-						style={{
-							display: "flex",
-							flexDirection: "column",
-							justifyContent: "center",
-							width: "100%",
-						}}
-					>
-						<div style={{ fontSize: 32, marginBottom: 12 }}>🏠</div>
-						<Title order={1} style={{ fontSize: 36, fontWeight: 500, lineHeight: 1.2, color: "#2d2d2c" }}>
-							{firstName ? <Trans>Hi {firstName}</Trans> : <Trans>Hi</Trans>}
-						</Title>
-						<Text size="md" c="dimmed" style={{ marginTop: 8 }}>
-							<Trans>Where would you like to go</Trans>
-						</Text>
-					</div>
+	let content: React.ReactNode;
+	if (orgList.length > 0) {
+		content = (
+			<Box w="100%" maw={FRAME_MAX_WIDTH} mt={FRAME_TOP_MARGIN}>
+				<Text aria-hidden mb={12} style={{ fontSize: 32 }}>
+					🏠
+				</Text>
+				<Title
+					order={1}
+					style={{
+						color: "var(--app-text)",
+						fontSize: 36,
+						fontWeight: 500,
+						lineHeight: 1.2,
+					}}
+				>
+					{firstName ? <Trans>Hi {firstName}</Trans> : <Trans>Hi</Trans>}
+				</Title>
+				<Text size="md" c="dimmed" mt={8}>
+					<Trans>Where would you like to go?</Trans>
+				</Text>
 
-					{/* Component 5: Search */}
-					<div style={{ width: "100%", marginTop: 32 }}>
-						<TextInput
-							leftSection={<MagnifyingGlass size={20} style={{ color: "rgba(45, 45, 44, 0.4)" }} />}
-							placeholder={t`Search projects, organisations, workspaces, settings…`}
-							value={q}
-							size="lg"
-							onChange={(e) => {
-								setQ(e.currentTarget.value);
-								setActiveIndex(0);
-							}}
-							onKeyDown={onKeyDown}
-							styles={{
-								input: {
-									fontSize: 16,
-									borderRadius: 8,
-									border: "1px solid rgba(45, 45, 44, 0.12)",
-									height: 52,
-									backgroundColor: "transparent",
-									"&:focus": {
-										borderColor: "#4169e1",
-									},
-								},
-							}}
-							autoFocus
-						/>
-					</div>
+				<TextInput
+					ref={searchInputRef}
+					mt={32}
+					size="lg"
+					leftSection={<MagnifyingGlassIcon size={20} />}
+					placeholder={t`Search projects, organisations, workspaces, settings…`}
+					value={q}
+					onChange={(e) => {
+						const value = e.currentTarget.value;
+						setQ(value);
+						setActiveIndex(value ? 0 : -1);
+					}}
+					onKeyDown={onKeyDown}
+					classNames={{ input: classes.searchInput }}
+					autoFocus
+					rightSectionPointerEvents="auto"
+					rightSection={
+						q ? (
+							<CloseButton aria-label={t`Clear search`} onClick={onClear} />
+						) : undefined
+					}
+					role="combobox"
+					aria-expanded={hits.length > 0}
+					aria-controls="search-results-list"
+					aria-activedescendant={
+						hits[activeIndex] ? `search-option-${activeIndex}` : undefined
+					}
+				/>
 
-					{/* Component 6: List */}
-					<div
-						style={{
-							width: "100%",
-							marginTop: 16,
-							display: "flex",
-							flexDirection: "column",
-							gap: 8,
-							padding: "4px 0",
-						}}
-					>
-						{hits.length === 0 ? (
-							<div
-								style={{
-									padding: "24px 0",
-									textAlign: "center",
-									fontSize: 14,
-									color: "rgba(45, 45, 44, 0.5)",
-								}}
-							>
-								{deepSearch.isFetching ? (
-									<Trans>Searching…</Trans>
-								) : (
-									<Trans>No matches found</Trans>
-								)}
-							</div>
-						) : (
-							hits.map((hit, i) => {
-								const Icon = hit.icon;
-								const active = i === activeIndex;
-								return (
-									<button
-										type="button"
-										key={hit.id}
-										onClick={() => onSelect(hit)}
-										onMouseEnter={() => setActiveIndex(i)}
-										style={{
-											display: "flex",
-											width: "100%",
-											alignItems: "center",
-											gap: 16,
-											borderRadius: 4,
-											padding: "16px 20px",
-											textAlign: "left",
-											fontSize: 14,
-											cursor: "pointer",
-											border: active
-												? "1px solid #4169e1"
-												: "1px solid rgba(45, 45, 44, 0.12)",
-											backgroundColor: active
-												? "rgba(65, 105, 225, 0.04)"
-												: "transparent",
-											color: "#2d2d2c",
-											transition: "border-color 0.15s ease, background-color 0.15s ease",
-											boxShadow: "0 1px 3px rgba(0,0,0,0.02)",
-										}}
-									>
-										<Icon size={20} style={{ color: active ? "#4169e1" : "rgba(45, 45, 44, 0.6)", flexShrink: 0 }} />
-										<div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-											<span style={{ fontSize: 16, fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-												{hit.label}
-											</span>
-											{hit.subtitle && (
-												<span
-													style={{
-														overflow: "hidden",
-														textOverflow: "ellipsis",
-														whiteSpace: "nowrap",
-														fontSize: 12,
-														color: active ? "#4169e1" : "rgba(45, 45, 44, 0.5)",
-														opacity: active ? 0.9 : 1,
-														marginTop: 2,
-													}}
-												>
-													{hit.subtitle}
-												</span>
-											)}
-										</div>
-									</button>
-								);
-							})
-						)}
-					</div>
-				</div>
-			) : invites.length > 0 ? (
-				<div style={{ display: "flex", flexDirection: "column", width: "100%", maxWidth: 580, marginTop: "20vh" }}>
-					<Stack align="center" gap={12}>
-						<Text c="dimmed" size="sm" ta="center">
-							{invites[0].type === "org" ? (
-								<Trans>
-									You have a pending invite to {invites[0].org_name}. Open it to
-									join the organisation.
-								</Trans>
+				<Stack
+					id="search-results-list"
+					role="listbox"
+					aria-label={t`Search results`}
+					gap={8}
+					mt={16}
+					py={4}
+				>
+					{hits.length === 0 ? (
+						<Text ta="center" c="dimmed" py={24} fz={14}>
+							{isFetching ? (
+								<Trans>Searching…</Trans>
 							) : (
-								<Trans>
-									You have a pending invite to{" "}
-									{invites[0].workspace_name ?? "a workspace"}. The admin needs
-									to free a seat before you can join.
-								</Trans>
+								<Trans>No matches found</Trans>
 							)}
 						</Text>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => navigate("/invites")}
-						>
-							<Trans>View invite</Trans>
-						</Button>
-					</Stack>
-				</div>
-			) : recentRemovals.length > 0 ? (
-				<div style={{ display: "flex", flexDirection: "column", width: "100%", maxWidth: 580, marginTop: "20vh" }}>
-					<Stack align="center" gap={8}>
-						<Text c="dimmed" size="sm" ta="center">
+					) : (
+						hits.map((hit, i) => {
+							const Icon = hit.icon;
+							const active = i === activeIndex;
+							return (
+								<button
+									type="button"
+									key={hit.id}
+									id={`search-option-${i}`}
+									role="option"
+									aria-selected={active}
+									onClick={() => onSelect(hit)}
+									className={
+										active
+											? `${classes.resultRow} ${classes.resultRowActive}`
+											: classes.resultRow
+									}
+								>
+									<Icon size={20} className={classes.resultIcon} />
+									<span className={classes.resultLabel}>
+										<span className={classes.resultTitle}>{hit.label}</span>
+										{hit.subtitle ? (
+											<span className={classes.resultSubtitle}>
+												{hit.subtitle}
+											</span>
+										) : null}
+									</span>
+								</button>
+							);
+						})
+					)}
+				</Stack>
+			</Box>
+		);
+	} else if (invites.length > 0) {
+		content = (
+			<Box w="100%" maw={FRAME_MAX_WIDTH} mt={FRAME_TOP_MARGIN}>
+				<Stack align="center" gap={12}>
+					<Text c="dimmed" size="sm" ta="center">
+						{invites[0].type === "org" ? (
 							<Trans>
-								Your access to {recentRemovals[0].workspace_name} ended on{" "}
-								{new Date(recentRemovals[0].ended_at).toLocaleDateString()}.
+								You have a pending invite to {invites[0].org_name}. Open it to
+								join the organisation.
 							</Trans>
-						</Text>
-						<Text c="dimmed" size="xs" ta="center">
-							<Trans>Contact the admin if this was unexpected.</Trans>
-						</Text>
-					</Stack>
-				</div>
-			) : (
-				<div style={{ display: "flex", flexDirection: "column", width: "100%", maxWidth: 580, marginTop: "20vh" }}>
-					<Stack align="center" gap={8}>
-						<Text c="dimmed" size="sm" ta="center">
-							<Trans>You're not part of any organisation right now.</Trans>
-						</Text>
-						<Text c="dimmed" size="sm" ta="center">
+						) : (
 							<Trans>
-								If you were expecting access, please ask the person who invited
-								you to send it again.
+								You have a pending invite to{" "}
+								{invites[0].workspace_name ?? "a workspace"}. The admin needs to
+								free a seat before you can join.
 							</Trans>
-						</Text>
-					</Stack>
-				</div>
-			)}
-		</div>
+						)}
+					</Text>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => navigate("/invites")}
+					>
+						<Trans>View invite</Trans>
+					</Button>
+				</Stack>
+			</Box>
+		);
+	} else if (recentRemovals.length > 0) {
+		content = (
+			<Box w="100%" maw={FRAME_MAX_WIDTH} mt={FRAME_TOP_MARGIN}>
+				<Stack align="center" gap={8}>
+					<Text c="dimmed" size="sm" ta="center">
+						<Trans>
+							Your access to {recentRemovals[0].workspace_name} ended on{" "}
+							{new Date(recentRemovals[0].ended_at).toLocaleDateString()}.
+						</Trans>
+					</Text>
+					<Text c="dimmed" size="xs" ta="center">
+						<Trans>Contact the admin if this was unexpected.</Trans>
+					</Text>
+				</Stack>
+			</Box>
+		);
+	} else {
+		content = (
+			<Box w="100%" maw={FRAME_MAX_WIDTH} mt={FRAME_TOP_MARGIN}>
+				<Stack align="center" gap={8}>
+					<Text c="dimmed" size="sm" ta="center">
+						<Trans>You're not part of any organisation right now.</Trans>
+					</Text>
+					<Text c="dimmed" size="sm" ta="center">
+						<Trans>
+							If you were expecting access, please ask the person who invited
+							you to send it again.
+						</Trans>
+					</Text>
+				</Stack>
+			</Box>
+		);
+	}
+
+	return (
+		<Box
+			w="100%"
+			px={16}
+			style={{
+				alignItems: "center",
+				display: "flex",
+				flexDirection: "column",
+				position: "relative",
+			}}
+		>
+			{content}
+		</Box>
 	);
 };


### PR DESCRIPTION
…y while searching

  Drive row hover with CSS (:hover) instead of onMouseEnter/onMouseLeave state,
  so it no longer lingers after the pointer leaves and no longer re-renders the
  list on every row. The keyboard highlight stays in state and is set to the
  first result only while a query is present (nothing pre-selected when empty).
  A :has() rule lets the hovered row win over the keyboard highlight so only one
  row is ever lit. Applied to both the /o page and the command palette (new
  SearchBlock.module.css), replacing the palette's hardcoded hex with brand
  tokens.