### PR TITLE
docs(analytics): plan for proxy + server-side business events

### DIFF
--- a/echo/docs/analytics-implementation-plan.md
+++ b/echo/docs/analytics-implementation-plan.md
@@ -1,0 +1,133 @@
+# Analytics instrumentation: implementation plan
+
+Engineering companion to the team-facing `docs/plan.md`. That doc is the "what
+and why" for a non-technical audience. This one is the "how" for whoever picks
+up the build. Nothing here is built yet; this is the agreed shape.
+
+## Goal
+
+Capture the business and product moments we currently can't see, and make the
+numbers trustworthy by (a) surviving ad blockers and (b) recording
+source-of-truth moments on the server where the browser can't be blocked.
+
+## Foundations
+
+### A. Reverse proxy (client events survive ad blockers)
+
+PostHog's prescribed default is a **managed reverse proxy** (CNAME a subdomain to
+a PostHog-provided host; they run it on Cloudflare, free for Cloud users). The
+self-hosted options are for cost or compliance cases.
+
+For us the deciding factor is **EU data residency** (civic/PII tool, EU PostHog
+projects, EU SendGrid). None of the options is automatically clean:
+
+| Option | Effort | Residency | Notes |
+|---|---|---|---|
+| Managed CNAME (`e.dembrane.com`) | Lowest | Cloudflare EU edge, "not strictly guaranteed", not HIPAA | PostHog's default. Needs DNS + privacy sign-off. |
+| Self-host in our ams3 cluster (nginx/Caddy) | Highest | Best, fully ours | Uses existing `echo-gitops` infra. We own maintenance. |
+| Vercel `vercel.json` rewrites (`/i`) | Low | Transits Vercel edge | Ship-today stopgap. PostHog won't troubleshoot. Vercel data-transfer fees (small since portal is event-only). |
+
+Decision is open (see below). The Vercel `/i` stopgap, if used, is the EU config
+below. Three rules, in order, **above** the catch-all `/(.*) -> /` rewrite:
+
+```json
+{
+  "rewrites": [
+    { "source": "/i/static/:path(.*)", "destination": "https://eu-assets.i.posthog.com/static/:path" },
+    { "source": "/i/array/:path(.*)",  "destination": "https://eu-assets.i.posthog.com/array/:path" },
+    { "source": "/i/:path(.*)",        "destination": "https://eu.i.posthog.com/:path" }
+  ]
+}
+```
+
+SDK (`frontend/src/main.tsx` + `config.ts`): `api_host: "/i"`,
+`ui_host: "https://eu.posthog.com"`. The `/array/` rule is required (SDK config +
+flags); without it things break silently. `vite.config.ts` `server.proxy` is
+local-dev only and does nothing in production (Vercel rewrites do prod). Local
+capture is off anyway, so the vite proxy is optional parity.
+
+CSP in `frontend/vercel.json` must be updated; the requests become same-origin.
+This touches security, so run `/security-review` on the proxy change.
+
+### B. Server-side capture
+
+Reuse `server/dembrane/analytics.py` `capture_event` (fire-and-forget, never
+raises, env-gated to prod + echo-next). `distinct_id = email or app_user_id`, as
+the existing onboarding event does.
+
+### Naming convention
+
+- Server-originated events get a `server_` prefix (e.g. `server_workspace_created`).
+- Exception: where a client and server event are two ends of one funnel
+  (registration), keep a shared base name + a `source: "server" | "client"`
+  property so PostHog's funnel tool can relate them.
+- Keep the existing `snake_case` past-tense style and funnel-pair pattern.
+
+## Phase 1: Server-side business events
+
+| Event | Endpoint |
+|---|---|
+| `server_user_created` | `POST /v2/auth/register` (`auth.py:274`) |
+| `server_workspace_created` | `POST /v2/workspaces` (`workspaces.py:633`) |
+| `server_tier_changed` | `PATCH /v2/workspaces/{id}/tier` (`workspaces.py:976`) |
+| `server_invite_sent` / `server_invite_resent` | `invites.py:110`, `invite_actions.py:124` |
+| `server_invite_accepted` / `server_member_joined` | accept + join endpoints in `access_requests.py` |
+| `server_workspace_join_requested` / `_approved` / `_denied` | `access_requests.py:199/288/498` |
+| `server_training_requested` | `training.py:251` |
+
+`invite_sent` fires when we hand the email to SendGrid (we control it). True
+`delivered`/`opened` need a SendGrid event webhook; deferred.
+
+## Phase 2: Portal journey + source attribution (frontend)
+
+- **Source attribution**: extend `useProjectSharingLink(project, source)` to append
+  `utm_source` (PostHog auto-captures `utm_*`). Tag the surfaces: the QR's encoded
+  `value` vs its clickable `href` get different tags (splits scan vs click);
+  `copy_link`, `qr_download`, `host_guide`, `report`, `portal`. Migrate the
+  hand-built `/start` URLs (`ProjectReportRoute.tsx:796`, participant-side,
+  `config.ts:171`) onto the hook so nothing ships untagged.
+- **Journey funnel** (client, participant routes): `portal_landed` ->
+  `consent_given` -> `recording_started`/`upload_started` -> `conversation_finished`
+  -> `report_viewed`.
+- **Recording errors**: promote the `captureException` at
+  `ParticipantConversationAudio.tsx:334` to a first-class
+  `portal_recording_error {stage, mime_type, device}` so we get a rate.
+- **Privacy gate**: no session recording on the portal; participants are
+  anonymous (no `identify`). Sign-off before shipping.
+
+## Phase 3: App-health events
+
+- `server_conversation_finished {method: "explicit" | "auto"}` — tag where
+  `is_finished` is set: user finish endpoint = explicit, L1 catch-up in `tasks.py`
+  = auto.
+- `server_summary_generated {duration_seconds, conversation_type}` — piggyback on
+  the finalization task that runs when the summary lands. Duration from the
+  transcribed/finish timestamp to now (confirm a timestamp exists to diff).
+- `verify_used` / `verify_regenerated` — participant verify flow (`VerifyArtefact.tsx`).
+- `explore_used {mode}` (piggyback on existing `chat_mode_selected`) /
+  `explore_rate_limited` (where the 429 surfaces).
+
+## Phase 4: Website + Tally (needs coordination, outside this repo)
+
+- Confirm the marketing site runs the same PostHog project so the cross-subdomain
+  cookie actually stitches website visitor -> signup.
+- Wire Tally's native PostHog integration (or capture on submit).
+
+## Recommended build order
+
+1. Proxy foundation (recovers all client-side events).
+2. Portal journey + source attribution (biggest blind spot).
+3. App-health events (cheap, mostly server-side piggybacks).
+4. Server-side business events.
+5. Website + Tally (waits on DNS/marketing/privacy).
+
+## Open decisions (for the team / Sameer)
+
+1. **Proxy home**: managed CNAME vs self-host in ams3 vs Vercel `/i` stopgap.
+   Hinges on EU residency tolerance and who owns DNS/infra.
+2. PostHog MCP connection (audit live events before building to avoid duplicates).
+   Connect manually: `claude mcp add posthog --transport http https://mcp.posthog.com/mcp`
+   then `/mcp` to authenticate (the `npx @posthog/wizard` TUI can't run headless).
+3. Confirm the marketing site shares our PostHog project.
+4. Dashboards/insights are owned by analytics and must be created in **both** EU
+   projects (production 160282 and echo-next 197841), never just one.

--- a/echo/docs/plan.md
+++ b/echo/docs/plan.md
@@ -1,0 +1,34 @@
+# Sharing to team plan
+
+The goal: capture the business moments we currently can't see, so we can answer basic questions like "where did this customer come from?", "of everyone who scans a QR, how many actually contribute?", and "how long does a host wait for their summary?". Today a lot of this is invisible to us.
+
+Two foundations make the numbers trustworthy:
+
+- A proxy so ad blockers stop quietly eating our data (we lose an estimated 10-30% today).
+- Recording the highest-value moments on our servers, not just in the browser, so they can't be blocked or lost (a payment clearing, a conversation finishing, a summary landing).
+
+Read it and tell me what's missing. What would you want to know that you can't see today?
+
+## Website -> Dashboard funnels
+
+- Marketing site -> dashboard. Connect a website visitor to the account they later create, so we can see which traffic turns into real hosts.
+- "Get in touch" (Tally) -> signup. Today the form lives in Tally and never reaches our analytics, so a website inquiry is disconnected from who signs up. This is the real top of the sales funnel while we're invoiced.
+- Registration. Landed -> filled details -> account created. We'll confirm the account on the server side too, so ad blockers can't hide signups.
+- Onboarding. Questionnaire completed, plus the role and intent they told us (whether they work with clients).
+- Invitations. Invite sent -> email delivered -> opened -> accepted -> active member. We're almost completely blind here today, so we can't see where invites fall apart.
+- Workspace creation. Started the wizard -> chose internal team vs external client -> switched back and forth -> created. The "switched back" moment answers "how many people backtrack from external to internal?".
+- Buying intent. Hit a paywall, opened billing, or clicked "Book a call". We have both paths already: self-serve checkout exists, and gated features open a booking link. Since we invoice everyone today, these intent signals are what should feed sales, more than self-serve checkout.
+
+## Portal
+
+- The journey funnel. Landed -> gave consent -> started recording or upload -> finished -> saw their report. This gives us the one number we most lack: of everyone who scans, how many actually contribute.
+- Source attribution at landing. Tag every way a link goes out (scanned QR, clicked QR, copied link, downloaded QR, host guide, report, from inside the portal) so we can split "how many came from a QR vs a link vs the printed guide" the instant anyone lands.
+- Conversation finish: explicit vs automatic. Did the host or participant actually press finish, or did our system close an abandoned conversation for them? Tells us whether the finish step is even discoverable.
+- Finish -> summary time. How long a host waits between recording ending and their summary appearing. This is their perceived wait, and we have zero visibility into it today.
+- Verify usage and regenerate. Whether the verify step gets used, and how often people regenerate. A proxy for how good the first result is.
+- Explore usage and rate limiting. How much explore and deep-dive get used and, critically, how often people slam into a limit. Both a quality and a packaging signal.
+- Portal recording errors. Recording failures are silent lost data today. We want a real error rate, not one-off reports.
+
+## A note on privacy
+
+Portal participants are anonymous and the tool handles sensitive input. Portal tracking should be event-only (no session recording) and run past whoever owns privacy first.


### PR DESCRIPTION
## What

Draft plan (docs only, no code) for instrumenting the analytics we currently can't see: where customers come from, the participant journey, and app health.

Two docs:
- `docs/plan.md` — team-facing "what and why", non-technical. Meant to seed a discussion thread.
- `docs/analytics-implementation-plan.md` — engineering companion: the "how", phased, with endpoints and the corrected proxy config.

## Highlights for review

- **Reverse proxy** to stop ad blockers eating client events. Open call on the home: managed CNAME (`e.dembrane.com`) vs self-host in our ams3 cluster vs a Vercel `/i` stopgap. Hinges on EU data residency tolerance.
- **Server-side capture** for source-of-truth moments (reusing `analytics.py`), so they can't be blocked or lost. Naming: `server_` prefix, with a `source` property for cross-client funnels like registration.
- **Portal journey + source attribution** (QR vs link vs printed guide), our biggest blind spot today.
- **App-health events**: explicit vs automatic conversation finish, finish to summary time, verify/explore usage + rate limiting, portal recording errors.
- Buying intent: confirmed we have both self-serve checkout and a "book a call" contact-sales link today.

## Status

Planning only. Nothing built. Open decisions are listed at the bottom of the implementation doc (proxy home, PostHog MCP connection, marketing-site PostHog project, dashboards in both EU projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
