### PR TITLE
feat(analytics): portal participant journey + link source attribution

### DIFF
--- a/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
@@ -130,7 +130,7 @@ export const ParticipantConversationAudio = () => {
 
 	// Navigation and language
 	const navigate = useI18nNavigate();
-	const newConversationLink = useProjectSharingLink(projectQuery.data);
+	const newConversationLink = useProjectSharingLink(projectQuery.data, "portal");
 	const wakeLock = useWakeLock();
 
 	// Ref to store callback that will be set after audioRecorder is created
@@ -280,6 +280,10 @@ export const ParticipantConversationAudio = () => {
 			}
 
 			await finishConversation(conversationId ?? "");
+			posthog.capture("conversation_finished", {
+				conversation_id: conversationId,
+				project_id: projectId,
+			});
 			close();
 			navigate(finishUrl);
 		} catch (error) {
@@ -347,6 +351,16 @@ export const ParticipantConversationAudio = () => {
 				totalChunks: chunkHistory.length,
 			},
 		);
+
+		// Also emit a plain event so we can chart a recording-error rate (the
+		// exception above lands in error tracking, which doesn't funnel cleanly).
+		posthog.capture("portal_recording_error", {
+			conversation_id: conversationId,
+			issue_type: "audio_interruption",
+			project_id: projectId,
+			recording_duration_seconds: interruptionRecordingTimeRef.current,
+			total_chunks: chunkHistory.length,
+		});
 	};
 
 	// Handler for reconnect button - waits for uploads, reports error, then reloads
@@ -387,6 +401,10 @@ export const ParticipantConversationAudio = () => {
 		}
 
 		startRecording();
