### PR TITLE
fix(workers): repair summary/merge (asyncio-in-gevent), scheduler Redis drops, NUL transcript writes

### DIFF
--- a/echo/server/dembrane/async_helpers.py
+++ b/echo/server/dembrane/async_helpers.py
@@ -224,39 +224,100 @@ def _get_thread_event_loop() -> asyncio.AbstractEventLoop:
         return loop
 
 
+# ---------------------------------------------------------------------------
+# Shared background event loop for running async code from sync contexts.
+#
+# Dramatiq actors (and CLI scripts) are synchronous but must call async code
+# (the async Directus client, LLM helpers, etc.). The previous approach created
+# a *fresh* event loop on every call and closed it immediately. That:
+#   * orphaned the connection pool of long-lived httpx.AsyncClient singletons
+#     (e.g. async_directus) -> RuntimeError("Event loop is closed"), and
+#   * under dramatiq-gevent, broke sniffio's async-library detection
+#     -> sniffio.AsyncLibraryNotFoundError,
+# so task_summarize_conversation / task_merge_conversation_chunks failed on
+# every run.
+#
+# Instead we run ONE asyncio loop for the lifetime of the process in a
+# dedicated *real* OS thread and submit coroutines to it. Because the loop
+# never closes, httpx clients bind to it once and keep pooling, and sniffio
+# sees a genuinely running asyncio loop (no nest_asyncio required). The loop
+# must live on a real OS thread (not a gevent greenlet) so its selector blocks
+# only that thread, never the gevent hub; gevent (>=25) cooperatively yields
+# while a greenlet waits on the cross-thread Future.
+# ---------------------------------------------------------------------------
+_bg_loop: Optional[asyncio.AbstractEventLoop] = None
+_bg_loop_lock = threading.Lock()
+
+
+def _real_thread_class() -> type:
+    """Return a true OS-thread class even when gevent has monkey-patched threading."""
+    try:
+        from gevent.monkey import get_original
+
+        return get_original("threading", "Thread")
+    except Exception:
+        return threading.Thread
+
+
+def _ensure_background_loop() -> asyncio.AbstractEventLoop:
+    """Get (or lazily start) the shared background event loop."""
+    global _bg_loop
+    if _bg_loop is not None and not _bg_loop.is_closed():
+        return _bg_loop
+    with _bg_loop_lock:
+        if _bg_loop is not None and not _bg_loop.is_closed():
+            return _bg_loop
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _runner() -> None:
+            asyncio.set_event_loop(loop)
+            loop.call_soon(ready.set)
+            loop.run_forever()
+
+        thread = _real_thread_class()(target=_runner, name="dembrane-async-loop", daemon=True)
+        thread.start()
+        ready.wait()
+        _bg_loop = loop
+        logger.info("Started shared background event loop on thread %s", thread.name)
+        return loop
+
+
 def run_async_in_new_loop(coro: Coroutine[Any, Any, T]) -> T:
     """
-    Execute an async coroutine in a fresh, isolated event loop.
+    Run an async coroutine to completion from a synchronous context.
 
-    Use from synchronous contexts such as Dramatiq actors or CLI scripts to
-    invoke async FastAPI handlers.
+    Use from Dramatiq actors or CLI scripts to invoke async code (async FastAPI
+    handlers, the async Directus client, LLM helpers, etc.).
 
-    A fresh loop is created per call rather than reusing a cached thread loop.
-    This prevents "Future attached to a different loop" errors when multiple
-    concurrent Dramatiq greenlets (dramatiq-gevent uses one OS thread with many
-    greenlets) share the same thread ID and would otherwise share the same loop.
-    The coroutines invoked here (summarize_conversation, get_conversation_content)
-    use only stateless async operations so fresh loops per call is safe.
+    The coroutine runs on a single long-lived background event loop (see
+    _ensure_background_loop); the calling thread/greenlet blocks on the result.
+    When called from *within* an already-running loop (e.g. a FastAPI request
+    that calls this sync helper) we fall back to nested execution on that loop
+    via nest_asyncio, preserving the previous behavior for that path.
     """
     if not asyncio.iscoroutine(coro) and not asyncio.isfuture(coro):
         raise TypeError("run_async_in_new_loop expects a coroutine or Future.")
 
