### PR TITLE
perf(org-members): batch workspace-access rollup + dedupe derived-acc…

### DIFF
--- a/echo/server/dembrane/api/v2/orgs.py
+++ b/echo/server/dembrane/api/v2/orgs.py
@@ -1554,10 +1554,17 @@ async def _rollup_workspace_access(org_id: str, user_ids: list[str]) -> dict[str
     """For each user, count how many workspaces in this organisation they can access.
 
     Access = direct workspace_membership OR derived via org role + settings.
-    Done in Python over the organisation's workspaces to match the derivation logic
-    in dembrane.inheritance exactly.
+    Same result as calling dembrane.inheritance.user_can_access per (workspace,
+    user) pair, but derives in-process from three batched fetches (workspaces,
+    org roles, direct memberships) instead of O(workspaces × users) round-trips.
+    The derived ladder is NOT reimplemented here: direct membership is checked
+    inline (it short-circuits derivation, any role counts) and everything else
+    delegates to the shared derive_workspace_role helper.
     """
-    from dembrane.inheritance import user_can_access
+    from dembrane.inheritance import derive_workspace_role
+
+    if not user_ids:
+        return {}
 
     workspaces = (
         await async_directus.get_items(
@@ -1568,7 +1575,7 @@ async def _rollup_workspace_access(org_id: str, user_ids: list[str]) -> dict[str
                         "org_id": {"_eq": org_id},
                         "deleted_at": {"_null": True},
                     },
-                    "fields": ["id"],
+                    "fields": ["id", "visibility", "settings"],
                     "limit": -1,
                 }
             },
@@ -1578,14 +1585,66 @@ async def _rollup_workspace_access(org_id: str, user_ids: list[str]) -> dict[str
     if not isinstance(workspaces, list) or not workspaces:
         return {uid: 0 for uid in user_ids}
 
+    ws_ids = [w["id"] for w in workspaces if w.get("id")]
+
+    # Org role per user (active rows only) — drives derived access.
+    org_rows = (
+        await async_directus.get_items(
+            "org_membership",
+            {
+                "query": {
+                    "filter": {
+                        "org_id": {"_eq": org_id},
+                        "user_id": {"_in": user_ids},
+                        "deleted_at": {"_null": True},
+                    },
+                    "fields": ["user_id", "role"],
+                    "limit": -1,
+                }
+            },
+        )
+        or []
+    )
+    org_role: dict[str, Optional[str]] = {
+        r["user_id"]: r.get("role")
+        for r in (org_rows if isinstance(org_rows, list) else [])
+        if r.get("user_id")
+    }
+
+    # Direct membership pairs — presence short-circuits derivation (any role counts).
+    mem_rows = (
+        await async_directus.get_items(
+            "workspace_membership",
+            {
+                "query": {
+                    "filter": {
+                        "workspace_id": {"_in": ws_ids},
+                        "user_id": {"_in": user_ids},
+                        "deleted_at": {"_null": True},
+                    },
+                    "fields": ["workspace_id", "user_id"],
+                    "limit": -1,
+                }
+            },
+        )
+        or []
+    )
+    direct_pairs: set[tuple[str, str]] = {
+        (r["workspace_id"], r["user_id"])
+        for r in (mem_rows if isinstance(mem_rows, list) else [])
+        if r.get("workspace_id") and r.get("user_id")
+    }
+
     counts = {uid: 0 for uid in user_ids}
     for w in workspaces:
+        wid = w["id"]
         for uid in user_ids:
-            if await user_can_access(w["id"], uid):
+            # Direct membership wins outright (any role). Otherwise fall back to
+            # the shared derived-access ladder.
+            if (wid, uid) in direct_pairs or derive_workspace_role(
+                w, org_role.get(uid), uid
+            ):
                 counts[uid] += 1
-    # Note: O(users × workspaces) round-trips. Fine at current scale; if a
-    # organisation ever grows past ~50 workspaces × 50 members we should batch-fetch
-    # org_memberships + workspace.settings once and derive in-process.
     return counts
 
 

--- a/echo/server/dembrane/inheritance.py
+++ b/echo/server/dembrane/inheritance.py
@@ -82,6 +82,42 @@ def is_sticky_removed(workspace: dict, user_id: str) -> bool:
     return any(t.get("user_id") == user_id for t in tombstones)
 
 
+def derive_workspace_role(
+    workspace: dict, org_role: Optional[str], user_id: str
+) -> Optional[str]:
+    """Derived (non-direct) workspace role for this user, or None. Pure, no I/O.
+
+    This is the single source of truth for the derived-access ladder. Direct
+    workspace_membership is checked by the caller and takes precedence — it is
+    NOT considered here. Callers pass the workspace row (needs visibility +
+    settings) and the user's org_membership.role for this workspace's org.
+
+    Resolution order (must stay in sync with user_can_access's documented order):
+        1. Sticky-removed → None (an explicit tombstone is never re-granted,
+           even for org owners).
+        2. Organisation owner → 'admin', regardless of workspace privacy
+           (owner carve-out: an owner can't be locked out of their own org).
+        3. Private workspace → None (blocks all remaining derivation).
+        4. Organisation admin → 'admin'.
+        5. Organisation member → 'member', iff the workspace opts in via
+           settings.inherit_organisation_members.
+
+    Returns the derived role string ('admin' / 'member'); the caller wraps it
+    with source='inherited'.
+    """
+    if is_sticky_removed(workspace, user_id):
+        return None
+    if org_role == "owner":
+        return "admin"
+    if not workspace_follows_organisation_admins(workspace):
+        return None
+    if org_role == "admin":
+        return "admin"
+    if org_role == "member" and workspace_follows_organisation_members(workspace):
+        return "member"
+    return None
+
+
 # ── Read-side resolvers ─────────────────────────────────────────────────
 
 
@@ -244,33 +280,18 @@ async def user_can_access(workspace_id: str, user_id: str) -> Optional[tuple[str
     if not workspace or workspace.get("deleted_at"):
         return None
 
-    if is_sticky_removed(workspace, user_id):
-        return None
-
     org_id = workspace.get("org_id")
     if not org_id:
         return None
 
     org_role = await _get_org_role(org_id, user_id)
 
-    # Organisation-owner carve-out: owners always derive admin access, regardless
-    # of workspace privacy. Otherwise, any workspace admin could set
-    # inherit_organisation_admins=false and lock the owner out of their own
-    # workspace — which breaks the "workspace lives in a organisation" contract.
-    if org_role == "owner":
-        return "admin", "inherited"
-
-    # Private workspace short-circuits organisation-admin and organisation-member
-    # derivation below.
-    if not workspace_follows_organisation_admins(workspace):
-        return None
-
-    if org_role == "admin":
-        return "admin", "inherited"
-
-    if org_role == "member" and workspace_follows_organisation_members(workspace):
-        return "member", "inherited"
-
+    # Derived ladder (sticky → owner carve-out → privacy → admin → member-opt-in)
+    # lives in derive_workspace_role so the batched org-members rollup
+    # (_rollup_workspace_access) shares one copy of the rules.
+    derived = derive_workspace_role(workspace, org_role, user_id)
+    if derived:
+        return derived, "inherited"
     return None
 
 

--- a/echo/server/tests/test_derive_workspace_role.py
+++ b/echo/server/tests/test_derive_workspace_role.py
@@ -1,0 +1,65 @@
+"""Unit tests for inheritance.derive_workspace_role (the derived-access ladder).
+
+This pure helper is the single source of truth for derived workspace access:
+both user_can_access (per-pair) and _rollup_workspace_access (batched org-members
+count) delegate to it. Direct membership is the callers' responsibility and is
+NOT exercised here — this only covers the derived ladder.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from dembrane.inheritance import derive_workspace_role
+
+_USER = "user-1"
+
+
+def _ws(
+    *,
+    private: bool = False,
+    inherit_members: bool = False,
+    sticky: bool = False,
+) -> dict[str, Any]:
+    """Build a workspace row with the fields the ladder reads."""
+    settings: dict[str, Any] = {"inherit_organisation_members": inherit_members}
+    if sticky:
+        settings["sticky_removed"] = [{"user_id": _USER, "removed_at": "x", "removed_by": "y"}]
+    return {
+        "id": "ws-1",
+        "visibility": "private" if private else "open_to_organisation",
+        "settings": settings,
+    }
+
+
+@pytest.mark.parametrize(
+    "workspace,org_role,expected",
+    [
+        # Owner carve-out: owners derive admin even on a private workspace.
+        (_ws(private=True), "owner", "admin"),
+        (_ws(), "owner", "admin"),
+        # Sticky-removal beats the owner carve-out (explicit tombstone stays out).
+        (_ws(sticky=True), "owner", None),
+        (_ws(sticky=True), "admin", None),
+        # Private blocks admin + member derivation (but not owner, above).
+        (_ws(private=True), "admin", None),
+        (_ws(private=True), "member", None),
+        (_ws(private=True, inherit_members=True), "member", None),
+        # Open workspace: admin derives admin.
+        (_ws(), "admin", "admin"),
+        # Open workspace: member derives only when the workspace opts in.
+        (_ws(inherit_members=True), "member", "member"),
+        (_ws(inherit_members=False), "member", None),
+        # No org role → no derived access.
+        (_ws(), None, None),
+        (_ws(inherit_members=True), None, None),
+        # Unknown/other roles (e.g. billing) never derive operational access.
+        (_ws(), "billing", None),
+    ],
+)
+def test_derive_workspace_role_ladder(
+    workspace: dict[str, Any], org_role: Optional[str], expected: Optional[str]
+) -> None:
+    assert derive_workspace_role(workspace, org_role, _USER) == expected


### PR DESCRIPTION
…ess logic

_rollup_workspace_access looped over every (workspace × member) pair calling user_can_access (~3 Directus queries each), costing W×U×3 sequential round-trips (~7,500 at 50×50) on a single /o/:id/members load.

Derive the counts in-process from 3 batched fetches (workspaces, org roles, direct memberships). Extract the derived-access ladder into a pure inheritance.derive_workspace_role so user_can_access (per-pair) and the batched rollup share one copy of the rules instead of duplicating the branch order. Add a unit test covering all five branches.