### PR TITLE
feat(bulk-move): bulk-move conversations between projects & projects between workspaces

### DIFF
--- a/echo/directus/sync/snapshot/fields/conversation/move_history.json
+++ b/echo/directus/sync/snapshot/fields/conversation/move_history.json
@@ -1,0 +1,48 @@
+{
+  "collection": "conversation",
+  "field": "move_history",
+  "type": "json",
+  "meta": {
+    "collection": "conversation",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "move_history",
+    "group": null,
+    "hidden": false,
+    "interface": "input-code",
+    "note": "Audit trail of moves: [{from, to, by, at}]. Redundant by design.",
+    "options": {
+      "language": "json"
+    },
+    "readonly": true,
+    "required": false,
+    "searchable": true,
+    "sort": 99,
+    "special": [
+      "cast-json"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "full"
+  },
+  "schema": {
+    "name": "move_history",
+    "table": "conversation",
+    "data_type": "json",
+    "default_value": null,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/echo/directus/sync/snapshot/fields/project/move_history.json
+++ b/echo/directus/sync/snapshot/fields/project/move_history.json
@@ -1,0 +1,48 @@
+{
+  "collection": "project",
+  "field": "move_history",
+  "type": "json",
+  "meta": {
+    "collection": "project",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "move_history",
+    "group": null,
+    "hidden": false,
+    "interface": "input-code",
+    "note": "Audit trail of moves: [{from, to, by, at}]. Redundant by design.",
+    "options": {
+      "language": "json"
+    },
+    "readonly": true,
+    "required": false,
+    "searchable": true,
+    "sort": 99,
+    "special": [
+      "cast-json"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "full"
+  },
+  "schema": {
+    "name": "move_history",
+    "table": "project",
+    "data_type": "json",
+    "default_value": null,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/echo/frontend/src/components/common/BulkActionBar.tsx
+++ b/echo/frontend/src/components/common/BulkActionBar.tsx
@@ -1,0 +1,79 @@
+import { Plural } from "@lingui/react/macro";
+import { Button, Checkbox, Group, Text } from "@mantine/core";
+import { TrayArrowUp } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+
+interface BulkActionBarProps {
+	/** Whether every current item is selected (header checkbox checked). */
+	allSelected: boolean;
+	/** Some but not all selected (header checkbox indeterminate). */
+	someSelected: boolean;
+	/** Toggle select-all (selects all current when partial, clears when all). */
+	onToggleAll: () => void;
+	selectedCount: number;
+	/** Full-text label for the move action, e.g. "Move conversations". */
+	moveLabel: ReactNode;
+	onMove: () => void;
+	"data-testid"?: string;
+}
+
+/**
+ * Subtle row between a search bar and a list: a select-all checkbox on the
+ * left, and the available bulk actions on the right that appear only once
+ * something is selected. The only action for now is Move (tertiary button,
+ * tray-arrow-up icon). Consistent across the conversations and projects
+ * overviews.
+ */
+export function BulkActionBar({
+	allSelected,
+	someSelected,
+	onToggleAll,
+	selectedCount,
+	moveLabel,
+	onMove,
+	"data-testid": dataTestId,
+}: BulkActionBarProps) {
+	return (
+		<Group
+			justify="space-between"
+			align="center"
+			px="xs"
+			py={6}
+			wrap="nowrap"
+			style={{
+				borderTop: "1px solid var(--mantine-color-default-border)",
+				borderBottom: "1px solid var(--mantine-color-default-border)",
+			}}
+			data-testid={dataTestId}
+		>
+			<Checkbox
+				checked={allSelected}
+				indeterminate={someSelected}
+				onChange={onToggleAll}
+				data-testid="bulk-select-all"
+				label={
+					selectedCount > 0 ? (
+						<Text size="sm">
+							<Plural
+								value={selectedCount}
+								one="# selected"
+								other="# selected"
+							/>
+						</Text>
+					) : undefined
+				}
+			/>
+			{selectedCount > 0 && (
+				<Button
+					variant="subtle"
+					size="xs"
+					leftSection={<TrayArrowUp size={16} />}
+					onClick={onMove}
+					data-testid="bulk-move-button"
+				>
+					{moveLabel}
+				</Button>
+			)}
+		</Group>
+	);
+}

--- a/echo/frontend/src/components/common/MoveHistory.tsx
+++ b/echo/frontend/src/components/common/MoveHistory.tsx
@@ -1,0 +1,62 @@
+import { Trans } from "@lingui/react/macro";
+import { Stack, Text } from "@mantine/core";
+import { formatDistanceToNowStrict } from "date-fns";
+
+export interface MoveHistoryEntry {
+	from?: string | null;
+	from_label?: string | null;
+	to?: string | null;
+	to_label?: string | null;
+	by?: string | null;
+	by_label?: string | null;
+	at?: string | null;
+}
+
+/**
+ * Read-only audit list of where an entity (conversation / project) has been
+ * moved and by whom. Reads the deliberately-redundant `move_history` log; each
+ * entry already carries human-readable labels, so no id resolution is needed.
+ * Renders nothing when there's no history.
+ */
+export function MoveHistory({
+	entries,
+	title,
+}: {
+	entries: MoveHistoryEntry[] | null | undefined;
+	title: React.ReactNode;
+}) {
+	if (!Array.isArray(entries) || entries.length === 0) return null;
+
+	// Newest first.
+	const ordered = [...entries].reverse();
+
+	return (
+		<Stack gap={4}>
+			<Text size="xs" fw={600}>
+				{title}
+			</Text>
+			{ordered.map((e, i) => {
+				const when = e.at
+					? formatDistanceToNowStrict(new Date(e.at), { addSuffix: true })
+					: null;
+				const from = e.from_label || e.from || "—";
+				const to = e.to_label || e.to || "—";
+				const by = e.by_label || null;
+				return (
+					<Text key={`${e.at}-${i}`} size="xs">
+						<Trans>
+							{from} → {to}
+						</Trans>
+						{by ? (
+							<>
+								{" · "}
+								<Trans>by {by}</Trans>
+							</>
+						) : null}
+						{when ? ` · ${when}` : ""}
+					</Text>
+				);
+			})}
+		</Stack>
+	);
+}

--- a/echo/frontend/src/components/conversation/BulkMoveConversationsModal.tsx
+++ b/echo/frontend/src/components/conversation/BulkMoveConversationsModal.tsx
@@ -1,0 +1,181 @@
+import { t } from "@lingui/core/macro";
+import { Plural, Trans } from "@lingui/react/macro";
+import {
+	Button,
+	Center,
+	Divider,
+	Group,
+	Loader,
+	Modal,
+	Radio,
+	ScrollArea,
+	Stack,
+	Text,
+	TextInput,
+} from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import { IconSearch } from "@tabler/icons-react";
+import posthog from "posthog-js";
+import { useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
+import { useInfiniteProjects } from "@/components/project/hooks";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import { testId } from "@/lib/testUtils";
+import { useBulkMoveConversationsMutation } from "./hooks";
+
+interface Props {
+	opened: boolean;
+	onClose: () => void;
+	conversationIds: string[];
+	/** Current project — excluded from the destination list. */
+	currentProjectId: string;
+	/** Called after a successful move so the caller can clear its selection. */
+	onMoved: () => void;
+}
+
+/**
+ * Move several selected conversations to one target project. Destinations are
+ * scoped to the current workspace (same as the single-conversation move). The
+ * server enforces project:update on source + target.
+ */
+export const BulkMoveConversationsModal = ({
+	opened,
+	onClose,
+	conversationIds,
+	currentProjectId,
+	onMoved,
+}: Props) => {
+	const { workspaceId } = useWorkspace();
+	const { ref: loadMoreRef, inView } = useInView();
+	const [search, setSearch] = useState("");
+	const [debouncedSearch] = useDebouncedValue(search, 200);
+	const [targetProjectId, setTargetProjectId] = useState("");
+	const bulkMove = useBulkMoveConversationsMutation();
+
+	const projectsQuery = useInfiniteProjects({
+		options: { initialLimit: 10 },
+		query: {
+			filter: {
+				id: { _neq: currentProjectId },
+				...(workspaceId && { workspace_id: { _eq: workspaceId } }),
+				...(debouncedSearch && { name: { _icontains: debouncedSearch } }),
+			},
+			sort: "-updated_at",
+		},
+	});
+
+	useEffect(() => {
+		if (!opened) {
+			setSearch("");
+			setTargetProjectId("");
+		}
+	}, [opened]);
+
+	useEffect(() => {
+		if (inView && projectsQuery.hasNextPage && !projectsQuery.isFetchingNextPage) {
+			projectsQuery.fetchNextPage();
+		}
+	}, [
+		inView,
+		projectsQuery.hasNextPage,
+		projectsQuery.isFetchingNextPage,
+		projectsQuery.fetchNextPage,
+	]);
+
+	const allProjects =
+		(
+			projectsQuery.data?.pages as
+				| { projects: Project[]; nextOffset?: number }[]
+				| undefined
+		)?.flatMap((page) => page.projects) ?? [];
+
+	const handleMove = () => {
+		if (!targetProjectId || conversationIds.length === 0) return;
+		posthog.capture("conversations_bulk_moved", {
+			count: conversationIds.length,
+		});
+		bulkMove.mutate(
+			{ conversationIds, targetProjectId },
+			{
+				onSuccess: () => {
+					onMoved();
+					onClose();
+				},
+			},
+		);
+	};
+
+	return (
+		<Modal
+			opened={opened}
+			onClose={onClose}
+			title={t`Move conversations`}
+			{...testId("bulk-move-conversations-modal")}
+		>
+			<Stack gap="lg">
+				<Text size="sm">
+					<Plural
+						value={conversationIds.length}
+						one="Move # conversation to another project."
+						other="Move # conversations to another project."
+					/>
+				</Text>
+				<TextInput
+					placeholder={t`Search projects...`}
+					leftSection={<IconSearch size={16} />}
+					value={search}
+					onChange={(e) => setSearch(e.currentTarget.value)}
+					{...testId("bulk-move-conversations-search")}
+				/>
+				<Divider />
+				<ScrollArea style={{ height: 300 }} scrollbarSize={4}>
+					{projectsQuery.isLoading ? (
+						<Center style={{ height: 200 }}>
+							<Loader />
+						</Center>
+					) : allProjects.length === 0 ? (
+						<Center style={{ height: 200 }}>
+							<Trans>No other projects in this workspace.</Trans>
+						</Center>
+					) : (
+						<Radio.Group value={targetProjectId} onChange={setTargetProjectId}>
+							<Stack gap="sm">
+								{allProjects.map((project, index) => (
+									<div
+										key={project.id}
+										ref={index === allProjects.length - 1 ? loadMoreRef : undefined}
+									>
+										<Radio value={project.id} label={project.name} />
+									</div>
+								))}
+								{projectsQuery.isFetchingNextPage && (
+									<Center>
+										<Loader size="sm" />
+									</Center>
+								)}
+							</Stack>
+						</Radio.Group>
+					)}
+				</ScrollArea>
+				<Group justify="flex-end">
+					<Button
+						variant="subtle"
+						onClick={onClose}
+						disabled={bulkMove.isPending}
+						{...testId("bulk-move-conversations-cancel")}
+					>
+						<Trans>Cancel</Trans>
+					</Button>
+					<Button
+						onClick={handleMove}
+						loading={bulkMove.isPending}
+						disabled={!targetProjectId || bulkMove.isPending}
+						{...testId("bulk-move-conversations-confirm")}
+					>
+						<Trans>Move</Trans>
+					</Button>
+				</Group>
+			</Stack>
+		</Modal>
+	);
+};

--- a/echo/frontend/src/components/conversation/MoveConversationButton.tsx
+++ b/echo/frontend/src/components/conversation/MoveConversationButton.tsx
@@ -19,6 +19,10 @@ import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useInView } from "react-intersection-observer";
 import { useParams } from "react-router";
+import {
+	MoveHistory,
+	type MoveHistoryEntry,
+} from "@/components/common/MoveHistory";
 import { FormLabel } from "@/components/form/FormLabel";
 import { useInfiniteProjects } from "@/components/project/hooks";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
@@ -238,6 +242,14 @@ export const MoveConversationButton = ({
 								{t`Move`}
 							</Button>
 						</Group>
+
+						<MoveHistory
+							entries={
+								(conversation as { move_history?: MoveHistoryEntry[] })
+									.move_history
+							}
+							title={<Trans>Move history</Trans>}
+						/>
 					</Stack>
 				</form>
 			</Modal>

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -43,9 +43,12 @@ import { formatDistanceToNowStrict } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import { useProjectChatContext } from "@/components/chat/hooks";
+import { BulkActionBar } from "@/components/common/BulkActionBar";
 import { I18nLink } from "@/components/common/i18nLink";
 import { toast } from "@/components/common/Toaster";
 import { AutoSelectConversations } from "@/components/conversation/AutoSelectConversations";
+import { BulkMoveConversationsModal } from "@/components/conversation/BulkMoveConversationsModal";
+import { useBulkSelection } from "@/hooks/useBulkSelection";
 import { SelectAllConfirmationModal } from "@/components/conversation/SelectAllConfirmationModal";
 import { UploadConversationDropzone } from "@/components/dropzone/UploadConversationDropzone";
 import { useProjectById } from "@/components/project/hooks";
@@ -577,6 +580,14 @@ export const ProjectConversationsPanel = ({
 	const allConversations =
 		conversationsQuery.data?.pages.flatMap((page) => page.conversations) ?? [];
 
+	// Bulk-move selection — only on the standalone overview (not the chat
+	// context-selection embedding). Server enforces project:update on move.
+	const bulkEnabled = !selectionMode;
+	const bulkSelection = useBulkSelection(
+		bulkEnabled ? allConversations.map((c) => c.id) : [],
+	);
+	const [bulkMoveOpen, bulkMoveHandlers] = useDisclosure(false);
+
 	useEffect(() => {
 		if (
 			inView &&
@@ -808,6 +819,18 @@ export const ProjectConversationsPanel = ({
 					</Group>
 				</Paper>
 
+				{bulkEnabled && allConversations.length > 0 && (
+					<BulkActionBar
+						allSelected={bulkSelection.allSelected}
+						someSelected={bulkSelection.someSelected}
+						onToggleAll={bulkSelection.toggleAll}
+						selectedCount={bulkSelection.count}
+						moveLabel={<Trans>Move conversations</Trans>}
+						onMove={bulkMoveHandlers.open}
+						data-testid="conversations-bulk-bar"
+					/>
+				)}
+
 				{selectionMode &&
 					ENABLE_CHAT_SELECT_ALL &&
 					chatMode === "deep_dive" &&
@@ -864,13 +887,8 @@ export const ProjectConversationsPanel = ({
 					</Paper>
 				)}
 
-				{allConversations.map((conversation, index) => (
-					<div
-						key={conversation.id}
-						ref={
-							index === allConversations.length - 1 ? loadMoreRef : undefined
-						}
-					>
+				{allConversations.map((conversation, index) => {
+					const row = (
 						<ConversationRow
 							conversation={conversation as Conversation & { live?: boolean }}
 							href={
@@ -884,8 +902,28 @@ export const ProjectConversationsPanel = ({
 							selectionChatId={selectionChatId}
 							selectionMode={selectionMode}
 						/>
-					</div>
-				))}
+					);
+					const isLast = index === allConversations.length - 1;
+					return (
+						<div key={conversation.id} ref={isLast ? loadMoreRef : undefined}>
+							{bulkEnabled ? (
+								<Group wrap="nowrap" align="flex-start" gap="sm">
+									<Box pt={4}>
+										<Checkbox
+											checked={bulkSelection.isSelected(conversation.id)}
+											onChange={() => bulkSelection.toggle(conversation.id)}
+											aria-label={t`Select conversation`}
+											data-testid={`conversation-select-${conversation.id}`}
+										/>
+									</Box>
+									<Box style={{ flex: 1, minWidth: 0 }}>{row}</Box>
+								</Group>
+							) : (
+								row
+							)}
+						</div>
+					);
+				})}
 
 				{conversationsQuery.isFetchingNextPage && (
 					<Center py="md">
@@ -918,6 +956,16 @@ export const ProjectConversationsPanel = ({
 					</Stack>
 				)}
 			</Modal>
+
+			{bulkEnabled && (
+				<BulkMoveConversationsModal
+					opened={bulkMoveOpen}
+					onClose={bulkMoveHandlers.close}
+					conversationIds={bulkSelection.selectedIds}
+					currentProjectId={projectId}
+					onMoved={bulkSelection.clear}
+				/>
+			)}
 
 			{selectionMode && ENABLE_CHAT_SELECT_ALL && (
 				<SelectAllConfirmationModal

--- a/echo/frontend/src/components/conversation/hooks/index.ts
+++ b/echo/frontend/src/components/conversation/hooks/index.ts
@@ -263,6 +263,34 @@ export const useMoveConversationMutation = () => {
 	});
 };
 
+export const useBulkMoveConversationsMutation = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({
+			conversationIds,
+			targetProjectId,
+		}: {
+			conversationIds: string[];
+			targetProjectId: string;
+		}) => {
+			// Let errors propagate so onError fires and the modal stays open on
+			// a permission failure (all-or-nothing on the server).
+			return bff.post("/conversations/bulk-move", {
+				conversation_ids: conversationIds,
+				target_project_id: targetProjectId,
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(`Couldn't move conversations: ${error.message}`);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["conversations"] });
+			queryClient.invalidateQueries({ queryKey: ["projects"] });
+			toast.success("Conversations moved");
+		},
+	});
+};
+
 export const useAddChatContextMutation = () => {
 	const queryClient = useQueryClient();
 	return useMutation({

--- a/echo/frontend/src/components/project/BulkMoveProjectsModal.tsx
+++ b/echo/frontend/src/components/project/BulkMoveProjectsModal.tsx
@@ -1,0 +1,125 @@
+import { t } from "@lingui/core/macro";
+import { Plural, Trans } from "@lingui/react/macro";
+import { Button, Group, Modal, Select, Stack, Text } from "@mantine/core";
+import posthog from "posthog-js";
+import { useEffect, useMemo, useState } from "react";
+import { useWorkspace } from "@/hooks/useWorkspace";
+import { testId } from "@/lib/testUtils";
+import { useBulkMoveProjectsMutation } from "./hooks";
+
+interface Props {
+	opened: boolean;
+	onClose: () => void;
+	projectIds: string[];
+	/** Workspace the projects currently live in (the source context). */
+	sourceWorkspaceId: string;
+	/** Called after a successful move so the caller can clear its selection. */
+	onMoved: () => void;
+}
+
+/**
+ * Move several selected projects to one target workspace. Destinations are the
+ * workspaces the user administers within the SAME billing / data-ownership
+ * context as the source (mirrors the single project move). The server
+ * re-enforces admin/owner on both + the context guard.
+ */
+export const BulkMoveProjectsModal = ({
+	opened,
+	onClose,
+	projectIds,
+	sourceWorkspaceId,
+	onMoved,
+}: Props) => {
+	const { workspaces } = useWorkspace();
+	const [targetWorkspaceId, setTargetWorkspaceId] = useState<string | null>(null);
+	const bulkMove = useBulkMoveProjectsMutation();
+
+	// Same context key as billing_service._billing_context_key: an external
+	// (bills_separately) workspace is its own context; internal ones share the org.
+	const options = useMemo(() => {
+		const contextKey = (w: (typeof workspaces)[number]) =>
+			w.bills_separately ? `ws:${w.id}` : `org:${w.org_id}`;
+		const source = workspaces.find((w) => w.id === sourceWorkspaceId);
+		const sourceKey = source ? contextKey(source) : null;
+		return workspaces
+			.filter(
+				(w) =>
+					(w.role === "admin" || w.role === "owner") &&
+					w.id !== sourceWorkspaceId &&
+					(sourceKey === null || contextKey(w) === sourceKey),
+			)
+			.map((w) => ({ label: w.name, value: w.id }));
+	}, [workspaces, sourceWorkspaceId]);
+
+	useEffect(() => {
+		if (!opened) setTargetWorkspaceId(null);
+	}, [opened]);
+
+	const handleMove = () => {
+		if (!targetWorkspaceId || projectIds.length === 0) return;
+		posthog.capture("projects_bulk_moved", { count: projectIds.length });
+		bulkMove.mutate(
+			{ projectIds, targetWorkspaceId },
+			{
+				onSuccess: () => {
+					onMoved();
+					onClose();
+				},
+			},
+		);
+	};
+
+	return (
+		<Modal
+			opened={opened}
+			onClose={onClose}
+			title={t`Move projects`}
+			{...testId("bulk-move-projects-modal")}
+		>
+			<Stack gap="lg">
+				<Text size="sm">
+					<Plural
+						value={projectIds.length}
+						one="Move # project to another workspace."
+						other="Move # projects to another workspace."
+					/>
+				</Text>
+				{options.length === 0 ? (
+					<Text size="sm">
+						<Trans>
+							There are no other workspaces you can move these projects into.
+						</Trans>
+					</Text>
+				) : (
+					<Select
+						label={<Trans>Destination workspace</Trans>}
+						placeholder={t`Select a workspace`}
+						data={options}
+						value={targetWorkspaceId}
+						onChange={setTargetWorkspaceId}
+						searchable
+						{...testId("bulk-move-projects-select")}
+					/>
+				)}
+				<Group justify="flex-end">
+					<Button
+						variant="subtle"
+						onClick={onClose}
+						disabled={bulkMove.isPending}
+						{...testId("bulk-move-projects-cancel")}
+					>
+						<Trans>Cancel</Trans>
+					</Button>
+					<Button
+						onClick={handleMove}
+						loading={bulkMove.isPending}
+						disabled={!targetWorkspaceId || bulkMove.isPending}
+						{...testId("bulk-move-projects-confirm")}
+					>
+						<Trans>Move</Trans>
+					</Button>
+				</Group>
+			</Stack>
+		</Modal>
+	);
+};

--- a/echo/frontend/src/components/project/ProjectMoveWorkspace.tsx
+++ b/echo/frontend/src/components/project/ProjectMoveWorkspace.tsx
@@ -7,6 +7,10 @@ import posthog from "posthog-js";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import { ConfirmModal } from "@/components/common/ConfirmModal";
+import {
+	MoveHistory,
+	type MoveHistoryEntry,
+} from "@/components/common/MoveHistory";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { testId } from "@/lib/testUtils";
@@ -121,6 +125,12 @@ export const ProjectMoveWorkspace = ({ project }: { project: Project }) => {
 					</Button>
 				</Stack>
 			)}
+			<MoveHistory
+				entries={
+					(project as { move_history?: MoveHistoryEntry[] }).move_history
+				}
+				title={<Trans>Move history</Trans>}
+			/>
 			<ConfirmModal
 				opened={isConfirmOpen}
 				onClose={closeConfirm}

--- a/echo/frontend/src/components/project/hooks/index.ts
+++ b/echo/frontend/src/components/project/hooks/index.ts
@@ -209,6 +209,42 @@ export const useMoveProjectMutation = () => {
 	});
 };
 
+export const useBulkMoveProjectsMutation = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({
+			projectIds,
+			targetWorkspaceId,
+		}: {
+			projectIds: string[];
+			targetWorkspaceId: string;
+		}) => {
+			const res = await fetch(`${API_BASE_URL}/v2/projects/bulk-move`, {
+				body: JSON.stringify({
+					project_ids: projectIds,
+					target_workspace_id: targetWorkspaceId,
+				}),
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				method: "POST",
+			});
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				throw new Error(data.detail || t`Failed to move projects`);
+			}
+			return (await res.json()) as { moved: string[]; count: number };
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["projects"] });
+			queryClient.invalidateQueries({ queryKey: ["v2", "workspace-projects"] });
+			toast.success(t`Projects moved`);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message || t`Failed to move projects`);
+		},
+	});
+};
+
 export const useCreateProjectTagMutation = () => {
 	const queryClient = useQueryClient();
 	return useMutation({

--- a/echo/frontend/src/hooks/useBulkSelection.ts
+++ b/echo/frontend/src/hooks/useBulkSelection.ts
@@ -1,0 +1,64 @@
+import { useCallback, useMemo, useState } from "react";
+
+/**
+ * Generic multi-select for a list of items keyed by id. Drives the bulk-move
+ * selection on the conversations and projects overviews.
+ *
+ * Select-all semantics (founder spec): the header checkbox is checked only when
+ * EVERY current item is selected; it shows indeterminate when some-but-not-all
+ * are selected; clicking it while partial selects all (override), clicking it
+ * while all-selected clears.
+ *
+ * `currentIds` is the set of ids currently visible/loaded — select-all and the
+ * all/some flags are computed against it, and selection is pruned to it so ids
+ * that scrolled out of a filtered list don't linger.
+ */
+export function useBulkSelection(currentIds: string[]) {
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+
+	const currentSet = useMemo(() => new Set(currentIds), [currentIds]);
+
+	// Only count selections that are still present in the current list.
+	const selectedInView = useMemo(
+		() => currentIds.filter((id) => selected.has(id)),
+		[currentIds, selected],
+	);
+	const count = selectedInView.length;
+	const allSelected = currentIds.length > 0 && count === currentIds.length;
+	const someSelected = count > 0 && !allSelected;
+
+	const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+	const toggle = useCallback((id: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}, []);
+
+	// Click while not-all-selected → select all current; while all → clear.
+	const toggleAll = useCallback(() => {
+		setSelected((prev) => {
+			const allNow =
+				currentIds.length > 0 && currentIds.every((id) => prev.has(id));
+			return allNow ? new Set() : new Set(currentIds);
+		});
+	}, [currentIds]);
+
+	const clear = useCallback(() => setSelected(new Set()), []);
+
+	return {
+		/** Selected ids that are still in the current list (the move payload). */
+		selectedIds: selectedInView,
+		count,
+		allSelected,
+		someSelected,
+		isSelected,
+		toggle,
+		toggleAll,
+		clear,
+		currentSet,
+	};
+}

--- a/echo/frontend/src/routes/project/ProjectsHome.tsx
+++ b/echo/frontend/src/routes/project/ProjectsHome.tsx
@@ -7,6 +7,7 @@ import {
 	Badge,
 	Box,
 	Button,
+	Checkbox,
 	Container,
 	Group,
 	SimpleGrid,
@@ -15,7 +16,11 @@ import {
 	TextInput,
 	Title,
 } from "@mantine/core";
-import { useDebouncedValue, useDocumentTitle } from "@mantine/hooks";
+import {
+	useDebouncedValue,
+	useDisclosure,
+	useDocumentTitle,
+} from "@mantine/hooks";
 import { usePostHog } from "@posthog/react";
 import { IconSearch, IconSettings, IconX } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
@@ -25,9 +30,12 @@ import { useSearchParams } from "react-router";
 import { useCurrentUser } from "@/components/auth/hooks";
 import { AccessDeniedPanel } from "@/components/common/AccessDeniedPanel";
 import { toast } from "@/components/common/Toaster";
+import { BulkActionBar } from "@/components/common/BulkActionBar";
+import { BulkMoveProjectsModal } from "@/components/project/BulkMoveProjectsModal";
 import { useTogglePinMutation } from "@/components/project/hooks";
 import { PinnedProjectCard } from "@/components/project/PinnedProjectCard";
 import { ProjectListItem } from "@/components/project/ProjectListItem";
+import { useBulkSelection } from "@/hooks/useBulkSelection";
 import { ProjectListSkeleton } from "@/components/project/ProjectListSkeleton";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
@@ -176,10 +184,17 @@ export const ProjectsHomeRoute = () => {
 
 	// Pinned rail shouldn't also appear in the "All projects" list —
 	// audit 2026-04-23 called the duplication out. One surface per project.
-	const nonPinnedProjects = useMemo(
-		() => allProjects.filter((p) => !pinnedIds.has(p.id)),
-		[allProjects, pinnedIds],
+	// Pinned projects also appear in the default "All projects" list as a
+	// shortcut (they're not removed from it), so the list — and the bulk-move
+	// selection — operate on the full set.
+	const displayProjects = allProjects;
+
+	const selectableIds = useMemo(
+		() => displayProjects.map((p) => p.id),
+		[displayProjects],
 	);
+	const selection = useBulkSelection(selectableIds);
+	const [moveOpen, moveHandlers] = useDisclosure(false);
 
 	const canManageWorkspace =
 		workspace?.role === "owner" || workspace?.role === "admin";
@@ -351,24 +366,12 @@ export const ProjectsHomeRoute = () => {
 								{...testId("project-search-input")}
 							/>
 
-							{nonPinnedProjects.length === 0 &&
+							{displayProjects.length === 0 &&
 								debouncedSearchValue !== "" &&
 								status === "success" && (
 									<Text c="dimmed">
 										<Trans>No projects found for search term</Trans>{" "}
 										<i>{debouncedSearchValue}</i>
-									</Text>
-								)}
-
-							{nonPinnedProjects.length === 0 &&
-								debouncedSearchValue === "" &&
-								status === "success" &&
-								showPinnedSection && (
-									<Text size="sm" c="dimmed">
-										<Trans>
-											Everything is pinned. Unpin a project to see it in this
-											list.
-										</Trans>
 									</Text>
 								)}
 
@@ -382,31 +385,58 @@ export const ProjectsHomeRoute = () => {
 								<ProjectListSkeleton searchValue={debouncedSearchValue} />
 							)}
 
-							{nonPinnedProjects.length > 0 && (
+							{/* Bulk-move select row (admin/owner only) — between the
+							    search and the list, consistent with conversations. */}
+							{canManageWorkspace && displayProjects.length > 0 && (
+								<BulkActionBar
+									allSelected={selection.allSelected}
+									someSelected={selection.someSelected}
+									onToggleAll={selection.toggleAll}
+									selectedCount={selection.count}
+									moveLabel={<Trans>Move projects</Trans>}
+									onMove={moveHandlers.open}
+									data-testid="projects-bulk-bar"
+								/>
+							)}
+
+							{displayProjects.length > 0 && (
 								<Box className="relative">
 									<Stack ref={listParent} gap="sm">
-										{nonPinnedProjects.map((project) => (
-											<Box
+										{displayProjects.map((project) => (
+											<Group
 												key={project.id}
+												wrap="nowrap"
+												align="center"
+												gap="xs"
 												ref={
-													nonPinnedProjects[nonPinnedProjects.length - 1].id ===
+													displayProjects[displayProjects.length - 1].id ===
 													project.id
 														? loadMoreRef
 														: undefined
 												}
 											>
-												<ProjectListItem
-													project={project as Project}
-													onTogglePin={
-														canPinOnThisWorkspace ? handleTogglePin : undefined
-													}
-													isPinned={pinnedIds.has(project.id)}
-													canPin={canPin && canPinOnThisWorkspace}
-													onSearchOwner={
-														isAdmin ? handleSearchOwner : undefined
-													}
-												/>
-											</Box>
+												{canManageWorkspace && (
+													<Checkbox
+														checked={selection.isSelected(project.id)}
+														onChange={() => selection.toggle(project.id)}
+														aria-label={t`Select project`}
+														data-testid={`project-select-${project.id}`}
+													/>
+												)}
+												<Box style={{ flex: 1, minWidth: 0 }}>
+													<ProjectListItem
+														project={project as Project}
+														onTogglePin={
+															canPinOnThisWorkspace ? handleTogglePin : undefined
+														}
+														isPinned={pinnedIds.has(project.id)}
+														canPin={canPin && canPinOnThisWorkspace}
+														onSearchOwner={
+															isAdmin ? handleSearchOwner : undefined
+														}
+													/>
+												</Box>
+											</Group>
 										))}
 
 										{isFetchingNextPage && (
@@ -418,6 +448,16 @@ export const ProjectsHomeRoute = () => {
 										)}
 									</Stack>
 								</Box>
+							)}
+
+							{workspaceId && (
+								<BulkMoveProjectsModal
+									opened={moveOpen}
+									onClose={moveHandlers.close}
+									projectIds={selection.selectedIds}
+									sourceWorkspaceId={workspaceId}
+									onMoved={selection.clear}
+								/>
 							)}
 						</Stack>
 					</>

--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -66,6 +66,7 @@ _CONVERSATION_DEFAULT_FIELDS = [
     "is_audio_processing_finished",
     "is_anonymized",
     "is_over_cap",
+    "move_history",
 ]
 
 # Shared by the list/count/select-all endpoints so they stay consistent.
@@ -709,16 +710,33 @@ async def move_conversation(
     on the target. Same-workspace is not required — cross-workspace
     moves are allowed when the user administers both.
     """
-    src_access, _ = await resolve_conversation_access(conversation_id, auth)
+    src_access, conv = await resolve_conversation_access(conversation_id, auth)
     src_access.require("project:update")
 
     dst_access = await resolve_project_access(body.target_project_id, auth)
     dst_access.require("project:update")
 
+    from dembrane.app_user import resolve_app_user
+    from dembrane.move_history import append_move_entry
+
+    me = await resolve_app_user(auth.user_id)
+    by_label = (me or {}).get("display_name") or (me or {}).get("email")
+
     updated = await async_directus.update_item(
         "conversation",
         conversation_id,
-        {"project_id": body.target_project_id},
+        {
+            "project_id": body.target_project_id,
+            "move_history": append_move_entry(
+                conv.get("move_history"),
+                from_id=conv.get("project_id"),
+                to_id=body.target_project_id,
+                by=src_access.app_user_id,
+                from_label=src_access.project.get("name"),
+                to_label=dst_access.project.get("name"),
+                by_label=by_label,
+            ),
+        },
     )
 
     from dembrane.cache_utils import invalidate_workspace_and_org_usage
@@ -733,6 +751,92 @@ async def move_conversation(
     if isinstance(updated, dict) and "data" in updated:
         return updated["data"]
     return updated or {}
+
+
+class BulkMoveConversations(BaseModel):
+    conversation_ids: list[str]
+    target_project_id: str
+
+
+@router.post("/bulk-move")
+async def bulk_move_conversations(
+    body: BulkMoveConversations,
+    auth: DependencyDirectusSession,
+) -> dict:
+    """Move several conversations to one target project in a single action.
+
+    Same authorization as the single move (`project:update` on the source of
+    each conversation AND on the target). All-or-nothing: every permission is
+    checked before any conversation is updated, so a partial-permission request
+    fails cleanly without moving anything. Records a move-history entry per
+    conversation.
+    """
+    if not body.conversation_ids:
+        raise HTTPException(status_code=400, detail="No conversations selected")
+    # De-dupe while preserving order.
+    ids = list(dict.fromkeys(body.conversation_ids))
+    if len(ids) > 500:
+        raise HTTPException(status_code=400, detail="Too many conversations (max 500)")
+
+    dst_access = await resolve_project_access(body.target_project_id, auth)
+    dst_access.require("project:update")
+    to_label = dst_access.project.get("name")
+
+    from dembrane.app_user import resolve_app_user
+
+    me = await resolve_app_user(auth.user_id)
+    by_label = (me or {}).get("display_name") or (me or {}).get("email")
+
+    # Phase 1: resolve + authorize every conversation before mutating any.
+    resolved: list[dict] = []
+    src_ws_ids: set[str] = set()
+    for cid in ids:
+        src_access, conv = await resolve_conversation_access(cid, auth)
+        src_access.require("project:update")
+        resolved.append(
+            {
+                "conv": conv,
+                "app_user_id": src_access.app_user_id,
+                "from_label": src_access.project.get("name"),
+            }
+        )
+        if src_access.workspace_id:
+            src_ws_ids.add(src_access.workspace_id)
+
+    # Phase 2: apply.
+    from dembrane.move_history import append_move_entry
+
+    moved: list[str] = []
+    for r in resolved:
+        conv = r["conv"]
+        await async_directus.update_item(
+            "conversation",
+            conv["id"],
+            {
+                "project_id": body.target_project_id,
+                "move_history": append_move_entry(
+                    conv.get("move_history"),
+                    from_id=conv.get("project_id"),
+                    to_id=body.target_project_id,
+                    by=r["app_user_id"],
+                    from_label=r["from_label"],
+                    to_label=to_label,
+                    by_label=by_label,
+                ),
+            },
+        )
+        moved.append(conv["id"])
+
+    from dembrane.cache_utils import invalidate_workspace_and_org_usage
+
+    for ws_id in src_ws_ids:
+        await invalidate_workspace_and_org_usage(ws_id, None)
+    if dst_access.workspace_id:
+        await invalidate_workspace_and_org_usage(
+            dst_access.workspace_id, dst_access.org_id
+        )
+
+    return {"moved": moved, "count": len(moved)}
 
 
 # ── /v2/bff/conversations/:id/chunks (paginated) ──────────────────────

--- a/echo/server/dembrane/api/v2/projects.py
+++ b/echo/server/dembrane/api/v2/projects.py
@@ -142,6 +142,66 @@ async def get_project_bff(
     return project
 
 
+async def _authorize_project_move(
+    *,
+    project: dict,
+    target_workspace_id: str,
+    target_workspace: dict,
+    app_user_id: str,
+    directus_user_id: str,
+) -> Optional[str]:
+    """Run the full project-move authorization for one project and return its
+    source workspace id. Raises HTTPException on any denial. Shared by the single
+    and bulk move endpoints so they enforce identical rules.
+
+    - admin/owner on BOTH source and target workspace (via user_can_access, which
+      honors derived org-admin/owner inheritance, ADR-0004).
+    - orphaned project (no source workspace): only its creator may move it.
+    - same billing / data-ownership context (ISSUE-033): a project can't leave an
+      external (workspace-scoped) workspace, nor enter one from another context.
+    """
+    source_workspace_id = project.get("workspace_id")
+
+    if not source_workspace_id:
+        if project.get("directus_user_id") != directus_user_id:
+            raise HTTPException(status_code=403, detail="Not the owner of this project")
+    else:
+        src = await user_can_access(source_workspace_id, app_user_id)
+        if src is None:
+            raise HTTPException(status_code=403, detail="No access to source workspace")
+        if src[0] not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=403, detail="Must be admin or owner of source workspace"
+            )
+
+    tgt = await user_can_access(target_workspace_id, app_user_id)
+    if tgt is None:
+        raise HTTPException(status_code=403, detail="No access to target workspace")
+    if tgt[0] not in ("admin", "owner"):
+        raise HTTPException(
+            status_code=403, detail="Must be admin or owner of target workspace"
+        )
+
+    from dembrane.billing_account import workspace_is_external_client
+    from dembrane.billing_service import same_billing_context
+
+    cross_context = (
+        not await same_billing_context(source_workspace_id, target_workspace_id)
+        if source_workspace_id
+        else workspace_is_external_client(target_workspace)
+    )
+    if cross_context:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Projects can only move between workspaces in the same billing "
+                "and data-ownership context. External-client workspaces keep "
+                "their projects within their own context."
+            ),
+        )
+    return source_workspace_id
+
+
 @router.post("/{project_id}/move", response_model=MoveProjectResponse)
 async def move_project(
     project_id: str,
@@ -157,73 +217,43 @@ async def move_project(
     target_workspace_id = body.target_workspace_id
 
     project = await async_directus.get_item("project", project_id)
-    if not project:
+    if not project or project.get("deleted_at"):
         raise HTTPException(status_code=404, detail="Project not found")
-    if project.get("deleted_at"):
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    source_workspace_id = project.get("workspace_id")
-
-    # Orphaned projects: verify ownership via directus_user_id
-    if not source_workspace_id:
-        if project.get("directus_user_id") != auth.user_id:
-            raise HTTPException(status_code=403, detail="Not the owner of this project")
-
-    # Source + target access must both resolve as admin/owner. Using
-    # user_can_access honors derived inheritance — a organisation owner who has
-    # no direct workspace row still legitimately administers the
-    # workspace. The previous raw workspace_membership lookup 403'd them
-    # incorrectly. (Audit round 2026-04-21, HIGH.)
-    if source_workspace_id:
-        src = await user_can_access(source_workspace_id, app_user_id)
-        if src is None:
-            raise HTTPException(status_code=403, detail="No access to source workspace")
-        if src[0] not in ("admin", "owner"):
-            raise HTTPException(
-                status_code=403,
-                detail="Must be admin or owner of source workspace",
-            )
-
-    tgt = await user_can_access(target_workspace_id, app_user_id)
-    if tgt is None:
-        raise HTTPException(status_code=403, detail="No access to target workspace")
-    if tgt[0] not in ("admin", "owner"):
-        raise HTTPException(status_code=403, detail="Must be admin or owner of target workspace")
 
     target_workspace = await async_directus.get_item("workspace", target_workspace_id)
     if not target_workspace or target_workspace.get("deleted_at"):
         raise HTTPException(status_code=404, detail="Target workspace not found")
 
-    # Projects move only within one billing / data-ownership context (ISSUE-033):
-    # internal workspaces of the same org share the org context and move freely;
-    # an external (workspace-scoped) workspace is its own isolated context. A
-    # project can't move OUT of an external workspace, nor INTO one from a
-    # different context — including an orphaned project (no source workspace),
-    # which must never be dropped into a client's isolated compliance context.
-    from dembrane.billing_account import workspace_is_external_client
-    from dembrane.billing_service import same_billing_context
-
-    cross_context = (
-        not await same_billing_context(source_workspace_id, target_workspace_id)
-        if source_workspace_id
-        # Orphan: only blocked from entering an external-client workspace.
-        else workspace_is_external_client(target_workspace)
+    source_workspace_id = await _authorize_project_move(
+        project=project,
+        target_workspace_id=target_workspace_id,
+        target_workspace=target_workspace,
+        app_user_id=app_user_id,
+        directus_user_id=auth.user_id,
     )
-    if cross_context:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "Projects can only move between workspaces in the same billing "
-                "and data-ownership context. External-client workspaces keep "
-                "their projects within their own context."
-            ),
-        )
+
+    from dembrane.move_history import append_move_entry
+
+    by_label = app_user.get("display_name") or app_user.get("email")
+    from_label = None
+    if source_workspace_id:
+        src_ws = await async_directus.get_item("workspace", source_workspace_id)
+        from_label = (src_ws or {}).get("name")
 
     await async_directus.update_item(
         "project",
         project_id,
         {
             "workspace_id": target_workspace_id,
+            "move_history": append_move_entry(
+                project.get("move_history"),
+                from_id=source_workspace_id,
+                to_id=target_workspace_id,
+                by=app_user_id,
+                from_label=from_label,
+                to_label=target_workspace.get("name"),
+                by_label=by_label,
+            ),
         },
     )
 
@@ -236,6 +266,99 @@ async def move_project(
         project_id=project_id,
         workspace_id=target_workspace_id,
     )
+
+
+class BulkMoveProjectsRequest(BaseModel):
+    project_ids: list[str]
+    target_workspace_id: str
+
+
+class BulkMoveProjectsResponse(BaseModel):
+    moved: list[str]
+    count: int
+
+
+@router.post("/bulk-move", response_model=BulkMoveProjectsResponse)
+async def bulk_move_projects(
+    body: BulkMoveProjectsRequest,
+    auth: DependencyDirectusSession,
+) -> BulkMoveProjectsResponse:
+    """Move several projects to one target workspace in a single action.
+
+    Same authorization as the single move, enforced per project (admin/owner on
+    each source + the target, plus the billing-context guard). All-or-nothing:
+    every project is authorized before any is moved, so a partial-permission
+    request fails without moving anything. Records move-history per project.
+    """
+    if not body.project_ids:
+        raise HTTPException(status_code=400, detail="No projects selected")
+    ids = list(dict.fromkeys(body.project_ids))
+    if len(ids) > 500:
+        raise HTTPException(status_code=400, detail="Too many projects (max 500)")
+
+    app_user = await get_app_user_or_raise(auth.user_id)
+    app_user_id = app_user["id"]
+    target_workspace_id = body.target_workspace_id
+
+    target_workspace = await async_directus.get_item("workspace", target_workspace_id)
+    if not target_workspace or target_workspace.get("deleted_at"):
+        raise HTTPException(status_code=404, detail="Target workspace not found")
+
+    # Phase 1: fetch + authorize every project before mutating any.
+    pending: list[tuple[dict, Optional[str]]] = []
+    for pid in ids:
+        project = await async_directus.get_item("project", pid)
+        if not project or project.get("deleted_at"):
+            raise HTTPException(status_code=404, detail=f"Project {pid} not found")
+        source_workspace_id = await _authorize_project_move(
+            project=project,
+            target_workspace_id=target_workspace_id,
+            target_workspace=target_workspace,
+            app_user_id=app_user_id,
+            directus_user_id=auth.user_id,
+        )
+        pending.append((project, source_workspace_id))
+
+    # Phase 2: apply. Resolve source-workspace names once per distinct source.
+    from dembrane.move_history import append_move_entry
+
+    by_label = app_user.get("display_name") or app_user.get("email")
+    to_label = target_workspace.get("name")
+    name_cache: dict[str, Optional[str]] = {}
+
+    async def _ws_name(ws_id: Optional[str]) -> Optional[str]:
+        if not ws_id:
+            return None
+        if ws_id not in name_cache:
+            row = await async_directus.get_item("workspace", ws_id)
+            name_cache[ws_id] = (row or {}).get("name")
+        return name_cache[ws_id]
+
+    moved: list[str] = []
+    for project, source_workspace_id in pending:
+        await async_directus.update_item(
+            "project",
+            project["id"],
+            {
+                "workspace_id": target_workspace_id,
+                "move_history": append_move_entry(
+                    project.get("move_history"),
+                    from_id=source_workspace_id,
+                    to_id=target_workspace_id,
+                    by=app_user_id,
+                    from_label=await _ws_name(source_workspace_id),
+                    to_label=to_label,
+                    by_label=by_label,
+                ),
+            },
+        )
+        moved.append(project["id"])
+
+    logger.info(
+        f"Bulk-moved {len(moved)} projects to workspace {target_workspace_id} "
+        f"by user {app_user_id}"
+    )
+    return BulkMoveProjectsResponse(moved=moved, count=len(moved))
 
 
 # ── Visibility toggle (workspace ↔ private) ─────────────────────────────

--- a/echo/server/dembrane/move_history.py
+++ b/echo/server/dembrane/move_history.py
@@ -1,0 +1,47 @@
+"""Move-history audit trail for conversations (between projects) and projects
+(between workspaces).
+
+A small, deliberately-redundant JSON log stored on the moved entity itself
+(`conversation.move_history` / `project.move_history`): each entry records where
+the item came from, where it went, who moved it, and when. Written on both the
+single-move and bulk-move paths so the record is consistent regardless of how
+the move was triggered. Surfaced read-only under the per-item move UI.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from datetime import datetime, timezone
+
+
+def append_move_entry(
+    history: Any,
+    *,
+    from_id: Optional[str],
+    to_id: str,
+    by: Optional[str],
+    from_label: Optional[str] = None,
+    to_label: Optional[str] = None,
+    by_label: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Return `history` with one move record appended.
+
+    `history` may be None or a non-list (legacy / unset) — treated as empty.
+    `from_id`/`to_id` are the prior/new parent (project or workspace), `by` the
+    app_user id who performed the move. Human-readable `*_label` fields are
+    stored alongside the ids (deliberately redundant) so the history renders
+    without resolving ids later.
+    """
+    entries: list[dict[str, Any]] = list(history) if isinstance(history, list) else []
+    entries.append(
+        {
+            "from": from_id,
+            "from_label": from_label,
+            "to": to_id,
+            "to_label": to_label,
+            "by": by,
+            "by_label": by_label,
+            "at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    return entries

--- a/echo/server/tests/test_bulk_move.py
+++ b/echo/server/tests/test_bulk_move.py
@@ -1,0 +1,152 @@
+"""Tests for bulk-move (conversations between projects, projects between
+workspaces) + the shared move_history audit log."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+from dembrane.move_history import append_move_entry
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+
+# ── move_history.append_move_entry ──────────────────────────────────────
+
+
+def test_append_move_entry_appends_with_labels():
+    out = append_move_entry(
+        None,
+        from_id="p-1",
+        to_id="p-2",
+        by="u-1",
+        from_label="Old",
+        to_label="New",
+        by_label="Jane",
+    )
+    assert len(out) == 1
+    e = out[0]
+    assert e["from"] == "p-1" and e["to"] == "p-2" and e["by"] == "u-1"
+    assert e["from_label"] == "Old" and e["to_label"] == "New" and e["by_label"] == "Jane"
+    assert e["at"]  # ISO timestamp present
+
+
+def test_append_move_entry_preserves_prior_history():
+    prior = [{"from": "a", "to": "b", "by": "u", "at": "t0"}]
+    out = append_move_entry(prior, from_id="b", to_id="c", by="u2")
+    assert len(out) == 2
+    assert out[0]["to"] == "b"  # original kept
+    assert out[1]["from"] == "b" and out[1]["to"] == "c"
+
+
+def test_append_move_entry_handles_non_list():
+    # Legacy / unset value that isn't a list is treated as empty.
+    out = append_move_entry("garbage", from_id="x", to_id="y", by=None)
+    assert len(out) == 1 and out[0]["to"] == "y"
+
+
+# ── bulk-move projects: all-or-nothing authorization ────────────────────
+
+
+def _projects_app(monkeypatch_targets):
+    from dembrane.api.v2 import projects as proj_mod
+
+    app = FastAPI()
+
+    async def _fake_auth():
+        return DirectusSession(user_id="du-1", is_admin=False)
+
+    app.dependency_overrides[require_directus_session] = _fake_auth
+    app.include_router(proj_mod.router, prefix="/v2/projects")
+    return app, proj_mod
+
+
+@pytest.mark.asyncio
+async def test_bulk_move_projects_all_or_nothing_on_permission():
+    """If the user lacks admin/owner on one project's source, the whole bulk
+    move is rejected and NOTHING is updated."""
+    app, proj_mod = _projects_app(None)
+
+    target_ws = {"id": "ws-dst", "deleted_at": None, "usage_context": "internal"}
+    projects = {
+        "p-ok": {"id": "p-ok", "workspace_id": "ws-a", "deleted_at": None},
+        "p-bad": {"id": "p-bad", "workspace_id": "ws-b", "deleted_at": None},
+    }
+
+    async def fake_get_item(collection, item_id):
+        if collection == "workspace":
+            return target_ws
+        return projects.get(item_id)
+
+    # admin on ws-a + target; only member on ws-b → p-bad fails.
+    async def fake_user_can_access(ws_id, _uid):
+        return ("member", "direct") if ws_id == "ws-b" else ("admin", "direct")
+
+    update_mock = AsyncMock(return_value={})
+    with (
+        patch.object(proj_mod, "get_app_user_or_raise", new=AsyncMock(return_value={"id": "au-1"})),
+        patch.object(proj_mod.async_directus, "get_item", new=AsyncMock(side_effect=fake_get_item)),
+        patch.object(proj_mod.async_directus, "update_item", new=update_mock),
+        patch.object(proj_mod, "user_can_access", new=AsyncMock(side_effect=fake_user_can_access)),
+        patch("dembrane.billing_service.same_billing_context", new=AsyncMock(return_value=True)),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.post(
+                "/v2/projects/bulk-move",
+                json={"project_ids": ["p-ok", "p-bad"], "target_workspace_id": "ws-dst"},
+            )
+    assert r.status_code == 403
+    update_mock.assert_not_called()  # nothing moved
+
+
+@pytest.mark.asyncio
+async def test_bulk_move_projects_success_records_history():
+    app, proj_mod = _projects_app(None)
+    target_ws = {"id": "ws-dst", "name": "Dest WS", "deleted_at": None, "usage_context": "internal"}
+    projects = {
+        "p-1": {"id": "p-1", "workspace_id": "ws-a", "deleted_at": None, "move_history": []},
+        "p-2": {"id": "p-2", "workspace_id": "ws-a", "deleted_at": None},
+    }
+
+    async def fake_get_item(collection, item_id):
+        if collection == "workspace":
+            return {"id": item_id, "name": f"WS {item_id}", "deleted_at": None} if item_id != "ws-dst" else target_ws
+        return projects.get(item_id)
+
+    update_mock = AsyncMock(return_value={})
+    with (
+        patch.object(proj_mod, "get_app_user_or_raise", new=AsyncMock(return_value={"id": "au-1", "display_name": "Jane"})),
+        patch.object(proj_mod.async_directus, "get_item", new=AsyncMock(side_effect=fake_get_item)),
+        patch.object(proj_mod.async_directus, "update_item", new=update_mock),
+        patch.object(proj_mod, "user_can_access", new=AsyncMock(return_value=("owner", "direct"))),
+        patch("dembrane.billing_service.same_billing_context", new=AsyncMock(return_value=True)),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.post(
+                "/v2/projects/bulk-move",
+                json={"project_ids": ["p-1", "p-2"], "target_workspace_id": "ws-dst"},
+            )
+    assert r.status_code == 200
+    assert r.json()["count"] == 2
+    assert update_mock.await_count == 2
+    # Each update carries a move_history entry with the by_label.
+    first_payload = update_mock.await_args_list[0].args[2]
+    entry = first_payload["move_history"][-1]
+    assert entry["to"] == "ws-dst" and entry["by_label"] == "Jane"
+
+
+@pytest.mark.asyncio
+async def test_bulk_move_projects_rejects_empty():
+    app, proj_mod = _projects_app(None)
+    with patch.object(proj_mod, "get_app_user_or_raise", new=AsyncMock(return_value={"id": "au-1"})):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.post(
+                "/v2/projects/bulk-move",
+                json={"project_ids": [], "target_workspace_id": "ws-dst"},
+            )
+    # Empty selection is rejected before any auth/work.
+    assert r.status_code == 400


### PR DESCRIPTION
Two interrelated bulk-move features with a consistent selection UI.

**Conversations overview** (`/w/:wid/projects/:pid/conversations`) and **workspace home** (`/w/:wid/home`) each get:
- A left checkbox per row.
- A subtle row between the search bar and the list: **select-all** checkbox on the left (checked when all selected, indeterminate when some, clicking while partial selects all), and a **tertiary "Move …"** button (`tray-arrow-up`) on the right that appears only when something is selected.
- A modal to pick the destination (target project / target workspace), reusing the single-move pickers + the same-billing-context filter.

**Permissions**: same as the existing single move (conversations: `project:update` on source + target; projects: admin/owner on both + billing-context guard), enforced **per item and all-or-nothing** server-side.

**Move history**: a redundant `move_history` JSON log on `conversation` + `project`, written on single *and* bulk moves (with human-readable from/to/by labels), shown read-only under the single-move UIs.

Also: pinned projects now also appear in the default "All projects" list (a shortcut, not removed), so they're selectable for bulk-move.

Tests: move-history helper + bulk-move all-or-nothing / success / history. `ruff` (full tree), `mypy` (no new errors), `tsc`, and `biome lint` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