-    import nest_asyncio
-
-    loop = asyncio.new_event_loop()
-    _worker_loop.set(loop)
-    # Apply nest_asyncio in case dramatiq-gevent has patched asyncio's running
-    # loop detection on this thread.
-    nest_asyncio.apply(loop)
-    logger.debug(
-        "Running async coroutine in fresh event loop: %s",
-        getattr(coro, "__qualname__", type(coro).__name__),
-    )
     try:
-        result = loop.run_until_complete(coro)
-        logger.debug(
-            "Completed async coroutine: %s", getattr(coro, "__qualname__", type(coro).__name__)
-        )
-        return result
-    finally:
-        loop.close()
+        running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if running_loop is not None:
+        # Inside a running loop (FastAPI): run nested to avoid deadlocking it.
+        import nest_asyncio
+
+        nest_asyncio.apply(running_loop)
+        return running_loop.run_until_complete(coro)
+
+    loop = _ensure_background_loop()
+    if asyncio.iscoroutine(coro):
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+    else:
+        # A bare Future/awaitable: adapt it onto the background loop.
+        async def _await_it() -> T:
+            return await coro
+
+        future = asyncio.run_coroutine_threadsafe(_await_it(), loop)
+    return future.result()

--- a/echo/server/dembrane/async_helpers.py
+++ b/echo/server/dembrane/async_helpers.py
@@ -249,7 +249,7 @@ _bg_loop: Optional[asyncio.AbstractEventLoop] = None
 _bg_loop_lock = threading.Lock()
 
 
-def _real_thread_class() -> type:
+def _real_thread_class() -> "type[threading.Thread]":
     """Return a true OS-thread class even when gevent has monkey-patched threading."""
     try:
         from gevent.monkey import get_original

--- a/echo/server/dembrane/service/conversation.py
+++ b/echo/server/dembrane/service/conversation.py
@@ -569,6 +569,21 @@ class ConversationService:
         if detected_language_confidence is not _UNSET:
             update["detected_language_confidence"] = detected_language_confidence
 