+		posthog.capture("recording_started", {
+			conversation_id: conversationId,
+			project_id: projectId,
+		});
 		if (wakeLock.isSupported) {
 			wakeLock.obtainWakeLock();
 			wakeLock.enableAutoReacquire();

--- a/echo/frontend/src/components/participant/ParticipantConversationText.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationText.tsx
@@ -40,7 +40,7 @@ export const ParticipantConversationText = () => {
 	const conversationQuery = useConversationQuery(projectId, conversationId);
 	const chunks = useConversationChunksQuery(projectId, conversationId);
 	const uploadChunkMutation = useUploadConversationTextChunk();
-	const newConversationLink = useProjectSharingLink(projectQuery.data);
+	const newConversationLink = useProjectSharingLink(projectQuery.data, "portal");
 
 	const [text, setText] = useState("");
 	const [

--- a/echo/frontend/src/components/participant/ParticipantInitiateForm.tsx
+++ b/echo/frontend/src/components/participant/ParticipantInitiateForm.tsx
@@ -10,6 +10,7 @@ import {
 	TextInput,
 } from "@mantine/core";
 import { AxiosError } from "axios";
+import posthog from "posthog-js";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -41,6 +42,10 @@ export const ParticipantInitiateForm = ({ project }: { project: Project }) => {
 		useInitiateConversationMutation();
 
 	const onSubmit = (data: FormValues) => {
+		posthog.capture("conversation_started", {
+			project_id: project.id,
+			source: "PORTAL_AUDIO",
+		});
 		initiateConversationMutation.mutate({
 			name: data.name ?? t`Participant`,
 			pin: "",

--- a/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
+++ b/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import posthog from "posthog-js";
 // Start of Selection
 import React, { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
@@ -246,6 +247,10 @@ const ParticipantOnboardingCards = ({
 			!checkboxStates[`${currentSlideIndex}`]
 		) {
 			return;
+		}
+		// Advancing past a required checkbox is the participant accepting consent.
+		if (currentCard.checkbox?.required) {
+			posthog.capture("consent_given", { project_id: project.id });
 		}
 		if (currentSlideIndex < allSlides.length - 1) {
 			setAnimationDirection("slide-left");

--- a/echo/frontend/src/components/project/ProjectQRCode.tsx
+++ b/echo/frontend/src/components/project/ProjectQRCode.tsx
@@ -12,8 +12,23 @@ interface ProjectQRCodeProps {
 	project?: Project;
 }
 
+// Where a participant link was handed out, carried as `utm_source` so PostHog
+// auto-attributes the landing. Lets us split "came from a QR vs a copied link
+// vs the printed host guide" the instant a participant lands.
+export type ShareLinkSource =
+	| "qr_scan"
+	| "qr_click"
+	| "copy_link"
+	| "qr_download"
+	| "host_guide"
+	| "report"
+	| "portal";
+
 // eslint-disable-next-line react-refresh/only-export-components
-export const useProjectSharingLink = (project?: Project) => {
+export const useProjectSharingLink = (
+	project?: Project,
+	source?: ShareLinkSource,
+) => {
 	const { preferences } = useAppPreferences();
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: not an issue
@@ -62,28 +77,38 @@ export const useProjectSharingLink = (project?: Project) => {
 
 		// Include theme in URL so participant portal uses the same theme
 		const baseLink = `${PARTICIPANT_BASE_URL}/${languageCode}/${project.id}/start`;
-		const theme = preferences.fontFamily;
-		const link = `${baseLink}?theme=${theme}`;
-		return link;
-	}, [project?.language, project?.id, preferences.fontFamily]);
+		const params = new URLSearchParams({ theme: preferences.fontFamily });
+		if (source) {
+			params.set("utm_source", source);
+		}
+		return `${baseLink}?${params.toString()}`;
+	}, [project?.language, project?.id, preferences.fontFamily, source]);
 };
 
 export const ProjectQRCode = ({ project }: ProjectQRCodeProps) => {
-	const link = useProjectSharingLink(project);
-	const qrRef = useRef<HTMLDivElement>(null);
+	// Each surface gets its own utm_source. The QR's encoded value (scanned off
+	// the screen) and its click target are distinct, so we can tell a scan from
+	// a host clicking the code. The downloaded PNG is rendered from a separate
+	// hidden QR so it carries its own `qr_download` tag instead of the on-screen
+	// scan link.
+	const scanLink = useProjectSharingLink(project, "qr_scan");
+	const clickLink = useProjectSharingLink(project, "qr_click");
+	const copyLink = useProjectSharingLink(project, "copy_link");
+	const downloadLink = useProjectSharingLink(project, "qr_download");
+	const downloadQrRef = useRef<HTMLDivElement>(null);
 
 	const handleDownloadQR = () => {
-		if (!qrRef.current) return;
-		const canvas = qrRef.current.querySelector("canvas");
+		if (!downloadQrRef.current) return;
+		const canvas = downloadQrRef.current.querySelector("canvas");
 		if (!canvas) return;
 
-		const downloadLink = document.createElement("a");
-		downloadLink.download = `qr-${project?.name || "code"}.png`;
-		downloadLink.href = canvas.toDataURL("image/png");
-		downloadLink.click();
+		const downloadAnchor = document.createElement("a");
+		downloadAnchor.download = `qr-${project?.name || "code"}.png`;
+		downloadAnchor.href = canvas.toDataURL("image/png");
+		downloadAnchor.click();
 	};
 
-	if (!link) {
+	if (!scanLink) {
 		return <Skeleton height={200} />;
 	}
 
@@ -100,14 +125,21 @@ export const ProjectQRCode = ({ project }: ProjectQRCodeProps) => {
 	return (
 		<Stack gap="sm" align="center" w="100%">
 			<QRCode
-				value={link}
-				href={link}
-				ref={qrRef}
+				value={scanLink}
+				href={clickLink ?? undefined}
 				className="h-auto w-full"
 				{...testId("project-qr-code")}
 			/>
+			{/* Offscreen QR carrying the qr_download tag; only used to export the PNG. */}
+			<div
+				ref={downloadQrRef}
+				aria-hidden
+				className="pointer-events-none absolute -left-[9999px] top-0 h-64 w-64 print:hidden"
+			>
+				{downloadLink && <QRCode value={downloadLink} />}
+			</div>
 			<Stack gap="xs" w="100%">
-				<CopyButton value={link} timeout={2000}>
+				<CopyButton value={copyLink ?? ""} timeout={2000}>
 					{({ copied, copy }) => (
 						<Button
 							size="sm"

--- a/echo/frontend/src/main.tsx
+++ b/echo/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import {
 	POSTHOG_HOST,
 	POSTHOG_TOKEN,
 	POSTHOG_UI_HOST,
+	USE_PARTICIPANT_ROUTER,
 } from "./config";
 
 posthog.init(POSTHOG_TOKEN, {
@@ -17,6 +18,10 @@ posthog.init(POSTHOG_TOKEN, {
 	// api_host is our reverse proxy; ui_host must stay the real PostHog host so
 	// the toolbar and in-app links resolve (required when api_host is proxied).
 	ui_host: POSTHOG_UI_HOST,
+	// The portal serves anonymous participants on a privacy-sensitive flow, so
+	// never record their sessions. We track the journey with explicit events
+	// instead. The dashboard (hosts) is unaffected.
+	disable_session_recording: USE_PARTICIPANT_ROUTER,
 	// Share the cookie across .dembrane.com so a visitor's distinct id carries
 	// over from the marketing site, stitching both into one person profile.
 	cross_subdomain_cookie: true,

--- a/echo/frontend/src/routes/participant/ParticipantReport.tsx
+++ b/echo/frontend/src/routes/participant/ParticipantReport.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { LoadingOverlay, Stack, Text } from "@mantine/core";
+import posthog from "posthog-js";
 import { useCallback, useEffect } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { Logo } from "@/components/common/Logo";
@@ -24,7 +25,7 @@ export const ParticipantReport = () => {
 		projectId ?? "",
 	);
 
-	const contributeLink = `${window.location.origin}/${language}/${projectId}/start`;
+	const contributeLink = `${window.location.origin}/${language}/${projectId}/start?utm_source=report`;
 
 	const recordView = useCallback(
 		(reportId: number) => {
@@ -56,6 +57,10 @@ export const ParticipantReport = () => {
 	useEffect(() => {
 		if (report) {
 			recordView(Number(report.id));
+			posthog.capture("report_viewed", {
+				project_id: projectId,
+				report_id: Number(report.id),
+			});
 
 			if (print) {
 				setTimeout(() => {
@@ -63,7 +68,7 @@ export const ParticipantReport = () => {
 				}, 1000);
 			}
 		}
-	}, [report, print, recordView]);
+	}, [report, print, recordView, projectId]);
 
 	if (isLoading) {
 		return <LoadingOverlay visible />;

--- a/echo/frontend/src/routes/participant/ParticipantStart.tsx
+++ b/echo/frontend/src/routes/participant/ParticipantStart.tsx
@@ -1,6 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Alert } from "@mantine/core";
-import { useEffect } from "react";
+import posthog from "posthog-js";
+import { useEffect, useRef } from "react";
 import { useParams } from "react-router";
 import useSessionStorageState from "use-session-storage-state";
 import DembraneLoadingSpinner from "@/components/common/DembraneLoadingSpinner";
@@ -24,11 +25,23 @@ export const ParticipantStartRoute = () => {
 		},
 	);
 
+	const landedCaptured = useRef(false);
 	useEffect(() => {
 		if (!isLoadingProject) {
 			setLoadingFinished(true);
+			// Funnel entry, fired once per mount. Skip when embedded (the host's
+			// portal-editor preview loads this in an iframe) so previews don't
+			// inflate participant landings. utm_source rides along from the URL.
+			if (
+				!landedCaptured.current &&
+				typeof window !== "undefined" &&
+				window.self === window.top
+			) {
+				landedCaptured.current = true;
+				posthog.capture("portal_landed", { project_id: projectId });
+			}
 		}
-	}, [isLoadingProject, setLoadingFinished]);
+	}, [isLoadingProject, setLoadingFinished, projectId]);
 
 	if (loadingFinished && projectError) {
 		return (

--- a/echo/frontend/src/routes/project/HostGuidePage.tsx
+++ b/echo/frontend/src/routes/project/HostGuidePage.tsx
@@ -1084,7 +1084,7 @@ export const HostGuidePage = () => {
 		},
 	});
 
-	const sharingLink = useProjectSharingLink(project);
+	const sharingLink = useProjectSharingLink(project, "host_guide");
 	const langCode = (project?.language?.slice(0, 2) || "en") as LanguageCode;
 	const defaults = defaultTranslations[langCode] || defaultTranslations.en;
 	const askForName =

--- a/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
+++ b/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
@@ -793,7 +793,7 @@ export const ProjectReportRoute = () => {
 		closeDeleteModal();
 	};
 
-	const contributionLink = `${PARTICIPANT_BASE_URL}/${language}/${projectId}/start`;
+	const contributionLink = `${PARTICIPANT_BASE_URL}/${language}/${projectId}/start?utm_source=report`;
 
 	const getSharingLink = (pid: string) =>
 		`${PARTICIPANT_BASE_URL}/${language}/${pid}/report`;


### PR DESCRIPTION
## What

Instruments the participant portal journey (our biggest analytics blind spot) and tags every way a participant link goes out so we can attribute landings. Implements the portal half of the plan in #713.

## Journey funnel (client, anonymous participants)

`portal_landed` → `consent_given` → `conversation_started` → `recording_started` → `conversation_finished` → `report_viewed`

- `portal_landed` is guarded to top-level windows, so the host's portal-editor preview (an iframe) doesn't inflate landings.
- `portal_recording_error` is emitted alongside the existing `captureException` so we get a chartable error rate (exceptions don't funnel cleanly).

## Link source attribution (`utm_source`)

`useProjectSharingLink(project, source)` now stamps `utm_source`, which PostHog auto-attributes onto the landing. Tagged surfaces:

- `qr_scan` vs `qr_click` — the QR's encoded value (scanned off screen) vs its click target are distinct, so we can tell a scan from a host clicking the code.
- `copy_link`, `qr_download` (rendered from a dedicated offscreen QR so it carries its own tag), `host_guide`, `report`, and in-portal `portal` links.

This answers "how many came from a QR vs a copied link vs the printed host guide" the instant a participant lands.

## Privacy

Session recording is disabled on the portal (anonymous participants on a sensitive flow); the dashboard is unaffected. The journey is tracked with explicit events instead. Per the privacy note in #713, this should still get a nod from whoever owns privacy/DPA.

## Notes / caveats

- `consent_given` fires when the participant advances past the required consent checkbox; going back and forward could re-fire it. PostHog funnels key on first occurrence, so this is cosmetic.
- These are client events, so they ride on the `r.dembrane.com` proxy (#720) and survive ad blockers.
- Verified: `tsc --noEmit` and `biome lint --diagnostic-level=error` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
