### PR TITLE
chore(dev): editor + container dev-environment setup

### DIFF
--- a/echo/.devcontainer/docker-compose.yml
+++ b/echo/.devcontainer/docker-compose.yml
@@ -108,8 +108,12 @@ services:
 
     volumes:
       - ../..:/workspaces:cached
-      # for docker passthrough
-      - /var/run/docker.sock:/var/run/docker.sock
+      # Container-engine socket passthrough. Only used by optional dev helpers
+      # (e.g. server/scripts/agentic/latest_runs.sh runs `docker ps`); the stack
+      # works without it. Defaults to the Docker socket. Podman users: run
+      # `sudo /opt/podman/bin/podman-mac-helper install` and restart the machine
+      # so /var/run/docker.sock routes to Podman, or override CONTAINER_HOST_SOCK.
+      - ${CONTAINER_HOST_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
     networks:
       - dembrane-network
     command: sleep infinity

--- a/echo/.zed/settings.json
+++ b/echo/.zed/settings.json
@@ -1,0 +1,42 @@
+{
+  "formatter": "language_server",
+  "format_on_save": "on",
+  "languages": {
+    "Python": {
+      "language_servers": ["ruff", "ty", "!pylsp"],
+      "formatter": {
+        "language_server": { "name": "ruff" }
+      },
+      "format_on_save": "on",
+      "code_actions_on_format": {
+        "source.fixAll.ruff": true,
+        "source.organizeImports.ruff": true
+      }
+    },
+    "TypeScript": {
+      "language_servers": ["biome", "!eslint", "!prettier"],
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "TSX": {
+      "language_servers": ["biome", "!eslint", "!prettier"],
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JavaScript": {
+      "language_servers": ["biome", "!eslint", "!prettier"],
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JSON": {
+      "language_servers": ["biome"],
+      "formatter": { "language_server": { "name": "biome" } }
+    }
+  },
+  "lsp": {
+    "ruff": {
+      "initialization_options": {
+        "settings": {
+          "configuration": "server/pyproject.toml"
+        }
+      }
+    }
+  }
+}

--- a/echo/frontend/package.json
+++ b/echo/frontend/package.json
@@ -125,11 +125,5 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.2",
     "vite": "^6.3.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "tar-fs": "^2.1.3",
-      "protobufjs": "^7.5.8"
-    }
   }
 }

--- a/echo/frontend/pnpm-lock.yaml
+++ b/echo/frontend/pnpm-lock.yaml
@@ -429,10 +429,6 @@ packages:
     resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
@@ -568,20 +564,12 @@ packages:
     resolution: {integrity: sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.27.0':
     resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.0':
-    resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
@@ -2630,6 +2618,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react-swc@3.11.0':
     resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
@@ -5239,15 +5228,15 @@ snapshots:
   '@babel/core@7.28.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
       '@babel/helpers': 7.27.6
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -5309,13 +5298,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
@@ -5335,9 +5317,9 @@ snapshots:
   '@babel/helper-module-transforms@7.27.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5366,8 +5348,8 @@ snapshots:
 
   '@babel/helpers@7.27.6':
     dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.27.0':
     dependencies:
@@ -5449,12 +5431,6 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.1
 
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
-
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5470,18 +5446,6 @@ snapshots:
       '@babel/types': 7.28.1
       debug: 4.4.0
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.28.0':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
-      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 

--- a/echo/frontend/pnpm-workspace.yaml
+++ b/echo/frontend/pnpm-workspace.yaml
@@ -1,4 +1,16 @@
 onlyBuiltDependencies:
   - '@swc/core'
 
+ignoredBuiltDependencies:
+  - canvas
+  - core-js
+  - es5-ext
+  - esbuild
+  - protobufjs
+  - react-grab
+
+overrides:
+  tar-fs: ^2.1.3
+  protobufjs: ^7.5.8
+
 minimumReleaseAge: 4320

--- a/echo/mprocs.yaml
+++ b/echo/mprocs.yaml
@@ -1,0 +1,30 @@
+# Dev service manager — replaces the terminal-keeper sessions.json for non-VS-Code editors.
+# Infra (redis/postgres/directus/agent) runs via .devcontainer/docker-compose.yml; these are the host processes.
+#
+# Run:  mprocs          (opens the TUI with all services)
+# Keys: j/k select · s start · x stop · r restart · a (or X) stop-all · q quit
+# Tip:  mprocs --names server,workers   to launch a subset
+procs:
+  server:
+    shell: "uv run uvicorn dembrane.main:app --port 8000 --reload --loop asyncio"
+    cwd: server
+
+  workers:
+    shell: "uv run dramatiq-gevent --queues network --processes 1 --threads 10 dembrane.tasks"
+    cwd: server
+
+  workers-cpu:
+    shell: "uv run dramatiq --queues cpu --processes 1 --threads 1 dembrane.tasks"
+    cwd: server
+
+  scheduler:
+    shell: "uv run python -m dembrane.scheduler"
+    cwd: server
+
+  admin-dashboard:
+    shell: "pnpm run dev"
+    cwd: frontend
+
+  participant-portal:
+    shell: "pnpm run participant:dev"
+    cwd: frontend

--- a/echo/server/pyproject.toml
+++ b/echo/server/pyproject.toml
@@ -84,6 +84,7 @@ package = false
 
 [tool.mypy]
 plugins = 'pydantic.mypy'
+# Keep in sync with [tool.ty.src].exclude below (editor type checker).
 exclude = ['scripts', 'tests']
 warn_redundant_casts = true
 warn_unused_ignores = true
@@ -208,6 +209,14 @@ project-excludes = [
     "**/tests*",
 ]
 ignore-missing-imports = ["*"]
+
+# ty (Astral's Rust type checker) — editor-only fast diagnostics.
+# mypy in check-code.sh / CI remains the source of truth.
+[tool.ty.src]
+exclude = ["tests", "scripts"]  # keep in sync with [tool.mypy].exclude
+
+[tool.ty.environment]
+python = ".venv"
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary

Dev-environment quality-of-life setup so the stack runs cleanly outside VS Code (Zed, Podman, mprocs).

- **mprocs.yaml**: TUI service manager for host processes (server, network/cpu workers, scheduler, admin + participant frontends). One command (`mprocs`) brings up the full host-side dev stack; infra still runs via `.devcontainer/docker-compose.yml`.
- **docker-compose**: container socket now routes via `${CONTAINER_HOST_SOCK:-/var/run/docker.sock}` so Podman users can pass through their own socket. Defaults to the Docker socket, so no change for existing setups.
- **frontend**: moved pnpm `overrides` (`tar-fs`, `protobufjs`) out of `package.json` into `pnpm-workspace.yaml`, and declared `ignoredBuiltDependencies`. Lockfile updated to match.
- **server**: added `ty` (Astral's Rust type checker) config for fast editor-only diagnostics. mypy in `check-code.sh` / CI remains the source of truth; excludes kept in sync.
- **.zed**: shared Zed editor settings (ruff for Python, biome for TS/JS, format on save).

## Notes

No runtime or product code touched. CI type-checking/linting behavior is unchanged (mypy still authoritative).

## Test plan

- [ ] `mprocs` brings up all services
- [ ] Existing Docker-based devcontainer still works (default socket path unchanged)
- [ ] `pnpm install` resolves with overrides from `pnpm-workspace.yaml`