### PR TITLE
  fix(onboarding): stop questionnaire reappearing after skip

### DIFF
--- a/echo/frontend/src/routes/onboarding/OnboardingRoute.tsx
+++ b/echo/frontend/src/routes/onboarding/OnboardingRoute.tsx
@@ -249,27 +249,27 @@ export const OnboardingRoute = () => {
 	};
 
 	// ISSUE-012: persist the questionnaire answers, then route to /o. Required
-	// but non-blocking — on a skip we still route on, and a submit failure
-	// must not trap the user on this screen.
+	// but non-blocking — a submit failure must not trap the user on this screen.
+	// A skip persists too (skipped=true): the login gate re-nudges anyone with
+	// no onboarding_answer_json, so a skip that wrote nothing looped every login.
 	const submitAnswers = async (skip: boolean) => {
-		if (!skip) {
-			setSubmittingAnswers(true);
-			try {
-				await fetch(`${API_BASE_URL}/v2/onboarding/answers`, {
-					body: JSON.stringify({
-						data: [{ q1 }, { q2: q2 ?? "" }, { q3: q3 ?? "" }],
-						version: "17-jun-26",
-					}),
-					credentials: "include",
-					headers: { "Content-Type": "application/json" },
-					method: "POST",
-				});
-				queryClient.invalidateQueries({ queryKey: ["v2", "me"] });
-			} catch {
-				// Non-blocking: never trap the user. They reach /o regardless.
-			} finally {
-				setSubmittingAnswers(false);
-			}
+		setSubmittingAnswers(true);
+		try {
+			await fetch(`${API_BASE_URL}/v2/onboarding/answers`, {
+				body: JSON.stringify({
+					data: skip ? [] : [{ q1 }, { q2: q2 ?? "" }, { q3: q3 ?? "" }],
+					skipped: skip,
+					version: "17-jun-26",
+				}),
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+			});
+			queryClient.invalidateQueries({ queryKey: ["v2", "me"] });
+		} catch {
+			// Non-blocking: never trap the user. They reach /o regardless.
+		} finally {
+			setSubmittingAnswers(false);
 		}
 		goToHome();
 	};
@@ -510,6 +510,7 @@ export const OnboardingRoute = () => {
 							<Button
 								size="md"
 								variant="subtle"
+								disabled={submittingAnswers}
 								onClick={() => submitAnswers(true)}
 							>
 								<Trans>Skip</Trans>

--- a/echo/server/dembrane/api/v2/onboarding.py
+++ b/echo/server/dembrane/api/v2/onboarding.py
@@ -747,7 +747,11 @@ async def submit_onboarding_answers(
     app_user = await get_app_user_or_raise(auth.user_id)
     app_user_id = app_user["id"]
 
-    onboarding_answer_json = {"version": body.version, "data": body.data}
+    onboarding_answer_json = {
+        "version": body.version,
+        "data": body.data,
+        "skipped": body.skipped,
+    }
 
     await async_directus.update_item(
         "app_user",
@@ -769,6 +773,7 @@ async def submit_onboarding_answers(
             properties={
                 "version": body.version,
                 "answers": body.data,
+                "skipped": body.skipped,
                 "wants_partner_review": wants_partner_review,
                 "is_high_risk": is_high_risk,
                 "training_status": training_status,
@@ -778,8 +783,11 @@ async def submit_onboarding_answers(
         logger.exception("PostHog mirror failed for onboarding answers")
 
     # ── Staff follow-up (in-app + email) ──
-    # Best-effort: a notify failure must never fail the answer write.
-    if wants_partner_review or is_high_risk or training_status is not None:
+    # Best-effort: a notify failure must never fail the answer write. A skip
+    # carries no answers, so nothing to follow up on.
+    if not body.skipped and (
+        wants_partner_review or is_high_risk or training_status is not None
+    ):
         try:
             await _notify_staff_onboarding_followup(
                 app_user=app_user,

--- a/echo/server/dembrane/api/v2/schemas.py
+++ b/echo/server/dembrane/api/v2/schemas.py
@@ -80,6 +80,9 @@ class OnboardingAnswersRequest(BaseModel):
     # Free-form per-question answers. Stored verbatim under the `data` key.
     # Known keys today: q1 (use context), q2 (high-risk yes/no), q3 (training).
     data: list[dict[str, Any]] = Field(default_factory=list)
+    # User dismissed the questionnaire. Still persisted (with no answers) so the
+    # login gate stops re-nudging them; never triggers staff follow-up.
+    skipped: bool = False
 
 
 class OnboardingAnswersResponse(BaseModel):

--- a/echo/server/tests/test_onboarding.py
+++ b/echo/server/tests/test_onboarding.py
@@ -399,6 +399,49 @@ async def test_submit_answers_high_risk_notifies_staff():
 
 
 @pytest.mark.asyncio
+async def test_skip_persists_marker_and_skips_staff_notify():
+    """A skip still writes onboarding_answer_json (with skipped=true) so the
+    login gate stops re-nudging, and never fires the staff follow-up."""
+    mock_directus = _mock_async_directus()
+    update_log: list[tuple[str, str, dict]] = []
+
+    async def _track_update(collection: str, item_id: str, payload: dict):
+        update_log.append((collection, item_id, payload))
+        return {"data": {}}
+
+    mock_directus.update_item = AsyncMock(side_effect=_track_update)
+    notify_mock = AsyncMock()
+
+    with (
+        patch("dembrane.api.v2.onboarding.async_directus", mock_directus),
+        patch("dembrane.api.v2.onboarding.get_app_user_or_raise", return_value=_APP_USER),
+        patch("dembrane.analytics.capture_event", new_callable=AsyncMock),
+        patch(
+            "dembrane.api.v2.onboarding._notify_staff_onboarding_followup",
+            notify_mock,
+        ),
+    ):
+        app = _build_answers_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/v2/onboarding/answers",
+                json={"version": "17-jun-26", "data": [], "skipped": True},
+            )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # onboarding_answer_json is now truthy → login gate won't re-nudge.
+    assert body["onboarding_answer_json"]["skipped"] is True
+    answer_updates = [
+        u for u in update_log if u[0] == "app_user" and "onboarding_answer_json" in u[2]
+    ]
+    assert len(answer_updates) == 1
+    assert answer_updates[0][2]["onboarding_answer_json"]["skipped"] is True
+    # A skip carries no answers → no staff follow-up.
+    notify_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_notify_staff_emits_and_emails():
     """The staff follow-up helper fans an in-app row to staff and emails the
     training owner."""


### PR DESCRIPTION
  The login gate routes users to /onboarding when onboarding_completed is
  true but onboarding_answer_json is null. Skipping the questionnaire wrote
  nothing, so the column stayed null and the "About you" step reappeared on
  every login — most visible for external/billing users, who tend to skip.

  Skip now persists onboarding_answer_json with skipped=true (and no answers),
  which clears the gate. The skip is mirrored to PostHog and never fires the
  staff follow-up, since it carries no answers. Stored as a key in the existing
  json column, so no Directus schema change.