+        # Postgres text/jsonb cannot store NUL bytes (0x00). Gemini transcript
+        # correction occasionally emits them, which made the chunk update fail
+        # with: invalid byte sequence for encoding "UTF8": 0x00. Strip them from
+        # every string value (including nested diarization fields) before write.
+        def _strip_null_bytes(value: Any) -> Any:
+            if isinstance(value, str):
+                return value.replace("\x00", "")
+            if isinstance(value, dict):
+                return {k: _strip_null_bytes(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [_strip_null_bytes(v) for v in value]
+            return value
+
+        update = {k: _strip_null_bytes(v) for k, v in update.items()}
+
         if update.keys():
             try:
                 with self._client_context() as client:

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -81,6 +81,14 @@ redis_connection_string = REDIS_URL + "/1" + ssl_params
 
 broker = RedisBroker(
     url=redis_connection_string,
+    # Managed Redis closes idle connections; without health checks the
+    # scheduler's pooled broker connection goes stale between cron firings and
+    # enqueue() raises ConnectionError("Connection closed by server"), so the
+    # dispatched task is silently dropped. health_check_interval revives idle
+    # connections before use; keepalive keeps the socket warm. (passed through
+    # to the underlying redis-py client)
+    health_check_interval=25,
+    socket_keepalive=True,
     # this is to disable Prometheus (https://groups.io/g/dramatiq-users/topic/disabling_prometheus/80745532)
     # middleware=[
     #     AgeLimit,

--- a/echo/server/tests/test_async_helpers.py
+++ b/echo/server/tests/test_async_helpers.py
@@ -1,18 +1,27 @@
 """
-Tests for run_async_in_new_loop — specifically the concurrent-greenlet scenario
-that caused "Future attached to a different loop" errors under load.
+Tests for run_async_in_new_loop.
 
-Regression test for: multiple concurrent callers sharing the same OS thread
-(as dramatiq-gevent greenlets do) must not share an event loop.
+It runs coroutines from sync contexts (Dramatiq actors) on a single long-lived
+background event loop in a dedicated real OS thread. Regression coverage for the
+production failures this design fixes:
+  * concurrent callers sharing one OS thread (dramatiq-gevent greenlets) must not
+    corrupt each other's loop ("Future attached to a different loop"),
+  * a long-lived httpx.AsyncClient reused across calls must keep working
+    (no "Event loop is closed"), and
+  * async code that relies on sniffio must run under gevent without
+    AsyncLibraryNotFoundError (covered by test_gevent_async_httpx).
 """
 
+import sys
 import asyncio
 import threading
+import textwrap
+import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 
-from dembrane.async_helpers import run_async_in_new_loop
+from dembrane.async_helpers import run_async_in_new_loop, _ensure_background_loop
 
 
 async def _simple_coro(value: int) -> int:
@@ -74,8 +83,8 @@ def test_run_async_in_new_loop_concurrent_threads():
 
 def test_run_async_in_new_loop_same_thread_sequential():
     """
-    Calls from the same thread are safe when sequential.
-    Verifies loop is properly closed between calls (no 'loop is closed' error).
+    Sequential calls from the same thread all succeed. The background loop is
+    reused (never closed) between calls, so there is no 'loop is closed' error.
     """
     for i in range(5):
         result = run_async_in_new_loop(_simple_coro(i))
@@ -88,8 +97,9 @@ def test_run_async_in_new_loop_same_thread_id_concurrent():
     that all share the same thread ID (simulated by patching get_ident).
 
     Before the fix (persistent loop per thread ID), all concurrent callers
-    shared one loop → "Future attached to a different loop".
-    After the fix (fresh loop per call), each call is isolated.
+    shared one loop driven by multiple greenlets → "Future attached to a
+    different loop". The shared background loop runs on its own dedicated thread,
+    so caller thread IDs are irrelevant.
     """
     original_get_ident = threading.get_ident
     # Make all threads report the same thread ID — exactly what gevent does
@@ -121,3 +131,80 @@ def test_run_async_in_new_loop_rejects_non_coroutine():
     """Type guard still works."""
     with pytest.raises(TypeError, match="expects a coroutine or Future"):
         run_async_in_new_loop(42)  # type: ignore
+
+
+def test_background_loop_is_reused():
+    """The same long-lived loop backs every call (never recreated/closed)."""
+    run_async_in_new_loop(_simple_coro(1))
+    loop_a = _ensure_background_loop()
+    run_async_in_new_loop(_simple_coro(2))
+    loop_b = _ensure_background_loop()
+    assert loop_a is loop_b
+    assert not loop_a.is_closed()
+
+
+def test_reused_async_client_across_calls():
+    """
+    Regression for task_merge_conversation_chunks' "Event loop is closed".
+
+    A long-lived httpx.AsyncClient (like async_directus) bound to the background
+    loop on first use must keep working across many run_async_in_new_loop calls.
+    The old fresh-loop-per-call design orphaned the client's pool on the closed
+    loop, so the second call raised RuntimeError("Event loop is closed").
+    """
+    import httpx
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})),
+        base_url="http://test",
+    )
+
+    async def _call() -> bool:
+        resp = await client.get("/ping")
+        return resp.json()["ok"]
+
+    try:
+        for _ in range(10):
+            assert run_async_in_new_loop(_call()) is True
+    finally:
+        run_async_in_new_loop(client.aclose())
+
+
+def test_gevent_async_httpx():
+    """
+    Regression for task_summarize_conversation's sniffio
+    AsyncLibraryNotFoundError under dramatiq-gevent.
+
+    Runs in a subprocess so gevent's monkeypatch is applied before imports (as
+    dramatiq-gevent does). Many greenlets drive async httpx (which calls
+    sniffio.current_async_library()) through run_async_in_new_loop concurrently.
+    """
+    script = textwrap.dedent(
+        """
+        from gevent import monkey; monkey.patch_all()
+        import asyncio, httpx, gevent
+        from dembrane.async_helpers import run_async_in_new_loop
+
+        _client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})),
+            base_url="http://test",
+        )
+
+        async def work(_):
+            await asyncio.sleep(0.02)
+            r = await _client.get("/ping")  # sniffio detection happens here
+            return r.json()["ok"]
+
+        jobs = [gevent.spawn(lambda i=i: run_async_in_new_loop(work(i))) for i in range(20)]
+        gevent.joinall(jobs, timeout=30)
+        errs = [repr(j.exception) for j in jobs if j.exception is not None]
+        assert not errs, errs
+        assert all(j.value is True for j in jobs)
+        print("PASS")
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "PASS" in proc.stdout

