### PR TITLE
feat(invites): add invite link as alternative to email delivery

### DIFF
--- a/echo/frontend/src/components/invite/InviteModal.tsx
+++ b/echo/frontend/src/components/invite/InviteModal.tsx
@@ -68,6 +68,7 @@ type WorkspaceInvitePayload = {
 	status: string;
 	email: string;
 	email_sent: boolean;
+	invite_url?: string | null;
 };
 
 async function inviteToWorkspace(
@@ -99,7 +100,7 @@ async function inviteToOrg(
 	orgId: string,
 	email: string,
 	role: InviteRole,
-): Promise<{ status: string; email: string }> {
+): Promise<{ status: string; email: string; invite_url?: string | null }> {
 	const res = await fetch(`${API_BASE_URL}/v2/orgs/${orgId}/invites`, {
 		body: JSON.stringify({ email, role }),
 		credentials: "include",
@@ -114,7 +115,7 @@ async function inviteToOrg(
 		(err as Error & { status?: number }).status = res.status;
 		throw err;
 	}
-	return data as { status: string; email: string };
+	return data as { status: string; email: string; invite_url?: string | null };
 }
 
 function mapHttpStatusToState(status: number | undefined): InviteResultState {
@@ -294,7 +295,11 @@ export function InviteModal({
 			const rows = settled.map((res, i) => {
 				const call = calls[i];
 				if (res.status === "fulfilled") {
-					const status = (res.value as { status?: string }).status ?? "sent";
+					const value = res.value as {
+						status?: string;
+						invite_url?: string | null;
+					};
+					const status = value.status ?? "sent";
 					// invited/added/reactivated → sent; already_member / already_invited surface as their own states.
 					let state: InviteResultState = "sent";
 					if (status === "already_member") state = "already_member";
@@ -304,6 +309,7 @@ export function InviteModal({
 						workspaceId: call.workspaceId,
 						workspaceName: call.workspaceName,
 						state,
+						inviteUrl: value.invite_url ?? null,
 					};
 				}
 				const err = res.reason as Error & { status?: number };

--- a/echo/frontend/src/components/invite/InviteResultsList.tsx
+++ b/echo/frontend/src/components/invite/InviteResultsList.tsx
@@ -1,5 +1,17 @@
+import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { Badge, Group, Paper, Stack, Text } from "@mantine/core";
+import {
+	ActionIcon,
+	Badge,
+	Group,
+	Paper,
+	Stack,
+	Text,
+	Tooltip,
+} from "@mantine/core";
+import { usePostHog } from "@posthog/react";
+import { IconLink } from "@tabler/icons-react";
+import { toast } from "@/components/common/Toaster";
 
 export type InviteResultState =
 	| "sent" // status: invited (new user) / added (existing user) / reactivated
@@ -16,6 +28,7 @@ export interface InviteResultRow {
 	workspaceName: string | null;
 	state: InviteResultState;
 	detail?: string;
+	inviteUrl?: string | null;
 }
 
 interface Props {
@@ -45,6 +58,19 @@ function badgeForState(state: InviteResultState) {
 
 // Per-email result rows shown after submit.
 export function InviteResultsList({ rows, "data-testid": dataTestId }: Props) {
+	const posthog = usePostHog();
+	const copy = (url: string, workspaceId: string | null) => {
+		void navigator.clipboard.writeText(url).then(
+			() => {
+				toast.success(t`Link copied`);
+				posthog?.capture("invite_link_copied", {
+					source: "create",
+					type: workspaceId ? "workspace" : "org",
+				});
+			},
+			() => toast.error(t`Couldn't copy the link.`),
+		);
+	};
 	if (rows.length === 0) return null;
 	return (
 		<Stack gap={6} data-testid={dataTestId}>
@@ -57,8 +83,8 @@ export function InviteResultsList({ rows, "data-testid": dataTestId }: Props) {
 						p="xs"
 						radius="sm"
 					>
-						<Group justify="space-between" wrap="nowrap" gap="xs">
-							<Stack gap={0} style={{ minWidth: 0 }}>
+						<Group wrap="nowrap" gap="xs">
+							<Stack gap={0} style={{ flex: 1, minWidth: 0 }}>
 								<Text size="sm" lineClamp={1}>
 									{row.email}
 								</Text>
@@ -79,6 +105,22 @@ export function InviteResultsList({ rows, "data-testid": dataTestId }: Props) {
 									</Text>
 								) : null}
 							</Stack>
+							{row.inviteUrl && (
+								<Tooltip label={t`Copy invite link`}>
+									<ActionIcon
+										size="sm"
+										variant="subtle"
+										onClick={() =>
+											copy(row.inviteUrl as string, row.workspaceId)
+										}
+										aria-label={t`Copy invite link`}
+										style={{ flexShrink: 0 }}
+										data-testid={`invite-result-copy-link-${idx}`}
+									>
+										<IconLink size={14} />
+									</ActionIcon>
+								</Tooltip>
+							)}
 							<Badge
 								size="sm"
 								variant="light"

--- a/echo/frontend/src/components/members/PendingInvitesSection.tsx
+++ b/echo/frontend/src/components/members/PendingInvitesSection.tsx
@@ -14,7 +14,8 @@ import {
 	Tooltip,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconRefresh, IconX } from "@tabler/icons-react";
+import { usePostHog } from "@posthog/react";
+import { IconLink, IconRefresh, IconX } from "@tabler/icons-react";
 import { useState } from "react";
 import { ConfirmModal } from "@/components/common/ConfirmModal";
 import { toast } from "@/components/common/Toaster";
@@ -55,6 +56,7 @@ export function PendingInvitesSection({ orgId, scope, workspaceId }: Props) {
 		orgId,
 		workspaceId: isWorkspaceScope ? workspaceId : undefined,
 	});
+	const posthog = usePostHog();
 
 	const [confirmOpened, { open: openConfirm, close: closeConfirm }] =
 		useDisclosure(false);
@@ -73,6 +75,20 @@ export function PendingInvitesSection({ orgId, scope, workspaceId }: Props) {
 		);
 	}
 	if (invites.length === 0) return null;
+
+	const handleCopyLink = (inv: PendingInvite) => {
+		if (!inv.invite_url) return;
+		void navigator.clipboard.writeText(inv.invite_url).then(
+			() => {
+				toast.success(t`Link copied`);
+				posthog?.capture("invite_link_copied", {
+					source: "pending_list",
+					type: inv.type,
+				});
+			},
+			() => toast.error(t`Couldn't copy the link.`),
+		);
+	};
 
 	const handleResend = (inv: PendingInvite) => {
 		resend.mutate(inv.id, {
@@ -145,6 +161,19 @@ export function PendingInvitesSection({ orgId, scope, workspaceId }: Props) {
 									<Badge size="xs" variant="light" color="yellow">
 										<Trans>Pending</Trans>
 									</Badge>
+									{inv.invite_url && (
+										<Tooltip label={t`Copy invite link`}>
+											<ActionIcon
+												size="sm"
+												variant="subtle"
+												onClick={() => handleCopyLink(inv)}
+												aria-label={t`Copy invite link`}
+												data-testid={`pending-invite-copy-link-${inv.id}`}
+											>
+												<IconLink size={14} />
+											</ActionIcon>
+										</Tooltip>
+									)}
 									<Tooltip label={t`Resend invite email`}>
 										<ActionIcon
 											size="sm"

--- a/echo/frontend/src/components/members/hooks/index.ts
+++ b/echo/frontend/src/components/members/hooks/index.ts
@@ -14,6 +14,7 @@ export interface PendingInvite {
 	invited_by_id: string | null;
 	invited_by_name: string | null;
 	invited_by_email: string | null;
+	invite_url: string | null;
 }
 
 const pendingInvitesKey = (orgId: string, workspaceId?: string) =>

--- a/echo/server/dembrane/api/v2/invites.py
+++ b/echo/server/dembrane/api/v2/invites.py
@@ -19,6 +19,7 @@ from dembrane.api.rate_limit import create_user_rate_limiter
 from dembrane.api.v2.schemas import WorkspaceInviteRequest, WorkspaceInviteResponse
 from dembrane.directus_async import async_directus
 from dembrane.api.v2.middleware import WorkspaceContext, get_workspace_context
+from dembrane.api.v2._invite_helpers import build_invite_accept_url
 
 router = APIRouter()
 logger = getLogger("api.v2.invites")
@@ -197,9 +198,7 @@ async def invite_to_workspace(
                 )
 
             # Net-new seat or reactivation of soft-deleted row: include pending invites in the cap.
-            await assert_can_add_seat(
-                ctx.workspace, audience="admin", include_pending=True
-            )
+            await assert_can_add_seat(ctx.workspace, audience="admin", include_pending=True)
 
             ws_org_id = ctx.workspace.get("org_id")
 
@@ -276,9 +275,7 @@ async def invite_to_workspace(
 
             await invalidate_workspace_and_org_usage(workspace_id, ws_org_id)
 
-            logger.info(
-                f"Added {email} to workspace {workspace_id} as {role} by {ctx.app_user_id}"
-            )
+            logger.info(f"Added {email} to workspace {workspace_id} as {role} by {ctx.app_user_id}")
 
             from dembrane.notifications import emit
 
@@ -376,6 +373,20 @@ async def invite_to_workspace(
     expires_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
 
     now_iso = datetime.now(timezone.utc).isoformat()
+    inviter_name = "Your organisation"
+    inviter_app_user_data = await async_directus.get_items(
+        "app_user",
+        {
+            "query": {
+                "filter": {"id": {"_eq": ctx.app_user_id}},
+                "fields": ["display_name"],
+                "limit": 1,
+            }
+        },
+    )
+    if isinstance(inviter_app_user_data, list) and len(inviter_app_user_data) > 0:
+        inviter_name = inviter_app_user_data[0].get("display_name") or "Your organisation"
+
     existing_invites = await async_directus.get_items(
         "workspace_invite",
         {
@@ -394,27 +405,24 @@ async def invite_to_workspace(
     )
 
     if isinstance(existing_invites, list) and len(existing_invites) > 0:
+        existing_id = existing_invites[0]["id"]
+        invite_url = build_invite_accept_url(
+            invite_type="workspace",
+            admin_base_url=settings.urls.admin_base_url,
+            hash_value=compute_invite_hash(existing_id),
+            inviter_name=inviter_name,
+            subject_name=ctx.workspace.get("name", ""),
+            role=role,
+            email=email,
+        )
         # 200 with status string so the modal renders this per-row rather than as a global failure.
         return WorkspaceInviteResponse(
             status="already_invited",
             email=email,
             user_existed=user_existed,
             email_sent=False,
+            invite_url=invite_url,
         )
-
-    inviter_name = "Your organisation"
-    inviter_app_user_data = await async_directus.get_items(
-        "app_user",
-        {
-            "query": {
-                "filter": {"id": {"_eq": ctx.app_user_id}},
-                "fields": ["display_name"],
-                "limit": 1,
-            }
-        },
-    )
-    if isinstance(inviter_app_user_data, list) and len(inviter_app_user_data) > 0:
-        inviter_name = inviter_app_user_data[0].get("display_name") or "Your organisation"
 
     invite_id = generate_uuid()
     await async_directus.create_item(
@@ -429,19 +437,16 @@ async def invite_to_workspace(
         },
     )
 
-    from urllib.parse import urlencode
-
     invite_hash = compute_invite_hash(invite_id)
-    ctx_params = urlencode(
-        {
-            "iss": inviter_name,
-            "ws": ctx.workspace.get("name", ""),
-            "role": role,
-            "email": email,
-            "h": invite_hash,
-        }
+    invite_url = build_invite_accept_url(
+        invite_type="workspace",
+        admin_base_url=settings.urls.admin_base_url,
+        hash_value=invite_hash,
+        inviter_name=inviter_name,
+        subject_name=ctx.workspace.get("name", ""),
+        role=role,
+        email=email,
     )
-    invite_url = f"{settings.urls.admin_base_url}/invite/accept?{ctx_params}"
 
     email_queued = _enqueue_invite_email(
         to=email,
@@ -465,4 +470,5 @@ async def invite_to_workspace(
         email=email,
         user_existed=user_existed,
         email_sent=email_queued,
+        invite_url=invite_url,
     )

--- a/echo/server/dembrane/api/v2/orgs.py
+++ b/echo/server/dembrane/api/v2/orgs.py
@@ -45,6 +45,7 @@ from dembrane.api.rate_limit import create_user_rate_limiter
 from dembrane.api.v2.invites import compute_invite_hash, _enqueue_invite_email
 from dembrane.directus_async import async_directus
 from dembrane.api.dependency_auth import DependencyDirectusSession
+from dembrane.api.v2._invite_helpers import build_invite_accept_url
 
 # Only http/https logos allowed — blocks javascript:/data: URIs. Shared
 # logic lives in workspace_settings; duplicated here to avoid a cross-router
@@ -156,6 +157,7 @@ class InviteToOrganisationResponse(BaseModel):
     email: str
     user_existed: bool
     email_sent: bool = True
+    invite_url: Optional[str] = None  # present only for invited / already_invited
 
 
 class ChangeMemberRoleRequest(BaseModel):
@@ -800,6 +802,7 @@ class OrgPendingInviteResponse(BaseModel):
     invited_by_id: Optional[str] = None
     invited_by_name: Optional[str] = None
     invited_by_email: Optional[str] = None
+    invite_url: Optional[str] = None
 
 
 @router.get("/{org_id}/pending-invites", response_model=list[OrgPendingInviteResponse])
@@ -942,6 +945,11 @@ async def list_org_pending_invites(
         if isinstance(inviter_rows, list):
             inviter_map = {u["id"]: u for u in inviter_rows if u.get("id")}
 
+    org_name = "your organisation"
+    if include_org_invites:
+        org_row = await async_directus.get_item("org", org_id)
+        org_name = (org_row or {}).get("name") or "your organisation"
+
     def _inviter_fields(inv: dict) -> dict:
         info = inviter_map.get(inv.get("invited_by") or "", {})
         return {
@@ -949,6 +957,19 @@ async def list_org_pending_invites(
             "invited_by_name": (info.get("display_name") or None) if info else None,
             "invited_by_email": (info.get("email") or None) if info else None,
         }
+
+    def _invite_url_for(inv: dict, invite_type: str, subject_name: str) -> str:
+        info = inviter_map.get(inv.get("invited_by") or "", {})
+        inviter_name = (info.get("display_name") if info else None) or "Your organisation"
+        return build_invite_accept_url(
+            invite_type=invite_type,  # type: ignore[arg-type]
+            admin_base_url=get_settings().urls.admin_base_url,
+            hash_value=compute_invite_hash(inv["id"]),
+            inviter_name=inviter_name,
+            subject_name=subject_name,
+            role=inv.get("role", "member"),
+            email=inv.get("email", ""),
+        )
 
     org_rows = [
         OrgPendingInviteResponse(
@@ -960,6 +981,7 @@ async def list_org_pending_invites(
             workspace_name=None,
             created_at=inv.get("created_at"),
             expires_at=inv.get("expires_at"),
+            invite_url=_invite_url_for(inv, "org", org_name),
             **_inviter_fields(inv),
         )
         for inv in org_invites
@@ -974,6 +996,9 @@ async def list_org_pending_invites(
             workspace_name=ws_name_map.get(inv.get("workspace_id") or "", ""),
             created_at=inv.get("created_at"),
             expires_at=inv.get("expires_at"),
+            invite_url=_invite_url_for(
+                inv, "workspace", ws_name_map.get(inv.get("workspace_id") or "", "")
+            ),
             **_inviter_fields(inv),
         )
         for inv in workspace_invites
@@ -981,7 +1006,7 @@ async def list_org_pending_invites(
 
     # Merge-sort by created_at DESC; null created_at goes last.
     combined = org_rows + ws_rows_out
-    combined.sort(key=lambda r: (r.created_at or ""), reverse=True)
+    combined.sort(key=lambda r: r.created_at or "", reverse=True)
     return combined
 
 
@@ -1181,12 +1206,23 @@ async def invite_to_organisation(
         },
     )
     if isinstance(existing_invites, list) and len(existing_invites) > 0:
+        existing_id = existing_invites[0]["id"]
+        invite_url = build_invite_accept_url(
+            invite_type="org",
+            admin_base_url=settings.urls.admin_base_url,
+            hash_value=compute_invite_hash(existing_id),
+            inviter_name=inviter_name,
+            subject_name=org_name,
+            role=role,
+            email=email,
+        )
         # 200 with status string so the modal renders this per-row rather than as a global failure.
         return InviteToOrganisationResponse(
             status="already_invited",
             email=email,
             user_existed=user_existed,
             email_sent=False,
+            invite_url=invite_url,
         )
 
     invite_id = generate_uuid()
@@ -1206,19 +1242,16 @@ async def invite_to_organisation(
         },
     )
 
-    from urllib.parse import urlencode
-
     invite_hash = compute_invite_hash(invite_id)
-    ctx_params = urlencode(
-        {
-            "iss": inviter_name,
-            "org": org_name,
-            "role": role,
-            "email": email,
-            "h": invite_hash,
-        }
+    invite_url = build_invite_accept_url(
+        invite_type="org",
+        admin_base_url=settings.urls.admin_base_url,
+        hash_value=invite_hash,
+        inviter_name=inviter_name,
+        subject_name=org_name,
+        role=role,
+        email=email,
     )
-    invite_url = f"{settings.urls.admin_base_url}/invite/accept?{ctx_params}"
 
     email_queued = _enqueue_invite_email(
         to=email,
@@ -1243,6 +1276,7 @@ async def invite_to_organisation(
         email=email,
         user_existed=user_existed,
         email_sent=email_queued,
+        invite_url=invite_url,
     )
 
 
@@ -1426,9 +1460,7 @@ async def _get_org_workspace_pinned(
     if not isinstance(rows, list):
         return []
     return [
-        OrgWorkspacePinnedProject(id=r["id"], name=r.get("name") or "")
-        for r in rows
-        if r.get("id")
+        OrgWorkspacePinnedProject(id=r["id"], name=r.get("name") or "") for r in rows if r.get("id")
     ]
 
 

--- a/echo/server/dembrane/api/v2/schemas.py
+++ b/echo/server/dembrane/api/v2/schemas.py
@@ -205,6 +205,7 @@ class WorkspaceInviteResponse(BaseModel):
     email: str
     user_existed: bool
     email_sent: bool = True  # False if SendGrid failed or was not configured
+    invite_url: Optional[str] = None  # present only for invited / already_invited
 
 
 # ── /v2/projects/:id/move ──

--- a/echo/server/tests/test_org_invite_endpoint.py
+++ b/echo/server/tests/test_org_invite_endpoint.py
@@ -46,9 +46,7 @@ def _noop_rate_limiter() -> AsyncMock:
 
 @pytest.fixture(autouse=True)
 def _patch_rate_limiter():
-    with patch(
-        "dembrane.api.v2.orgs._org_invite_rate_limiter", _noop_rate_limiter()
-    ):
+    with patch("dembrane.api.v2.orgs._org_invite_rate_limiter", _noop_rate_limiter()):
         yield
 
 
@@ -78,9 +76,7 @@ def _make_directus_mock(
       7. org_invite (existing pending)
     """
     mock = AsyncMock()
-    mock.get_item = AsyncMock(
-        side_effect=lambda col, _id: _ORG_ROW if col == "org" else None
-    )
+    mock.get_item = AsyncMock(side_effect=lambda col, _id: _ORG_ROW if col == "org" else None)
 
     call_state = {"org_membership_call": 0}
 
@@ -136,9 +132,7 @@ async def test_invite_new_user_creates_org_invite_row():
         patch("dembrane.api.v2.orgs.resolve_app_user", return_value=None),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "newbie@example.com", "role": "member"},
@@ -153,12 +147,21 @@ async def test_invite_new_user_creates_org_invite_row():
     creates = [c.args for c in mock.create_item.call_args_list]
     collections_created = [c[0] for c in creates]
     assert "org_invite" in collections_created
-    org_invite_payload = next(
-        c[1] for c in creates if c[0] == "org_invite"
-    )
+    org_invite_payload = next(c[1] for c in creates if c[0] == "org_invite")
     assert org_invite_payload["org_id"] == _ORG_ID
     assert org_invite_payload["email"] == "newbie@example.com"
     assert org_invite_payload["role"] == "member"
+
+    from urllib.parse import parse_qs, urlparse
+
+    from dembrane.api.v2.invites import compute_invite_hash
+
+    assert body["invite_url"]
+    assert "/invite/accept" in body["invite_url"]
+    created_invite_id = org_invite_payload["id"]
+    parsed = parse_qs(urlparse(body["invite_url"]).query)
+    assert parsed["h"][0] == compute_invite_hash(created_invite_id)
+    assert parsed["org"][0] == "Acme Org"
 
 
 @pytest.mark.asyncio
@@ -173,9 +176,7 @@ async def test_invite_existing_user_not_in_org_creates_org_membership():
     with (
         patch("dembrane.api.v2.orgs.async_directus", mock),
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
-        patch(
-            "dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user
-        ),
+        patch("dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user),
         patch("dembrane.notifications.emit_to_audience", new_callable=AsyncMock),
         patch(
             "dembrane.notifications.audience_organisation_admins",
@@ -184,9 +185,7 @@ async def test_invite_existing_user_not_in_org_creates_org_membership():
         ),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "bob@example.com", "role": "member"},
@@ -197,9 +196,7 @@ async def test_invite_existing_user_not_in_org_creates_org_membership():
     assert body["status"] == "added"
     assert body["user_existed"] is True
 
-    om_creates = [
-        c.args for c in mock.create_item.call_args_list if c.args[0] == "org_membership"
-    ]
+    om_creates = [c.args for c in mock.create_item.call_args_list if c.args[0] == "org_membership"]
     assert len(om_creates) == 1
     payload = om_creates[0][1]
     assert payload["org_id"] == _ORG_ID
@@ -215,25 +212,17 @@ async def test_invite_existing_member_is_idempotent_no_email():
 
     mock = _make_directus_mock(
         invitee_directus_user=invitee_directus,
-        existing_org_membership=[
-            {"id": "om-1", "role": "member", "deleted_at": None}
-        ],
+        existing_org_membership=[{"id": "om-1", "role": "member", "deleted_at": None}],
     )
 
     with (
         patch("dembrane.api.v2.orgs.async_directus", mock),
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
-        patch(
-            "dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user
-        ),
-        patch(
-            "dembrane.api.v2.orgs._enqueue_invite_email", return_value=True
-        ) as enqueue_mock,
+        patch("dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user),
+        patch("dembrane.api.v2.orgs._enqueue_invite_email", return_value=True) as enqueue_mock,
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "carol@example.com", "role": "admin"},
@@ -263,14 +252,10 @@ async def test_invite_reactivates_soft_deleted_org_membership():
     with (
         patch("dembrane.api.v2.orgs.async_directus", mock),
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
-        patch(
-            "dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user
-        ),
+        patch("dembrane.api.v2.orgs.resolve_app_user", return_value=invitee_app_user),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "dave@example.com", "role": "admin"},
@@ -299,9 +284,7 @@ async def test_invite_rejects_role_escalation_above_caller_level():
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "claimer@example.com", "role": "owner"},
@@ -321,9 +304,7 @@ async def test_invite_rejects_non_admin_caller():
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "x@example.com", "role": "member"},
@@ -342,9 +323,7 @@ async def test_invite_blocks_self_invite():
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": _APP_USER["email"], "role": "member"},
@@ -369,9 +348,7 @@ async def test_invite_is_idempotent_when_pending_invite_exists():
         patch("dembrane.api.v2.orgs.resolve_app_user", return_value=None),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "ghost@example.com", "role": "member"},
@@ -382,9 +359,7 @@ async def test_invite_is_idempotent_when_pending_invite_exists():
     assert body["status"] == "already_invited"
     assert body["email_sent"] is False
     # No new org_invite row should have been created on the idempotent path.
-    create_calls = [
-        c.args for c in mock.create_item.call_args_list if c.args[0] == "org_invite"
-    ]
+    create_calls = [c.args for c in mock.create_item.call_args_list if c.args[0] == "org_invite"]
     assert not create_calls
 
 
@@ -406,9 +381,7 @@ async def test_invite_rate_limit_returns_429():
         patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
     ):
         app = _build_app()
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.post(
                 f"/v2/orgs/{_ORG_ID}/invites",
                 json={"email": "y@example.com", "role": "member"},

--- a/echo/server/tests/test_pending_invites_listing.py
+++ b/echo/server/tests/test_pending_invites_listing.py
@@ -53,9 +53,7 @@ def _make_directus_mock(
         if collection == "workspace_invite":
             # honor _in filter on workspace_id so the ?workspace_id= path
             # test can isolate a single workspace's rows.
-            wid_filter = (
-                params.get("query", {}).get("filter", {}).get("workspace_id", {})
-            )
+            wid_filter = params.get("query", {}).get("filter", {}).get("workspace_id", {})
             wanted = set(wid_filter.get("_in", []))
             base = workspace_invites or []
             if wanted:
@@ -239,6 +237,62 @@ async def test_empty_when_no_invites():
 
 
 @pytest.mark.asyncio
+async def test_rows_include_invite_url_with_matching_hash():
+    """Every row carries an invite_url whose h param equals
+    compute_invite_hash(row id), for both org and workspace rows."""
+    from urllib.parse import parse_qs, urlparse
+
+    from dembrane.api.v2.invites import compute_invite_hash
+
+    org_inv = {
+        "id": "oi-1",
+        "email": "a@x.com",
+        "role": "member",
+        "created_at": "2026-05-01T10:00:00Z",
+        "expires_at": "2026-05-08T10:00:00Z",
+        "invited_by": _APP_USER_ID,
+    }
+    ws_inv = {
+        "id": "wi-1",
+        "email": "b@x.com",
+        "role": "admin",
+        "workspace_id": "ws-a",
+        "created_at": "2026-05-02T10:00:00Z",
+        "expires_at": "2026-05-09T10:00:00Z",
+        "invited_by": _APP_USER_ID,
+    }
+    mock = _make_directus_mock(
+        org_invites=[org_inv],
+        workspace_invites=[ws_inv],
+        inviters=[{"id": _APP_USER_ID, "display_name": "Org Admin", "email": "admin@example.com"}],
+    )
+    mock.get_item = AsyncMock(
+        side_effect=lambda col, _id: {"id": _ORG_ID, "name": "Acme Org"} if col == "org" else None
+    )
+
+    with (
+        patch("dembrane.api.v2.orgs.async_directus", mock),
+        patch("dembrane.api.v2.orgs.get_app_user_or_raise", return_value=_APP_USER),
+    ):
+        app = _build_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get(f"/v2/orgs/{_ORG_ID}/pending-invites")
+
+    assert resp.status_code == 200, resp.text
+    by_id = {r["id"]: r for r in resp.json()}
+
+    ws_url = by_id["wi-1"]["invite_url"]
+    assert "/invite/accept" in ws_url
+    assert parse_qs(urlparse(ws_url).query)["h"][0] == compute_invite_hash("wi-1")
+    assert parse_qs(urlparse(ws_url).query)["ws"][0] == "Alpha"
+
+    org_url = by_id["oi-1"]["invite_url"]
+    assert "/invite/accept" in org_url
+    assert parse_qs(urlparse(org_url).query)["h"][0] == compute_invite_hash("oi-1")
+    assert parse_qs(urlparse(org_url).query)["org"][0] == "Acme Org"
+
+
+@pytest.mark.asyncio
 async def test_query_excludes_soft_deleted_expired_and_accepted_rows():
     """Pin the filter contract: both invite tables must be queried with
     accepted_at:_null, deleted_at:_null, and expires_at:_gt:now. If
@@ -273,6 +327,5 @@ async def test_query_excludes_soft_deleted_expired_and_accepted_rows():
             f"invites would leak (security regression)"
         )
         assert "_gt" in f.get("expires_at", {}), (
-            f"{collection} query is missing expires_at:_gt filter — "
-            f"expired invites would leak"
+            f"{collection} query is missing expires_at:_gt filter — expired invites would leak"
         )

--- a/echo/server/tests/test_workspace_invite_endpoint.py
+++ b/echo/server/tests/test_workspace_invite_endpoint.py
@@ -121,6 +121,7 @@ def _build_directus_mock(
     invitee_directus_user: dict[str, Any] | None,
     existing_workspace_membership: list[dict[str, Any]] | None = None,
     existing_org_membership_for_invitee: list[dict[str, Any]] | None = None,
+    existing_workspace_invite: list[dict[str, Any]] | None = None,
 ) -> AsyncMock:
     """Mock async_directus for the workspace invite codepath.
 
@@ -139,6 +140,9 @@ def _build_directus_mock(
 
     workspace_membership_rows = existing_workspace_membership or []
     org_membership_rows = existing_org_membership_for_invitee or []
+    workspace_invite_rows = (
+        existing_workspace_invite if existing_workspace_invite is not None else []
+    )
 
     async def _fake_get_items(collection: str, _params: dict) -> Any:
         if collection == "app_user":
@@ -154,7 +158,7 @@ def _build_directus_mock(
         if collection == "org_membership":
             return org_membership_rows
         if collection == "workspace_invite":
-            return []
+            return workspace_invite_rows
         return []
 
     mock.get_items = AsyncMock(side_effect=_fake_get_items)
@@ -217,6 +221,7 @@ async def test_reinvite_existing_member_returns_already_member_no_email():
     # No state changes on the idempotent path.
     mock.create_item.assert_not_called()
     mock.update_item.assert_not_called()
+    assert body.get("invite_url") is None
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -431,11 +436,13 @@ async def test_revoked_invite_does_not_block_reinvite():
     mock.get_items = AsyncMock(side_effect=_fake_get_items)
     mock.get_users = AsyncMock(return_value=[])  # net-new path: no Directus user
     mock.get_item = AsyncMock(
-        side_effect=lambda col, _id: {"id": _APP_USER_ID, "display_name": "WS Admin"}
-        if col == "app_user"
-        else {"id": _ORG_ID, "name": "Acme"}
-        if col == "org"
-        else None
+        side_effect=lambda col, _id: (
+            {"id": _APP_USER_ID, "display_name": "WS Admin"}
+            if col == "app_user"
+            else {"id": _ORG_ID, "name": "Acme"}
+            if col == "org"
+            else None
+        )
     )
     mock.create_item = AsyncMock(return_value={"data": {"id": "new-id"}})
     mock.update_item = AsyncMock(return_value={"data": {}})
@@ -460,9 +467,7 @@ async def test_revoked_invite_does_not_block_reinvite():
     # Pin the filter so a future refactor that drops deleted_at:_null
     # from the live-row predicate fails this test instead of silently
     # re-introducing the regression.
-    live_filters = [
-        f for f in seen_filters if "accepted_at" in f and "expires_at" in f
-    ]
+    live_filters = [f for f in seen_filters if "accepted_at" in f and "expires_at" in f]
     assert live_filters, "Expected a live-invite filter on workspace_invite"
     assert live_filters[0].get("deleted_at") == {"_null": True}, (
         "workspace_invite live-row filter must include deleted_at:_null "
@@ -471,3 +476,87 @@ async def test_revoked_invite_does_not_block_reinvite():
 
     creates = [c.args[0] for c in mock.create_item.call_args_list]
     assert "workspace_invite" in creates
+
+
+@pytest.mark.asyncio
+async def test_new_invitee_returns_invite_url_with_valid_hash():
+    """Inviting a brand-new email creates a workspace_invite and the
+    response carries invite_url whose h matches compute_invite_hash."""
+    from urllib.parse import parse_qs, urlparse
+
+    from dembrane.api.v2.invites import compute_invite_hash
+
+    mock = _build_directus_mock(invitee_directus_user=None)
+
+    with (
+        patch("dembrane.api.v2.invites.async_directus", mock),
+        patch("dembrane.api.v2.invites.resolve_app_user", return_value=None),
+        patch("dembrane.api.v2.invites._enqueue_invite_email", return_value=True),
+    ):
+        app = _build_app(_make_ctx())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"/v2/workspaces/{_WORKSPACE_ID}/invite",
+                json={"email": "new@example.com", "role": "member"},
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "invited"
+    assert body["invite_url"]
+    assert "/invite/accept" in body["invite_url"]
+
+    created = next(
+        c.args for c in mock.create_item.call_args_list if c.args[0] == "workspace_invite"
+    )
+    created_id = created[1]["id"]
+    parsed = parse_qs(urlparse(body["invite_url"]).query)
+    assert parsed["h"][0] == compute_invite_hash(created_id)
+    assert parsed["email"][0] == "new@example.com"
+
+
+# ────────────────────────────────────────────────────────────────────
+# already_invited branch: existing pending invite returns invite_url
+# ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_already_invited_returns_invite_url_with_valid_hash():
+    """Inviting a brand-new email when a pending workspace_invite already
+    exists returns status='already_invited' with an invite_url whose h
+    param matches compute_invite_hash of the existing invite id."""
+    from urllib.parse import parse_qs, urlparse
+
+    from dembrane.api.v2.invites import compute_invite_hash
+
+    _EXISTING_INVITE_ID = "existing-wi-1"
+
+    mock = _build_directus_mock(
+        invitee_directus_user=None,
+        existing_workspace_invite=[{"id": _EXISTING_INVITE_ID}],
+    )
+
+    with (
+        patch("dembrane.api.v2.invites.async_directus", mock),
+        patch("dembrane.api.v2.invites.resolve_app_user", return_value=None),
+        patch("dembrane.api.v2.invites._enqueue_invite_email", return_value=True),
+    ):
+        app = _build_app(_make_ctx())
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                f"/v2/workspaces/{_WORKSPACE_ID}/invite",
+                json={"email": "pending@example.com", "role": "member"},
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "already_invited"
+    assert body["invite_url"], "invite_url must be present on already_invited"
+    assert "/invite/accept" in body["invite_url"]
+
+    parsed = parse_qs(urlparse(body["invite_url"]).query)
+    assert parsed["h"][0] == compute_invite_hash(_EXISTING_INVITE_ID)
+
+    # No new workspace_invite row should be created on this path.
+    creates = [c.args[0] for c in mock.create_item.call_args_list]
+    assert "workspace_invite" not in creates


### PR DESCRIPTION
Invite emails can silently fail to arrive (e.g. strict networks blocking the message), which blocks onboarding. Admins can now copy the invite acceptance link and deliver it through another channel.

  Backend: return `invite_url` on the workspace and org invite-create
  responses (for invited/already_invited) and on every pending-invites
  list row, built from the existing HMAC via build_invite_accept_url.
  Direct-add statuses stay null. The acceptance flow is unchanged, so
  the link is still email-validated on accept.

  Frontend: add a "Copy link" action to pending-invite rows and to the
  invite modal results, with an invite_link_copied analytics event.