### PR TITLE
chore(billing): monthly surcharge 20% -> 15%

### DIFF
--- a/echo/docs/adr/0005-per-seat-tier-overhaul.md
+++ b/echo/docs/adr/0005-per-seat-tier-overhaul.md
@@ -33,7 +33,7 @@ We are simplifying to per-seat pricing, removing hour caps on paid tiers, and re
   | White labeling | — | — | ✓ | ✓ |
   | EU-sovereign stack (OVH, sovereign LLMs) | — | — | — | ✓ |
 
-- **Pricing is per seat / month, EUR for all tiers**, billed yearly by default; monthly is 20% more. `MONTHLY_BILLING_PREMIUM_PCT` becomes 20 (was 10 in ADR 0002). Figures: Innovator €20, Changemaker €75, Guardian €150.
+- **Pricing is per seat / month, EUR for all tiers**, billed yearly by default; monthly is 15% more. `MONTHLY_BILLING_PREMIUM_PCT` is 15 (2026-06-21; was 20, and 10 in ADR 0002). Figures: Innovator €20, Changemaker €75, Guardian €150.
 
 - **Hours stop being a paid-tier lever.** All paid tiers have unlimited recording and transcription under fair use (fair use = a legitimate purpose). Only Free keeps an hour cap (1 hour). The per-tier `included_hours` / `hour_overage_eur` matrix fields and the over-cap machinery from ADR 0001 apply to Free only.
 
@@ -55,7 +55,7 @@ We are simplifying to per-seat pricing, removing hour caps on paid tiers, and re
 
 - **ADR 0001 reduces to Free-only.** The `is_over_cap` stamp, `task_stamp_conversation_on_finish`, live-lock computation, and hour overage now only ever matter on Free. The paid-tier branches of that logic are dead and should be removed, not left dormant.
 
-- **ADR 0002 is amended.** The monthly premium constant becomes 20, and the `pricing` object becomes per-seat. The annual/monthly toggle and the proposed/approved billing-period capture on `workspace_request` are unchanged in shape.
+- **ADR 0002 is amended.** The monthly premium constant is 15 (2026-06-21; initially 20 under this ADR), and the `pricing` object becomes per-seat. The annual/monthly toggle and the proposed/approved billing-period capture on `workspace_request` are unchanged in shape.
 
 - **ADR 0004's invite modal stops blocking.** The hard-disable of workspace rows on hard-block tiers and the soft-cap overage warning both go away; the modal shows a metered seat count and never prevents an invite.
 

--- a/echo/docs/plans/billing-account-split.md
+++ b/echo/docs/plans/billing-account-split.md
@@ -98,7 +98,7 @@ Ship Model A first. It lets us extract the entity, move the writes, and wire Mol
 
 The current matrix splits by compliance context. Customer research says the valued things are: EU hosting and the security that implies, reduced admin burden (we help them run events, produce trainings, use the tool well, reach their goals), and that the product is a genuine time-saver. The pricing pain points: getting started was expensive (a usable single-user setup on Pioneer was about €200/mo), and every tier capped hours. The hour cap was originally a proxy for chat/analysis context cost, not for recording or transcription, which are cheap. Combined with EU AI Act high-risk concerns across much of the customer base, the model was hard to start with. The new direction simplifies and lowers the entry price.
 
-### New tiers (all prices billed yearly; monthly is 20% more)
+### New tiers (all prices billed yearly; monthly is 15% more)
 
 - **Free** (unchanged): 1 hour of recording, single user, open registration.
 - **Innovator** (coming soon): $20 per seat / month. No built-in analysis. Chat and analysis are bring-your-own: connect ChatGPT or Claude through an MCP we will release.
@@ -111,7 +111,7 @@ The current matrix splits by compliance context. Customer research says the valu
 - **Pricing is per seat, not a flat tier price.** This fits the pooled account model directly: the pool is seats. The account's seat count sums across its covered workspaces, and billing is seat_count times the tier's per-seat price.
 - **Hours stop being a paid-tier lever.** All paid tiers have unlimited recording and transcription under fair use (fair use = a legitimate purpose). Only Free keeps an hour cap (1 hour). The over-cap machinery (ADR 0001, `is_over_cap` stamping, hour overage in `tier_capacity.py`) collapses to a Free-tier-only check.
 - **Tier now encodes analysis capability and compliance level, not capacity.** Innovator has no built-in analysis. Changemaker includes EU Gemini analysis. Guardian is the sovereign EU stack. This introduces an analysis/chat feature gate keyed on tier (changemaker and above) in `policies.py`.
