### PR TITLE
fix(workers): don't take nest_asyncio fallback under gevent (residual summary hangs)

### DIFF
--- a/echo/server/dembrane/async_helpers.py
+++ b/echo/server/dembrane/async_helpers.py
@@ -259,6 +259,16 @@ def _real_thread_class() -> "type[threading.Thread]":
         return threading.Thread
 
 
+def _is_gevent_patched() -> bool:
+    """True when gevent has monkey-patched the runtime (i.e. the dramatiq-gevent worker)."""
+    try:
+        from gevent import monkey
+
+        return bool(monkey.is_anything_patched())
+    except Exception:
+        return False
+
+
 def _ensure_background_loop() -> asyncio.AbstractEventLoop:
     """Get (or lazily start) the shared background event loop."""
     global _bg_loop
@@ -292,24 +302,33 @@ def run_async_in_new_loop(coro: Coroutine[Any, Any, T]) -> T:
 
     The coroutine runs on a single long-lived background event loop (see
     _ensure_background_loop); the calling thread/greenlet blocks on the result.
-    When called from *within* an already-running loop (e.g. a FastAPI request
-    that calls this sync helper) we fall back to nested execution on that loop
-    via nest_asyncio, preserving the previous behavior for that path.
+
+    When called from *within* an already-running loop on the FastAPI (asyncio
+    uvicorn) server we fall back to nested execution on that loop via
+    nest_asyncio, preserving the previous behavior for that path.
+
+    Under dramatiq-gevent we must NOT use that fallback: asyncio's running-loop
+    is thread-local and shared across greenlets, so get_running_loop() can return
+    a loop that a *different* greenlet is driving. Taking the nested path then
+    drives a foreign/contended loop and the actor hangs until TimeLimitExceeded.
+    In the gevent worker we always use the dedicated background loop (its own OS
+    thread), which is immune to greenlet interleaving.
     """
     if not asyncio.iscoroutine(coro) and not asyncio.isfuture(coro):
         raise TypeError("run_async_in_new_loop expects a coroutine or Future.")
 
-    try:
-        running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
-    except RuntimeError:
-        running_loop = None
+    if not _is_gevent_patched():
+        try:
+            running_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
 
-    if running_loop is not None:
-        # Inside a running loop (FastAPI): run nested to avoid deadlocking it.
-        import nest_asyncio
+        if running_loop is not None:
+            # Inside a real running loop (FastAPI): run nested to avoid deadlocking it.
+            import nest_asyncio
 
-        nest_asyncio.apply(running_loop)
-        return running_loop.run_until_complete(coro)
+            nest_asyncio.apply(running_loop)
+            return running_loop.run_until_complete(coro)
 
     loop = _ensure_background_loop()
     if asyncio.iscoroutine(coro):

--- a/echo/server/tests/test_async_helpers.py
+++ b/echo/server/tests/test_async_helpers.py
@@ -208,3 +208,55 @@ def test_gevent_async_httpx():
     )
     assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
     assert "PASS" in proc.stdout
+
+
+def test_gevent_ignores_running_loop_detection():
+    """
+    Regression for the stuck-summary hang seen on Echo Next.
+
+    Under dramatiq-gevent, asyncio's running-loop is thread-local and shared
+    across greenlets, so get_running_loop() can return a loop a *different*
+    greenlet is driving. The old fallback then drove that foreign loop and the
+    actor hung until dramatiq's TimeLimitExceeded. Under gevent,
+    run_async_in_new_loop must IGNORE get_running_loop() and always use the
+    dedicated background loop (its own real OS thread).
+
+    Deterministic: we make get_running_loop() on the *calling* greenlet return a
+    sentinel that raises if driven (the bg loop runs on a separate real thread,
+    so it keeps the real get_running_loop). The fix must never touch the sentinel.
+    Runs in a subprocess so gevent patches before imports.
+    """
+    script = textwrap.dedent(
+        """
+        from gevent import monkey; monkey.patch_all()
+        import asyncio, threading
+        from dembrane.async_helpers import run_async_in_new_loop
+
+        class _BoomLoop:
+            def run_until_complete(self, coro):
+                raise AssertionError("took the contended running-loop fallback path")
+
+        _real = asyncio.get_running_loop
+        _caller_ident = threading.get_ident()
+        def _fake_get_running_loop():
+            # Only lie to the calling greenlet; the bg loop's real OS thread
+            # (different ident) keeps the genuine implementation.
+            if threading.get_ident() == _caller_ident:
+                return _BoomLoop()
+            return _real()
+        asyncio.get_running_loop = _fake_get_running_loop
+
+        async def work():
+            await asyncio.sleep(0.02)
+            return threading.current_thread().name
+
+        ran_on = run_async_in_new_loop(work())
+        assert ran_on == "dembrane-async-loop", ran_on  # used the bg loop, not the sentinel
+        print("PASS")
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "PASS" in proc.stdout


### PR DESCRIPTION
## Summary

Follow-up to #712. After that fix deployed to Echo Next, **most** summaries worked, but a subset still hung and never completed. This PR fixes the remaining cause.

## What we found on Echo Next

- Recent conversations summarized correctly (e.g. `ec2a9c6b` finished with a 384-char summary after a catch-up cycle). The shared-loop fix works.
- But two conversations (`46aeea9e`, `f3e878ba`) were stuck: the catch-up scheduler re-dispatched them every cycle, `task_summarize_conversation` started ("Summarizing... 1/1 chunks"), then died with `dramatiq.middleware.time_limit.TimeLimitExceeded`. Their chunks were fully transcribed with real text and no coordination locks, so it was not empty-transcript or lock-related.

The traceback pointed straight at the fallback path added in #712:
```
tasks.py  run_async_in_new_loop(...)
async_helpers.py  return running_loop.run_until_complete(coro)   # nest_asyncio fallback
nest_asyncio  _run_once -> selector.select -> gevent ...
dramatiq.middleware.time_limit.TimeLimitExceeded
```

## Root cause

#712 added a fallback: if `asyncio.get_running_loop()` reports a running loop (the FastAPI case), run the coroutine nested on that loop via nest_asyncio instead of the background loop.

Under **dramatiq-gevent**, asyncio's running-loop is **thread-local and shared across greenlets** (greenlets share one OS thread). So when one greenlet is driving a loop, another greenlet's `task_summarize_conversation` calls `get_running_loop()` and gets a loop a *different* greenlet owns. Driving that foreign/contended loop via `run_until_complete` hangs the actor until the dramatiq time limit kills it. It is intermittent (depends on greenlet overlap), which is why only some conversations were affected.

## Fix

Gate the fallback on `not _is_gevent_patched()`:
- **Under gevent (network worker):** always use the dedicated background loop (its own real OS thread, immune to greenlet interleaving). Never call `get_running_loop()`.
- **Non-gevent + running loop (FastAPI asyncio uvicorn worker):** keep the nested nest_asyncio path so `async_directus` stays bound to the uvicorn loop.
- **Non-gevent + no running loop (cpu worker / CLI):** background loop, as before.

## Validation

- `tests/test_async_helpers.py`: 10/10 pass, including a new deterministic regression test `test_gevent_ignores_running_loop_detection`. It makes `get_running_loop()` on the calling greenlet return a sentinel that raises if driven, and asserts the coroutine still runs on the `dembrane-async-loop` background thread.
- Confirmed the test is a real guard: with the gate removed it **fails**; with the gate it passes.

## After merge

Echo Next will pick this up automatically. The two stuck conversations should summarize on the next catch-up cycle (their locks are TTL-bound, no manual cleanup needed). Prod still needs a release tag to get both #712 and this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
