### PR TITLE
fix(summarize): don't retry tier-locked (402) conversations; recover via catch-up

### DIFF
--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -630,6 +630,20 @@ def task_summarize_conversation(conversation_id: str) -> None:
         clear_summarize_in_progress(conversation_id)
         return
     except Exception as e:
+        # Tier-locked (free tier): summarize_conversation raises HTTPException 402
+        # when the conversation is locked. Retrying is pointless — the lock only
+        # lifts on upgrade, and dramatiq retries would just churn and eventually
+        # dead-letter the message (lost). Skip retries and CLEAR the lock so the
+        # catch-up scheduler (task_catch_up_unsummarized_conversations) can
+        # re-attempt cleanly: summary stays null, so the conversation remains in
+        # the catch-up set and gets summarized automatically once they upgrade.
+        if getattr(e, "status_code", None) == 402:
+            logger.info(
+                f"Conversation {conversation_id} is tier-locked (402); skipping summary "
+                "until the workspace upgrades (catch-up will retry)."
+            )
+            clear_summarize_in_progress(conversation_id)
+            return
         logger.error(f"Error: {e}")
         # Retriable error - don't clear lock, let TTL handle it
         # This prevents catch-up task from starting duplicate work during retry window

--- a/echo/server/tests/test_tasks_summarize_tier_lock.py
+++ b/echo/server/tests/test_tasks_summarize_tier_lock.py
@@ -1,0 +1,82 @@
+"""
+task_summarize_conversation must treat a tier-lock (HTTPException 402) as
+non-retriable: return cleanly and clear the summarize lock so the catch-up
+scheduler re-attempts it (and succeeds once the workspace upgrades). Genuine
+errors must still retry (re-raise, lock retained).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+import dembrane.tasks as tasks
+import dembrane.coordination as coordination
+from dembrane.service import conversation_service
+
+
+class _Locked402(Exception):
+    """Mimics fastapi.HTTPException(status_code=402) — what summarize raises when locked."""
+
+    status_code = 402
+
+
+def _common_monkeypatch(monkeypatch, cleared):
+    monkeypatch.setattr(tasks, "ProcessingStatusContext", lambda **_kw: nullcontext())
+    monkeypatch.setattr(
+        conversation_service,
+        "get_by_id_or_raise",
+        lambda cid: {"id": cid, "is_finished": False, "summary": None, "project_id": "p1"},
+    )
+    monkeypatch.setattr(
+        conversation_service,
+        "get_chunk_counts",
+        lambda _cid: {"total": 1, "ok": 1, "error": 0, "processed": 1, "pending": 0},
+    )
+    monkeypatch.setattr(coordination, "mark_summarize_in_progress", lambda _cid: True)
+    monkeypatch.setattr(
+        coordination, "clear_summarize_in_progress", lambda cid: cleared.append(cid)
+    )
+
+
+def _raise_in_loop(exc):
+    def _run(coro):
+        # the actor passes summarize_conversation(...) coro here; close it to
+        # avoid an "un-awaited coroutine" warning, then raise as if it failed.
+        try:
+            coro.close()
+        except Exception:
+            pass
+        raise exc
+
+    return _run
+
+
+def test_summarize_tier_locked_402_skips_retry_and_clears_lock(monkeypatch):
+    cleared: list[str] = []
+    _common_monkeypatch(monkeypatch, cleared)
+    monkeypatch.setattr(
+        tasks,
+        "run_async_in_new_loop",
+        _raise_in_loop(_Locked402("Conversation is locked. Upgrade to generate a summary.")),
+    )
+
+    # Must NOT raise (so dramatiq does not retry / dead-letter the message).
+    assert tasks.task_summarize_conversation("conv-locked") is None
+    # Lock cleared so the catch-up scheduler can re-attempt after upgrade.
+    assert cleared == ["conv-locked"]
+
+
+def test_summarize_genuine_error_still_retries(monkeypatch):
+    cleared: list[str] = []
+    _common_monkeypatch(monkeypatch, cleared)
+    monkeypatch.setattr(
+        tasks, "run_async_in_new_loop", _raise_in_loop(RuntimeError("transient LLM error"))
+    )
+
+    # Non-402 errors must propagate so dramatiq retries them...
+    with pytest.raises(RuntimeError):
+        tasks.task_summarize_conversation("conv-error")
+    # ...and the lock must be retained (let TTL handle it during the retry window).
+    assert cleared == []


### PR DESCRIPTION
## Summary

Free-tier-locked conversations were stuck in a wasteful retry loop. This makes the tier-lock non-retriable while keeping automatic recovery on upgrade.

## What was happening (found on Echo Next)

After #712/#718, two conversations still never summarized. The traceback:
```
conversation.py  summarize_conversation
fastapi.exceptions.HTTPException: 402: Conversation is locked. Upgrade to generate a summary.
```
They are on a **free-tier** workspace, so summarization is intentionally gated (from #710). But `task_summarize_conversation` re-raised the 402 as a normal error, so:
- dramatiq retried it (exponential backoff, eventually dead-letter), and
- the catch-up scheduler re-dispatched it every 5 min,

churning the worker and the summarize lock for a call that can **never** succeed on retry — the lock only lifts on upgrade.

## Fix

`task_summarize_conversation` now treats an HTTPException **402** as non-retriable:
- log it,
- `clear_summarize_in_progress(...)`,
- return without raising (so dramatiq does not retry / dead-letter).

Genuine errors still re-raise (retry) with the lock retained, unchanged.

## How upgrade-recovery works (no extra code needed)

The catch-up scheduler `task_catch_up_unsummarized_conversations` (every 5 min) finds `is_all_chunks_transcribed = True AND summary IS NULL` and re-dispatches summarize. We deliberately do **not** exclude locked conversations from it:
- **While locked:** each cycle dispatches → 402 → clean skip (one cheap tier check), summary stays null.
- **After upgrade:** the lock lifts, the next cycle summarizes it and it drops out of the set.

So locked conversations are retried automatically on upgrade; we only removed the pointless tight retry loop, not the recovery path.

## Scope (only summarize is affected)

- `summarize_conversation` (this task): tier 402 from a background actor → fixed here.
- `generate_title_for_conversation` and report gating (`free_tier_limit_error`): raised at the **API request layer** (402 returned to the user) — no retry loop.
- `get_conversation_content` (the merge path): no tier gate.

## Tests

`tests/test_tasks_summarize_tier_lock.py`:
- 402 → task returns without raising and clears the lock.
- non-402 error → task re-raises (retries) and retains the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