-- **Monthly premium is 20%** (`MONTHLY_BILLING_PREMIUM_PCT` was 10 per ADR 0002, becomes 20).
+- **Monthly premium is 15%** (`MONTHLY_BILLING_PREMIUM_PCT`; 10 per ADR 0002, then 20, now 15 as of 2026-06-21).
 - **Pilot and Pioneer are removed.** The `tier` enum and all copy shrink to free / innovator / changemaker / guardian.
 
 ### Migration
@@ -235,7 +235,7 @@ The work order is deliberate: build the billing-account entity first, then its U
 - **Phase 2: UX flows for the billing account.** Attach a billing account to an org or a workspace, re-point workspaces (the partner/handoff flow), org-scoped pooled seat metering and usage views, billing surfaces that follow the account's scope. Seats metered and shown, never blocked.
 - **Phase 3: Mollie and payments.** Customer per account, subscription per tier with seat quantity, webhook endpoint, payment-method and invoice surfaces. This is where we settle who pays, how, the admin overrides (for example provisioning seats on an offline/invoice sale), and the visibility rules (who sees invoices and payment, via the existing `billing`/`admin`/`owner` roles).
 
-The pricing overhaul (new tiers, EUR per-seat, +20% monthly, drop Pilot/Pioneer, hours-to-fair-use, analysis-as-integration, migrate existing customers to Changemaker) is a parallel track that lands on top of the account once Phase 1 exists. It is large enough to warrant its own ADR; this plan depends on it but does not block on it for Phase 1, since Phase 1 preserves the current tiers.
+The pricing overhaul (new tiers, EUR per-seat, +15% monthly, drop Pilot/Pioneer, hours-to-fair-use, analysis-as-integration, migrate existing customers to Changemaker) is a parallel track that lands on top of the account once Phase 1 exists. It is large enough to warrant its own ADR; this plan depends on it but does not block on it for Phase 1, since Phase 1 preserves the current tiers.
 
 ## Open questions
 

--- a/echo/docs/plans/self-serve-billing-and-payments.md
+++ b/echo/docs/plans/self-serve-billing-and-payments.md
@@ -45,7 +45,7 @@ Unchanged in spirit: a new user gets a personal org + a default workspace on a
      then checkout starts for the upgrade (see below). The workspace is never
      blocked from existing while payment is pending.
    - **Coming-soon / bespoke** -> "contact sales", no checkout.
-3. Billing period: annual (default) or monthly (+20%). Price shown = seats x
+3. Billing period: annual (default) or monthly (+15%). Price shown = seats x
    per-seat. At creation seats = 1 (the creator); seats meter up as members are
    invited.
 4. **Mollie hosted checkout** (test mode first): redirect, pay.

--- a/echo/frontend/src/lib/tiers.ts
+++ b/echo/frontend/src/lib/tiers.ts
@@ -87,7 +87,7 @@ export const SELLABLE_TIER: Tier = "changemaker";
 // ("X% off when you pay annually"). Single knob — mirrors
 // MONTHLY_BILLING_PREMIUM_PCT in server/dembrane/tier_capacity.py. Change both
 // together. Drives the toggle badge + the offline price fallback.
-export const MONTHLY_BILLING_PREMIUM_PCT = 20;
+export const MONTHLY_BILLING_PREMIUM_PCT = 15;
 
 // Single source for the offline/fallback per-seat annual price (EUR/seat/mo).
 // Mirrors price_eur_monthly in server/dembrane/tier_capacity.py; the live price

--- a/echo/server/dembrane/tier_capacity.py
+++ b/echo/server/dembrane/tier_capacity.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 # `price_eur_monthly` is the annual-billing anchor; monthly cadence is the
 # surcharged variant ("X% off when billed annually"). Editing this constant +
 # a deploy is the entire workflow — no env var, no Directus row.
-MONTHLY_BILLING_PREMIUM_PCT = 20
+MONTHLY_BILLING_PREMIUM_PCT = 15
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Lower the monthly-billing premium from **20% to 15%**.

Single source of truth, mirrored in two constants:
- `server/dembrane/tier_capacity.py` `MONTHLY_BILLING_PREMIUM_PCT`
- `frontend/src/lib/tiers.ts` `MONTHLY_BILLING_PREMIUM_PCT`

Drives the per-seat monthly price (`annual × (1 + pct/100)`), the billing-period toggle badge, and the offline price fallback. ADR 0005 / 0002 amendment + plan docs updated to the operative 15%.

Independent of #688 (touches only `tier_capacity.py` / `lib/tiers.ts` / docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)