### PR TITLE
chore(workspaces): make visibility the sole written source of truth for privacy

### DIFF
--- a/echo/directus/migrations/backfill_workspace_visibility.py
+++ b/echo/directus/migrations/backfill_workspace_visibility.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Idempotent backfill for workspace.visibility (retire inherit_organisation_admins).
+
+The `visibility` enum column ('open_to_organisation' | 'private') is the source
+of truth for workspace privacy. `inheritance.workspace_follows_organisation_admins`
+reads it first and only falls back to the legacy `settings.inherit_organisation_admins`
+JSON flag when visibility is NULL (pre-enum rows).
+
+Once every row has a non-NULL visibility, that fallback is dead and the legacy
+flag can be removed (a later "contract" step). This script performs the
+behavior-preserving 1:1 backfill:
+
+  For every workspace with visibility NULL/empty, set visibility from the legacy
+  flag: settings.inherit_organisation_admins is False -> 'private', otherwise
+  'open_to_organisation' (the default-open rule, matrix v1.1 §9).
+
+Idempotent: rows that already have a visibility are skipped, so re-running is a
+no-op. No schema change — the visibility column already exists in the snapshot.
+
+Usage:
+  python3 backfill_workspace_visibility.py \
+      -u https://directus.echo-next.dembrane.com \
+      -e admin@dembrane.com -p '<password>'
+
+  # dry run (no writes, just report what would change):
+  python3 backfill_workspace_visibility.py -u ... -e ... -p ... --dry-run
+"""
+
+from __future__ import annotations
+
+import sys
+import json
+import argparse
+import urllib.error
+import urllib.request
+
+OPEN = "open_to_organisation"
+PRIVATE = "private"
+
+
+class Directus:
+    def __init__(self, base_url: str, token: str, dry_run: bool = False):
+        self.base = base_url.rstrip("/")
+        self.token = token
+        self.dry_run = dry_run
+
+    def _request(self, method: str, path: str, body: dict | None = None) -> dict:
+        url = f"{self.base}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode()
+            raise RuntimeError(f"{method} {path} -> {e.code}: {detail}") from None
+
+    def get(self, path: str) -> dict:
+        return self._request("GET", path)
+
+    def patch(self, path: str, body: dict) -> dict:
+        if self.dry_run:
+            print(f"    [dry-run] PATCH {path} {json.dumps(body)}")
+            return {}
+        return self._request("PATCH", path, body)
+
+
+def login(base_url: str, email: str, password: str) -> str:
+    url = f"{base_url.rstrip('/')}/auth/login"
+    body = json.dumps({"email": email, "password": password}).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())["data"]["access_token"]
+
+
+def visibility_from_legacy(ws: dict) -> str:
+    """Mirror inheritance.workspace_follows_organisation_admins' legacy fallback:
+    default open unless the legacy flag is explicitly False."""
+    settings = ws.get("settings")
+    if not isinstance(settings, dict):
+        settings = {}
+    follows_admins = settings.get("inherit_organisation_admins", True)
+    return OPEN if follows_admins else PRIVATE
+
+
+def backfill(dx: Directus) -> tuple[int, int]:
+    """Set visibility from the legacy flag for every row missing one.
+    Returns (updated, already_set)."""
+    res = dx.get("/items/workspace?limit=-1&fields=id,visibility,settings")
+    workspaces = res["data"]
+    updated = 0
+    already = 0
+    for ws in workspaces:
+        if ws.get("visibility"):
+            already += 1
+            continue
+        vis = visibility_from_legacy(ws)
+        dx.patch(f"/items/workspace/{ws['id']}", {"visibility": vis})
+        updated += 1
+        print(f"    workspace {ws['id']} -> visibility={vis}")
+    return updated, already
+
+
+def verify(dx: Directus) -> int:
+    """Return the number of workspaces still missing a visibility."""
+    res = dx.get("/items/workspace?limit=-1&fields=id,visibility")
+    return sum(1 for ws in res["data"] if not ws.get("visibility"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-u", "--url", required=True)
+    ap.add_argument("-e", "--email", required=True)
+    ap.add_argument("-p", "--password", required=True)
+    ap.add_argument("--dry-run", action="store_true", help="report changes without writing")
+    args = ap.parse_args()
+
+    print(f"Authenticating to {args.url} ...")
+    token = login(args.url, args.email, args.password)
+    dx = Directus(args.url, token, dry_run=args.dry_run)
+
+    print("Backfilling workspace.visibility from legacy flag ...")
+    updated, already = backfill(dx)
+    print(f"  set visibility on {updated} workspace(s); {already} already had one")
+
+    if args.dry_run:
+        print("\nDry run complete. No changes written.")
+        return 0
+
+    remaining = verify(dx)
+    if remaining:
+        print(f"\nWARNING: {remaining} workspace(s) still have no visibility.")
+        return 1
+    print("\nAll workspaces have a visibility. The legacy fallback is now inert.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/echo/server/dembrane/api/v2/workspace_settings.py
+++ b/echo/server/dembrane/api/v2/workspace_settings.py
@@ -374,34 +374,22 @@ async def update_workspace_settings(
                 _require_external_for_whitelabel(ctx)
         payload["logo_url"] = cleaned_logo or None
 
-    # Privacy flags write into workspace.settings (existing JSON column).
-    if (
-        body.inherit_organisation_admins is not None
-        or body.inherit_organisation_members is not None
-    ):
-        # Normalise NULL settings (legacy rows) to {} before dict ops.
-        current_settings = ctx.workspace.get("settings") or {}
-        if not isinstance(current_settings, dict):
-            current_settings = {}
-        # Setting inherit_organisation_admins=false makes the workspace private — gated.
-        going_private = (
-            body.inherit_organisation_admins is False
-            and current_settings.get("inherit_organisation_admins", True) is not False
-        )
+    # Privacy: the `visibility` enum is the source of truth (discovery and
+    # POST /access-requests filter on it). The request still speaks the
+    # inherit_organisation_admins boolean as the API boundary; map it onto
+    # visibility and no longer write the legacy settings.inherit_organisation_admins
+    # flag. inherit_organisation_members is accepted but ignored — member
+    # derivation is retired (matrix v1.1 §6).
+    if body.inherit_organisation_admins is not None:
+        # Open -> Private is gated. Read current state from visibility (the
+        # helper falls back to the legacy flag for not-yet-backfilled rows).
+        currently_open = workspace_follows_organisation_admins(ctx.workspace)
+        going_private = body.inherit_organisation_admins is False and currently_open
         if going_private:
             ctx.require_policy("workspace:set_private")
-
-        merged = dict(current_settings)
-        if body.inherit_organisation_admins is not None:
-            merged["inherit_organisation_admins"] = bool(body.inherit_organisation_admins)
-        if body.inherit_organisation_members is not None:
-            merged["inherit_organisation_members"] = bool(body.inherit_organisation_members)
-        payload["settings"] = merged
-        # Same mapping as workspace create (workspaces.py): discovery and
-        # POST /access-requests filter on workspace.visibility — it must move
-        # whenever Open↔Private toggles, not only settings JSON.
-        inherit_admins_effective = bool(merged.get("inherit_organisation_admins", True))
-        payload["visibility"] = "open_to_organisation" if inherit_admins_effective else "private"
+        payload["visibility"] = (
+            "open_to_organisation" if body.inherit_organisation_admins else "private"
+        )
 
     if not payload:
         raise HTTPException(status_code=400, detail="Nothing to update")

--- a/echo/server/dembrane/inheritance.py
+++ b/echo/server/dembrane/inheritance.py
@@ -54,7 +54,10 @@ def workspace_follows_organisation_admins(workspace: dict) -> bool:
         return True
     if visibility == "private":
         return False
-    # Legacy fallback until the walkback purges settings flags.
+    # Legacy fallback for rows whose visibility predates the enum and is still
+    # NULL. directus/migrations/backfill_workspace_visibility.py backfills these;
+    # once it has run in every environment this branch is dead and can be removed
+    # (visibility-only), making the settings flag fully retired.
     return _settings(workspace).get("inherit_organisation_admins", True)
 
 


### PR DESCRIPTION
## What
Retire the legacy `settings.inherit_organisation_admins` JSON flag as a *stored* field. The `workspace.visibility` enum (`open_to_organisation` | `private`) — already read first by `workspace_follows_organisation_admins` — becomes the sole written source of truth for workspace privacy.

## Why
Privacy was dual-bookkept: the `visibility` column AND a `settings.inherit_organisation_admins` boolean were both written and kept in sync. The enum is authoritative everywhere on read; the JSON flag is legacy duplication that drifts and confuses.

## Changes
- **`workspace_settings.py`** (`update_workspace_settings`): write only `visibility`; no longer write the `settings` JSON privacy flags. Going-private detection reads current state via `workspace_follows_organisation_admins(ctx.workspace)` (visibility-first). Still gated by `workspace:set_private`. `inherit_organisation_members` is accepted but ignored (member derivation retired, matrix v1.1 §6).
- **`directus/migrations/backfill_workspace_visibility.py`** (new): idempotent backfill of `visibility` from the legacy flag for pre-enum NULL rows (default-open rule). Supports `--dry-run`. No schema change (the column already exists).
- **`inheritance.py`**: comment only — documents that the legacy read-fallback is removable once the backfill has run everywhere.

## Not changing
The HTTP API still speaks the `inherit_organisation_admins` boolean (now computed from `visibility`), so the **frontend contract is unchanged** (no FE edits).

## Deploy note
Run the backfill before/with deploy (per docs/database_migrations.md), e.g.:
`python3 echo/directus/migrations/backfill_workspace_visibility.py -u <directus-url> -e <admin> -p <pw> --dry-run` then without `--dry-run`.

## Follow-up (separate PR)
Once the backfill is confirmed in all environments, remove the legacy read-fallback in `workspace_follows_organisation_admins` (visibility-only) and optionally purge the stale `settings` flags. Deferred because removing the fallback before backfill could make a NULL-visibility private workspace read as open.

## Test plan
- `ruff` clean; affected tests pass (`test_discoverable_workspaces`, `test_request_workspace_access`, `test_approve_access_request_role`)
- `/security-review` run: no findings (privacy gate semantically equivalent + more correct; no read inconsistency from dropping the dual-write)