### PR TITLE
ECHO-861 ECHO-741 feat(search): match query words in any order across all search surfaces

### DIFF
--- a/echo/frontend/src/features/sidebar/hooks/useSearchHits.ts
+++ b/echo/frontend/src/features/sidebar/hooks/useSearchHits.ts
@@ -181,9 +181,11 @@ export function useSearchHits(
 			return [...recentHits, ...rest].slice(0, MAX_HITS);
 		}
 
+		// Split on whitespace so "Marketing Acme" matches "Acme Marketing".
+		const tokens = needle.split(/\s+/).filter(Boolean);
 		const clientHits = all.filter((h) => {
 			const hay = `${h.label} ${h.subtitle ?? ""}`.toLowerCase();
-			return hay.includes(needle);
+			return tokens.every((tok) => hay.includes(tok));
 		});
 
 		// Deep results from /home/search, deduped by destination so the same

--- a/echo/server/dembrane/api/search.py
+++ b/echo/server/dembrane/api/search.py
@@ -10,6 +10,7 @@ from pydantic import Field, BaseModel
 from dembrane.directus import DirectusClient, directus
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.api.rate_limit import create_user_rate_limiter
+from dembrane.search_filters import all_tokens_filter
 from dembrane.api.dependency_auth import DependencyDirectusSession, require_directus_client
 
 SearchRouter = APIRouter(
@@ -193,12 +194,21 @@ def _search_like_filter(field: str, term: str) -> Dict[str, Any]:
     return {field: {"_icontains": term}}
 
 
+# Alias to the private name the fetchers below call.
+_all_tokens_filter = all_tokens_filter
+
+
 def _fetch_projects(client: DirectusClient, term: str, limit: int) -> List[dict]:
     payload = client.get_items(
         "project",
         {
             "query": {
-                "filter": {**_search_like_filter("name", term), "deleted_at": {"_null": True}},
+                "filter": {
+                    "_and": [
+                        _all_tokens_filter(["name"], term),
+                        {"deleted_at": {"_null": True}},
+                    ]
+                },
                 "fields": ["id", "name", "workspace_id", "updated_at", "count(conversations)"],
                 "sort": ["-updated_at"],
                 "limit": limit,
@@ -216,12 +226,9 @@ def _fetch_conversations(client: DirectusClient, term: str, limit: int) -> List[
                 "filter": {
                     "_and": [
                         {"deleted_at": {"_null": True}},
-                        {"_or": [
-                            _search_like_filter("participant_name", term),
-                            _search_like_filter("participant_email", term),
-                            _search_like_filter("summary", term),
-                            _search_like_filter("id", term),
-                        ]},
+                        _all_tokens_filter(
+                            ["participant_name", "participant_email", "summary"], term
+                        ),
                     ]
                 },
                 "fields": [
@@ -257,6 +264,7 @@ def _fetch_chunks(client: DirectusClient, term: str, limit: int) -> List[dict]:
         "conversation_chunk",
         {
             "query": {
+                # Phrase match (not token-AND): transcripts match a contiguous spoken phrase.
                 "filter": {
                     "_or": [
                         _search_like_filter("transcript", term),
@@ -289,10 +297,7 @@ def _fetch_chats(client: DirectusClient, term: str, limit: int) -> List[dict]:
                 "filter": {
                     "_and": [
                         {"deleted_at": {"_null": True}},
-                        {"_or": [
-                            _search_like_filter("name", term),
-                            _search_like_filter("id", term),
-                        ]},
+                        _all_tokens_filter(["name"], term),
                     ]
                 },
                 "fields": [

--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel
 
 from dembrane.tier_capacity import is_conversation_locked
 from dembrane.directus_async import async_directus
+from dembrane.search_filters import merge_search_filter
 from dembrane.api.v2.bff._access import (
     filter_exclude_deleted,
     resolve_project_access,
@@ -65,6 +66,15 @@ _CONVERSATION_DEFAULT_FIELDS = [
     "is_audio_processing_finished",
     "is_anonymized",
     "is_over_cap",
+]
+
+# Shared by the list/count/select-all endpoints so they stay consistent.
+# No `id`: Directus rejects _icontains on uuid fields and errors the query.
+_CONVERSATION_SEARCH_FIELDS = [
+    "participant_name",
+    "participant_email",
+    "title",
+    "summary",
 ]
 
 
@@ -163,7 +173,9 @@ async def list_conversations(
         "offset": offset,
     }
     if search_text and search_text.strip():
-        query_dict["search"] = search_text.strip()
+        query_dict["filter"] = merge_search_filter(
+            conv_filter, search_text.strip(), _CONVERSATION_SEARCH_FIELDS
+        )
 
     convs = (
         await async_directus.get_items(
@@ -394,7 +406,9 @@ async def count_conversations(
         "filter": filt,
     }
     if search_text and search_text.strip():
-        query_dict["search"] = search_text.strip()
+        query_dict["filter"] = merge_search_filter(
+            filt, search_text.strip(), _CONVERSATION_SEARCH_FIELDS
+        )
 
     agg = await async_directus.get_items(
         "conversation",
@@ -547,7 +561,9 @@ async def count_remaining_conversations(
 
     query: dict = {"fields": ["id"], "filter": filt, "limit": -1}
     if search_text and search_text.strip():
-        query["search"] = search_text.strip()
+        query["filter"] = merge_search_filter(
+            filt, search_text.strip(), _CONVERSATION_SEARCH_FIELDS
+        )
 
     candidates = await async_directus.get_items("conversation", {"query": query})
     if not isinstance(candidates, list) or not candidates:

--- a/echo/server/dembrane/api/v2/bff/tags.py
+++ b/echo/server/dembrane/api/v2/bff/tags.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from dembrane.utils import generate_uuid
 from dembrane.directus_async import async_directus
+from dembrane.search_filters import merge_search_filter
 from dembrane.api.v2.bff._access import (
     resolve_tag_access,
     resolve_project_access,
@@ -360,9 +361,6 @@ async def list_my_projects(
         "workspace_id": {"_in": ws_ids},
         "deleted_at": {"_null": True},
     }
-    # Directus project rows don't have a full-text index; `search` param
-    # does a LIKE match across string fields when the server-side
-    # directus_client supports it.
     query: dict = {
         "filter": filt,
         "fields": [
@@ -379,7 +377,7 @@ async def list_my_projects(
         "offset": offset,
     }
     if search and search.strip():
-        query["search"] = search.strip()
+        query["filter"] = merge_search_filter(filt, search.strip(), ["name"])
     raw = await async_directus.get_items("project", {"query": query}) or []
     raw_list = raw if isinstance(raw, list) else []
 

--- a/echo/server/dembrane/api/v2/workspace_projects.py
+++ b/echo/server/dembrane/api/v2/workspace_projects.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from dembrane.utils import generate_uuid
 from dembrane.directus_async import async_directus
+from dembrane.search_filters import merge_search_filter
 from dembrane.api.v2.middleware import (
     WorkspaceContext,
     get_workspace_context,
@@ -320,6 +321,9 @@ async def list_workspace_projects(
         {**base_filter, **visibility_clause} if visibility_clause is not None else base_filter
     )
 
+    if search and search.strip():
+        effective_filter = merge_search_filter(effective_filter, search.strip(), ["name"])
+
     query: dict = {
         "fields": [
             "id",
@@ -336,8 +340,6 @@ async def list_workspace_projects(
         "limit": limit + 1,
         "offset": offset,
     }
-    if search:
-        query["search"] = search
 
     projects_raw = await async_directus.get_items("project", {"query": query})
     if not isinstance(projects_raw, list):

--- a/echo/server/dembrane/search_filters.py
+++ b/echo/server/dembrane/search_filters.py
@@ -1,0 +1,45 @@
+"""Order-independent ("token-AND") Directus search filters.
+
+Search should match a record when every word of the query appears in any
+order, not only as one contiguous phrase: "review annual budget" must find a
+project titled "Annual Budget Review". These helpers build the Directus filter
+that enforces "every token present, any order, case-insensitive".
+
+Shared by the global search endpoint (dembrane.api.search) and the
+workspace-scoped project list (dembrane.api.v2.workspace_projects).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+
+def tokens(term: str) -> List[str]:
+    """Split a search term into whitespace-separated tokens, dropping empties."""
+    return [t for t in term.split() if t]
+
+
+def all_tokens_filter(fields: Sequence[str], term: str) -> Dict[str, Any]:
+    """Directus filter requiring every token of `term` to appear (in any order)
+    in at least one of `fields`. Case-insensitive substring match per token.
+
+    Shape: _and of per-token clauses; each clause is an _or over `fields`.
+    Returns {} for an empty/whitespace-only term (callers guard before fetching).
+    """
+    toks = tokens(term)
+    if not toks:
+        return {}
+    return {"_and": [{"_or": [{f: {"_icontains": tok}} for f in fields]} for tok in toks]}
+
+
+def merge_search_filter(
+    base_filter: Dict[str, Any], term: str, fields: Sequence[str] = ("name",)
+) -> Dict[str, Any]:
+    """AND an existing Directus filter with a token-AND search over `fields`.
+
+    Returns `base_filter` unchanged for a blank term (no-op).
+    """
+    token_filter = all_tokens_filter(fields, term)
+    if not token_filter:
+        return base_filter
+    return {"_and": [base_filter, token_filter]}

--- a/echo/server/tests/api/test_search_tokenization.py
+++ b/echo/server/tests/api/test_search_tokenization.py
@@ -1,0 +1,82 @@
+"""Token-AND wiring in the global search fetchers.
+
+Verifies each fetcher hands Directus an order-independent filter so a
+multi-word query matches in any word order, while transcript search stays a
+contiguous phrase match. The filter builder itself is unit-tested in
+tests/test_search_filters.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dembrane.api.search import (
+    _fetch_chats,
+    _fetch_chunks,
+    _fetch_projects,
+    _all_tokens_filter,
+    _fetch_conversations,
+)
+
+
+def _capture_client() -> MagicMock:
+    """A Directus client stub that records the query it was handed and
+    returns an empty list (we assert on the query, not the results)."""
+    client = MagicMock()
+    client.get_items.return_value = []
+    return client
+
+
+def _filter_of(client: MagicMock) -> dict:
+    # client.get_items(collection, {"query": {...}})
+    _collection, params = client.get_items.call_args.args
+    return params["query"]["filter"]
+
+
+def test_fetch_projects_uses_token_and_over_name():
+    client = _capture_client()
+    _fetch_projects(client, "Annual Budget Review", 15)
+    assert _filter_of(client) == {
+        "_and": [
+            _all_tokens_filter(["name"], "Annual Budget Review"),
+            {"deleted_at": {"_null": True}},
+        ]
+    }
+
+
+def test_fetch_conversations_uses_token_and_over_text_fields():
+    client = _capture_client()
+    _fetch_conversations(client, "alice budget", 15)
+    filt = _filter_of(client)
+    # membership checks avoid coupling to the order of _and clauses
+    assert {"deleted_at": {"_null": True}} in filt["_and"]
+    # `id` is excluded: Directus rejects _icontains on uuid fields.
+    assert (
+        _all_tokens_filter(
+            ["participant_name", "participant_email", "summary"], "alice budget"
+        )
+        in filt["_and"]
+    )
+
+
+def test_fetch_chats_uses_token_and_over_name():
+    client = _capture_client()
+    _fetch_chats(client, "weekly sync", 15)
+    filt = _filter_of(client)
+    # membership checks avoid coupling to the order of _and clauses
+    assert {"deleted_at": {"_null": True}} in filt["_and"]
+    # `id` is excluded: Directus rejects _icontains on uuid fields.
+    assert _all_tokens_filter(["name"], "weekly sync") in filt["_and"]
+
+
+def test_fetch_chunks_stays_phrase_match():
+    # Transcripts intentionally keep a single contiguous _icontains per field.
+    client = _capture_client()
+    _fetch_chunks(client, "exact spoken phrase", 15)
+    filt = _filter_of(client)
+    assert filt == {
+        "_or": [
+            {"transcript": {"_icontains": "exact spoken phrase"}},
+            {"raw_transcript": {"_icontains": "exact spoken phrase"}},
+        ]
+    }

--- a/echo/server/tests/test_search_filters.py
+++ b/echo/server/tests/test_search_filters.py
@@ -1,0 +1,71 @@
+"""Shared order-independent search filter helpers.
+
+Search must match query words in any order: "review annual budget" should find
+a project titled "Annual Budget Review". These cover the token splitter, the
+token-AND filter builder, and the merge helper used by the workspace project
+list to combine token-AND name search with an existing access filter.
+"""
+
+from __future__ import annotations
+
+from dembrane.search_filters import tokens, all_tokens_filter, merge_search_filter
+
+
+def test_tokens_splits_on_whitespace_and_drops_empties():
+    assert tokens("annual budget review") == ["annual", "budget", "review"]
+    assert tokens("  multiple   spaces\tand\ntabs ") == [
+        "multiple",
+        "spaces",
+        "and",
+        "tabs",
+    ]
+    assert tokens("") == []
+    assert tokens("   ") == []
+
+
+def test_all_tokens_filter_ands_every_token_over_fields():
+    assert all_tokens_filter(["name"], "annual budget") == {
+        "_and": [
+            {"_or": [{"name": {"_icontains": "annual"}}]},
+            {"_or": [{"name": {"_icontains": "budget"}}]},
+        ]
+    }
+
+
+def test_all_tokens_filter_empty_term_returns_empty():
+    assert all_tokens_filter(["name"], "") == {}
+    assert all_tokens_filter(["name"], "   ") == {}
+
+
+def test_merge_search_filter_ands_base_with_token_filter():
+    base = {"workspace_id": {"_eq": "ws-1"}, "deleted_at": {"_null": True}}
+    merged = merge_search_filter(base, "annual budget review", ["name"])
+    assert merged == {
+        "_and": [
+            base,
+            {
+                "_and": [
+                    {"_or": [{"name": {"_icontains": "annual"}}]},
+                    {"_or": [{"name": {"_icontains": "budget"}}]},
+                    {"_or": [{"name": {"_icontains": "review"}}]},
+                ]
+            },
+        ]
+    }
+
+
+def test_merge_search_filter_blank_term_is_noop():
+    base = {"workspace_id": {"_eq": "ws-1"}, "deleted_at": {"_null": True}}
+    assert merge_search_filter(base, "", ["name"]) is base
+    assert merge_search_filter(base, "   ", ["name"]) is base
+
+
+def test_merge_search_filter_defaults_to_name_field():
+    base = {"deleted_at": {"_null": True}}
+    merged = merge_search_filter(base, "budget")
+    assert merged == {
+        "_and": [
+            base,
+            {"_and": [{"_or": [{"name": {"_icontains": "budget"}}]}]},
+        ]
+    }


### PR DESCRIPTION
  Search required the exact contiguous phrase, so "review annual budget"
  missed an "Annual Budget Review" record. Switch every surface to token-AND
  matching: split the query on whitespace and require each token to appear
  in any order (case-insensitive substring per token).

  - Add dembrane/search_filters.py: shared tokens / all_tokens_filter / merge_search_filter helpers
  - Apply to global search (projects, conversations, chats), the workspace project list, the move-conversation picker, and the conversation list/count/select-all endpoints
  - Frontend sidebar clientHits (orgs/workspaces/settings) now token-AND too
  - Transcript search stays a contiguous phrase match by design
  - Exclude `id` from search field lists: Directus rejects _icontains on uuid fields, which errored the whole query and returned no results

  Tests: shared-helper unit tests + fetcher integration tests.