### PR TITLE
feat(sidebar): point Documentation link to Notion Info Hub

### DIFF
--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -141,6 +141,15 @@ export const LEGAL_DPA_URL = "https://www.dembrane.com/legal/DPA" as const;
 export const COMMUNITY_SLACK_URL =
 	"https://join.slack.com/t/dembranecommunity/shared_invite/zt-3qzvryh8l-M6w3u5BvuM8LssOhMbJGgQ";
 
+// Info Hub (documentation): published Notion pages, locale-aware.
+export const DOCS_URL_EN =
+	"https://dembrane.notion.site/Info-Hub-Welcome-to-dembrane-26f9cd84270580049be7cb1e7a472162" as const;
+export const DOCS_URL_NL =
+	"https://dembrane.notion.site/Welkom-bij-het-info-portaal-van-dembrane-2959cd842705804c815ac315464b6fa0" as const;
+
+export const getDocumentationUrl = (locale = "en-US") =>
+	locale === "nl-NL" ? DOCS_URL_NL : DOCS_URL_EN;
+
 export const DEBUG_MODE = import.meta.env.VITE_DEBUG_MODE === "1";
 
 export const ENABLE_CHAT_AUTO_SELECT = false;

--- a/echo/frontend/src/features/sidebar/blocks/HelpBlock.tsx
+++ b/echo/frontend/src/features/sidebar/blocks/HelpBlock.tsx
@@ -3,16 +3,14 @@ import { ChatCircle, EnvelopeSimple, Note, Pulse } from "@phosphor-icons/react";
 import { useState } from "react";
 import { useParams } from "react-router";
 import { FeedbackPortalModal } from "@/components/common/FeedbackPortalModal";
+import { getDocumentationUrl } from "@/config";
 import { NavButton } from "../primitives/NavButton";
 import { SectionLabel } from "../primitives/SectionLabel";
 
 export const HelpBlock = () => {
 	const { language } = useParams();
 	const [feedbackOpen, setFeedbackOpen] = useState(false);
-	const docUrl =
-		language === "nl-NL"
-			? "https://docs.dembrane.com/nl-NL"
-			: "https://docs.dembrane.com/en-US";
+	const docUrl = getDocumentationUrl(language);
 
 	return (
 		<>

--- a/echo/frontend/src/features/sidebar/views/HelpView.tsx
+++ b/echo/frontend/src/features/sidebar/views/HelpView.tsx
@@ -9,7 +9,7 @@ import {
 import { useState } from "react";
 import { useParams } from "react-router";
 import { FeedbackPortalModal } from "@/components/common/FeedbackPortalModal";
-import { COMMUNITY_SLACK_URL } from "@/config";
+import { COMMUNITY_SLACK_URL, getDocumentationUrl } from "@/config";
 import { useSidebarView } from "../hooks/useSidebarView";
 import { NavButton } from "../primitives/NavButton";
 import { ViewHeader } from "../primitives/ViewHeader";
@@ -18,10 +18,7 @@ export const HelpView = () => {
 	const { backTo } = useSidebarView();
 	const { language } = useParams();
 	const [feedbackOpen, setFeedbackOpen] = useState(false);
-	const docUrl =
-		language === "nl-NL"
-			? "https://docs.dembrane.com/nl-NL"
-			: "https://docs.dembrane.com/en-US";
+	const docUrl = getDocumentationUrl(language);
 
 	return (
 		<>


### PR DESCRIPTION
## What

The sidebar **Help → Documentation** button opened `docs.dembrane.com/{nl-NL,en-US}`, which is no longer where we want hosts to land. This points it at the published **Info Hub** Notion pages instead, locale-aware:

- `nl-NL` → Dutch Info Hub
- all other locales → English Info Hub

## How

- Add `DOCS_URL_EN`, `DOCS_URL_NL`, and `getDocumentationUrl(locale)` to `config.ts`, mirroring the existing `getProductFeedbackUrl(locale)` / `PRIVACY_POLICY_URL` (notion.site) patterns.
- Use the helper in `HelpBlock.tsx` and `HelpView.tsx`, replacing a duplicated ternary in both.
- Locale mapping is unchanged from before; only the destination URLs change.
- No Lingui changes (the `<Trans>Documentation</Trans>` label is untouched; only a URL constant changed).

## Notes

- Related Notion change (done separately, already live): each Info Hub page now has a small language-switch link at the top (EN↔NL).
- The two Info Hub pages still contain in-body links to `docs.dembrane.com` (First Aid, Reporting a Bug); left as-is, out of scope here.

## Verify

- `tsc --noEmit` passes; `grep docs.dembrane src` returns nothing.
- In-app: Help footer → Documentation opens the English Info Hub; switch to Dutch and it opens the Dutch Info Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)