### PR TITLE
chore(workspaces): drop legacy inherit_organisation_admins read-fallback (visibility-only)

### DIFF
--- a/echo/server/dembrane/inheritance.py
+++ b/echo/server/dembrane/inheritance.py
@@ -9,7 +9,10 @@ See docs/workspaces/inheritance-rules.md for the full spec.
 
 Settings shape on workspace.settings (JSON):
     {
-        "inherit_organisation_admins": bool  (default True)  # organisation admins follow organisation access
+        # inherit_organisation_admins: RETIRED. Admin inheritance is now driven
+        # solely by the workspace.visibility enum (see
+        # workspace_follows_organisation_admins). Stale values may linger in old
+        # rows' JSON but are never read.
         "inherit_organisation_members": bool (default False) # organisation members follow organisation access
         "sticky_removed": [                          # tombstones: no re-grant
             {"user_id": str, "removed_at": ISO8601, "removed_by": str}, ...
@@ -43,22 +46,15 @@ def _settings(workspace: dict) -> dict:
 def workspace_follows_organisation_admins(workspace: dict) -> bool:
     """True if organisation admins follow this workspace's access (inherit admin role).
 
-    Resolution order (matrix v1.1 §6 transition):
-      1. workspace.visibility column, when present: 'open_to_organisation' → True,
-         'private' → False.
-      2. Legacy settings.inherit_organisation_admins flag on pre-enum rows.
-      3. Default True (open) — matches matrix §9 default.
+    Driven solely by the workspace.visibility enum: 'private' → False, everything
+    else (the 'open_to_organisation' default, or an absent value) → True, matching
+    the matrix v1.1 §9 default-open rule.
+
+    The legacy settings.inherit_organisation_admins fallback was removed once
+    directus/migrations/backfill_workspace_visibility.py had run in every
+    environment, so no row reaches here with a NULL visibility.
     """
-    visibility = workspace.get("visibility")
-    if visibility == "open_to_organisation":
-        return True
-    if visibility == "private":
-        return False
-    # Legacy fallback for rows whose visibility predates the enum and is still
-    # NULL. directus/migrations/backfill_workspace_visibility.py backfills these;
-    # once it has run in every environment this branch is dead and can be removed
-    # (visibility-only), making the settings flag fully retired.
-    return _settings(workspace).get("inherit_organisation_admins", True)
+    return workspace.get("visibility") != "private"
 
 
 def workspace_follows_organisation_members(workspace: dict) -> bool:


### PR DESCRIPTION
## What
Final "contract" step of the privacy-flag retirement. `workspace_follows_organisation_admins` now reads **only** `workspace.visibility` (`'private'` → False, else open). The legacy `settings.inherit_organisation_admins` read-fallback is removed.

## Why now
The backfill migration (`directus/migrations/backfill_workspace_visibility.py`, shipped in #701) has run in **all environments** (echo-next: 73/73 rows already had visibility; prod confirmed), so no row reaches the resolver with a NULL visibility. The fallback was the last reader of the legacy flag.

## Safety
- Behavior-preserving: the backfill mapped legacy `false` → `private`, else `open`, so visibility-only returns the identical answer for every existing row.
- New rows always have `visibility` (create + settings-update write paths both set it; column default `open_to_organisation`).
- Verified all 18 call paths pass a workspace dict that includes `visibility` (full `get_item` fetches, explicit projections, or id-only callers that fetch internally).
- `/security-review`: no findings.

## Notes
- Stale `inherit_organisation_admins` values may linger in old rows' `settings` JSON; they are never read (a cosmetic purge is optional, not needed).
- `workspace_follows_organisation_members` is untouched (different concern, not backed by the visibility enum).
- Defense-in-depth follow-up (optional): make `visibility` `NOT NULL` with a DB default so the invariant is structural rather than procedural.

## Test plan
- `ruff` clean; `test_discoverable_workspaces` + `test_request_workspace_access` pass.