--- a/echo/server/tests/test_async_helpers.py
+++ b/echo/server/tests/test_async_helpers.py
@@ -14,8 +14,8 @@ production failures this design fixes:
 
 import sys
 import asyncio
-import threading
 import textwrap
+import threading
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -155,7 +155,7 @@ def test_reused_async_client_across_calls():
     import httpx
 
     client = httpx.AsyncClient(
-        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})),
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={"ok": True})),
         base_url="http://test",
     )
 
@@ -186,7 +186,7 @@ def test_gevent_async_httpx():
         from dembrane.async_helpers import run_async_in_new_loop
 
         _client = httpx.AsyncClient(
-            transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})),
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={"ok": True})),
             base_url="http://test",
         )
 


### PR DESCRIPTION
## Summary

Conversation summaries and chunk merging were failing at ~100% in production, and the scheduler was intermittently dropping cron-dispatched work. This PR fixes the two underlying reliability bugs plus a transcript data-corruption bug. A related production infra change (Valkey idle timeout) was already applied live and is documented below.

User-visible symptom that started this: "summaries are terribly slow after someone clicks finish conversation." It was not slow, it was broken: summaries never landed.

## Problem diagnosis

Investigated the prod k8s cluster (`echo-prod`) logs across api, workers, scheduler, and directus.

### 1. Summarization totally broken (P0)
- `task_summarize_conversation`: **0 completions in 12h, 822+ failures in 6h** across the network workers, 72 distinct conversations affected. Prod DB confirmed it: of the last 40 conversations, 35 were `is_finished=True` + `is_all_chunks_transcribed=True` but had `summary = NULL`.
- Failure: `sniffio._impl.AsyncLibraryNotFoundError: unknown async library, or not in async context`, raised on the very first async call (`async_directus.get_item` -> `httpx.AsyncClient` -> sniffio), before reaching the LLM.

### 2. Chunk merging broken (P0, same root cause)
- `task_merge_conversation_chunks`: 39 failures in 6h with `RuntimeError: Event loop is closed`, same call site (`async_directus.get_item`). Merged transcripts (used by reports/export) were not being produced.

### Root cause (both)
Every Dramatiq actor ran async code through `run_async_in_new_loop`, which **created and then closed a throwaway event loop on every call**. That single design choice caused both failures:
- The process-global async httpx client (`async_directus`) bound its connection pool to a loop that was then closed -> `RuntimeError: Event loop is closed`.
- Under dramatiq-gevent, many greenlets share one OS thread; interleaving across those ephemeral loops corrupts asyncio's thread-local running loop, so `sniffio.current_async_library()` cannot detect the backend -> `AsyncLibraryNotFoundError`.

Everything bolted around this (`nest_asyncio`, the `_worker_loop` ContextVar, `safe_gather`, per-thread loop caches) was scaffolding to survive the throwaway-loop choice. The fix removes the need for it.

### 3. Scheduler dropping enqueued work (P1)
- `echo-worker-scheduler`: 37 `redis.exceptions.ConnectionError: Connection closed by server` in 6h. Cron jobs failed at `dramatiq...redis.py enqueue() -> do_dispatch`, so the dispatched task was silently dropped. Affected jobs: collect-and-finish unfinished conversations, reconcile transcribed flag, catch-up unsummarized, scheduled report dispatch, and billing jobs (activate accounts, re-price, downgrade).
- Cause: managed Valkey closes idle connections (`ValkeyTimeout=300`). The scheduler's pooled broker connection sits idle between cron firings (the 15-min and hourly jobs always exceed 300s), so the next `enqueue()` hits a server-closed socket.

