### PR TITLE
fix(i18n): persist UI language

### DIFF
--- a/echo/frontend/src/components/language/LanguagePicker.tsx
+++ b/echo/frontend/src/components/language/LanguagePicker.tsx
@@ -6,6 +6,7 @@ import { useLocation } from "react-router";
 import { ConfirmModal } from "@/components/common/ConfirmModal";
 import { SUPPORTED_LANGUAGES } from "@/config";
 import { useLanguage } from "@/hooks/useLanguage";
+import { storeLanguage } from "@/lib/language";
 import { testId } from "@/lib/testUtils";
 import classes from "./LanguagePicker.module.css";
 
@@ -87,6 +88,9 @@ export const LanguagePicker = () => {
 			(lang) => lang === selectedLanguage,
 		);
 		if (!validLanguage) return;
+
+		// Persist the choice so it survives the reload and future sessions.
+		storeLanguage(validLanguage);
 
 		let newPathname = pathname;
 

--- a/echo/frontend/src/hooks/useI18nNavigate.ts
+++ b/echo/frontend/src/hooks/useI18nNavigate.ts
@@ -4,7 +4,7 @@ import {
 	useNavigate,
 	useParams,
 } from "react-router";
-import { SUPPORTED_LANGUAGES } from "@/config";
+import { stripLanguagePrefix } from "@/lib/language";
 import { useLanguage } from "./useLanguage";
 
 export function useI18nNavigate() {
@@ -39,26 +39,17 @@ export function useI18nNavigate() {
 			return;
 		}
 
-		// Check if 'to' starts with any supported language prefix
-		const pathToCheck = targetPath ?? to.toString();
-		const hasLanguagePrefix = SUPPORTED_LANGUAGES.some((lang) =>
-			pathToCheck.startsWith(`/${lang}`),
-		);
-
-		if (hasLanguagePrefix) {
-			navigate(to, options);
+		// Strip any prefix already on the target and re-apply the active one, so a
+		// stale prefix in ?next (e.g. /en-US/...) can't revert the UI after login.
+		const languagePrefix = finalLanguage ? `/${finalLanguage}` : "";
+		if (typeof to === "string") {
+			navigate(`${languagePrefix}${stripLanguagePrefix(to)}`, options);
 		} else {
-			// Add the language prefix if it's not already present
-			const languagePrefix = finalLanguage ? `/${finalLanguage}` : "";
-			if (typeof to === "string") {
-				navigate(`${languagePrefix}${to}`, options);
-			} else {
-				const nextTo = {
-					...to,
-					pathname: `${languagePrefix}${to.pathname ?? ""}`,
-				};
-				navigate(nextTo, options);
-			}
+			const nextTo = {
+				...to,
+				pathname: `${languagePrefix}${stripLanguagePrefix(to.pathname ?? "")}`,
+			};
+			navigate(nextTo, options);
 		}
 	};
 }

--- a/echo/frontend/src/hooks/useLanguage.ts
+++ b/echo/frontend/src/hooks/useLanguage.ts
@@ -2,6 +2,7 @@ import { i18n } from "@lingui/core";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import { SUPPORTED_LANGUAGES } from "@/config";
+import { readStoredLanguage } from "@/lib/language";
 
 export const defaultLanguage = "en-US";
 
@@ -25,11 +26,14 @@ i18n.load({
 	"cs-CZ": csMessages,
 });
 
-i18n.activate(defaultLanguage);
+// Seed from the saved preference so a prefix-less entry doesn't flash English.
+i18n.activate(readStoredLanguage() ?? defaultLanguage);
 
 export const useLanguage = () => {
 	const params = useParams();
-	const language = params.language ?? i18n.locale ?? defaultLanguage;
+	// URL prefix wins (shareable/explicit); otherwise restore the saved choice.
+	const language =
+		params.language ?? readStoredLanguage() ?? i18n.locale ?? defaultLanguage;
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {

--- a/echo/frontend/src/lib/language.ts
+++ b/echo/frontend/src/lib/language.ts
@@ -1,0 +1,39 @@
+import { SUPPORTED_LANGUAGES } from "@/config";
+
+// Language otherwise lives only in the URL prefix; persist it so it survives
+// reloads and prefix-less entries (bare domain, bookmark, the login ?next).
+export const LANGUAGE_STORAGE_KEY = "dembrane-language";
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const isSupportedLanguage = (
+	value: string | null | undefined,
+): value is SupportedLanguage =>
+	!!value && SUPPORTED_LANGUAGES.some((lang) => lang === value);
+
+export const readStoredLanguage = (): SupportedLanguage | null => {
+	if (typeof window === "undefined") return null;
+	try {
+		const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+		return isSupportedLanguage(stored) ? stored : null;
+	} catch {
+		return null;
+	}
+};
+
+export const storeLanguage = (language: string): void => {
+	if (typeof window === "undefined" || !isSupportedLanguage(language)) return;
+	try {
+		window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+	} catch {
+		// Private-mode / storage-disabled: fall back to URL-only behaviour.
+	}
+};
+
+// Strip a leading /<lang> segment; the lookahead avoids false matches like /en-USA.
+const LANGUAGE_PREFIX_RE = new RegExp(
+	`^/(?:${SUPPORTED_LANGUAGES.join("|")})(?=/|$|\\?|#)`,
+);
+
+export const stripLanguagePrefix = (path: string): string =>
+	path.replace(LANGUAGE_PREFIX_RE, "");


### PR DESCRIPTION

Language lived only in the URL prefix with no persistence: any prefix-less entry (bare domain, bookmark, new session) reset it to English, and a stale /<lang> prefix carried in ?next reverted the UI to English after login.

- Persist the chosen language to localStorage (dembrane-language) and use it as the fallback in useLanguage when the URL has no prefix.
- useI18nNavigate now strips any existing /<lang> prefix and re-applies the active language, so a stale ?next prefix can't override the user's choice.