### 4. NUL byte breaks transcript correction (P2)
- `task_correct_transcript` (Gemini pass) occasionally emits a `\x00` byte into `conversation_chunk.transcript`; Postgres rejects the row: `invalid byte sequence for encoding "UTF8": 0x00` (6 worker + 30 directus errors in 6h).

## What this PR changes

- **`async_helpers.py`**: run all actor coroutines on a single long-lived asyncio loop in a dedicated real OS thread; actors submit via `run_coroutine_threadsafe(...).result()`. The loop never closes, so httpx clients bind once and pool correctly, and sniffio sees a genuinely running loop (no `nest_asyncio`). A real OS thread keeps asyncio's selector off the gevent hub; gevent (>=25) yields cooperatively while a greenlet waits on the cross-thread result. The already-running-loop path (FastAPI) keeps the nested `nest_asyncio` behavior. Fixes summarize + merge (and the other 12 callers: billing reconcile, notifications, report creator).
- **`tasks.py`**: add `health_check_interval=25` and `socket_keepalive=True` to the Redis broker so the client revives idle pooled connections before use. This is the durable client-side defense against dropped connections (failover, network blips), complementary to the server-side timeout change below.
- **`service/conversation.py` (`update_chunk`)**: strip NUL (`0x00`) bytes from string/dict/list values (transcript, raw_transcript, nested diarization) before the Directus write.
- **`tests/test_async_helpers.py`**: new regression coverage and updated docstrings.

## Production action already taken (not in this PR)

To unblock the scheduler immediately without waiting for a release, the managed Valkey idle timeout was disabled live:

```
doctl databases configuration update <prod-redis-id> --engine valkey --config-json '{"valkey_timeout": 0}'
```

This is the source-level fix; the `health_check_interval` in this PR is the complementary client-side defense. Verified: scheduler `Connection closed by server` errors stopped after the change (0 since), no restart/failover required. Reversible with `{"valkey_timeout": 300}`.

## Validation

Validated against the modified code (existing repo `.venv` is the Linux container's, so a throwaway host venv was used; CI runs the full suite on Linux):

- `tests/test_async_helpers.py`: 9/9 pass, including a new subprocess test that runs the **gevent + sniffio** path (the exact summarize failure) and a reused-async-client test (the exact merge failure, no "Event loop is closed").
- Reproduced the OLD failure under gevent to confirm the diagnosis: `RuntimeError: ...different loop` 19/20 + `AsyncLibraryNotFoundError` 1/20.
- Realistic summarize path (real `run_in_thread_pool` + async httpx, 20 greenlets under gevent): 20/20, fully concurrent.
- Confirmed dramatiq 1.17 + redis-py accept the broker kwargs.

## How to test

1. Deploy this branch to a worker environment (or run the network + cpu workers locally).
2. Finish a conversation (or trigger `task_summarize_conversation` / `task_merge_conversation_chunks`).
3. Expect: `task_summarize_conversation.completed` in worker logs, `summary` populated on the conversation, no `AsyncLibraryNotFoundError` / `Event loop is closed`.
4. Scheduler: no `Connection closed by server`; cron jobs dispatch cleanly.
5. `cd echo/server && uv run pytest tests/test_async_helpers.py`.

## Out of scope (separate follow-ups)

- **echo-agent down** (`ImagePullBackOff`): the agent image for the deployed commit was never pushed to the registry. Needs a CI rebuild or rollback in the gitops repo.
- **`workspace.tier` / `directus_users.admin_access` 403s**: missing field/permission from the in-flight migration.
- **`ValkeyMaxmemoryPolicy = allkeys-lru`** on the shared broker+cache cluster: under memory pressure Valkey can evict broker queue keys / task results (silent task loss). Left as-is; worth revisiting (dedicated broker instance or policy change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
