### PR TITLE
feat(analytics): chat + report events (client depth + server lifecycle)

### DIFF
--- a/echo/frontend/src/components/chat/References.tsx
+++ b/echo/frontend/src/components/chat/References.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { Badge, Box, Text } from "@mantine/core";
+import posthog from "posthog-js";
 import { useParams } from "react-router";
 import { I18nLink } from "@/components/common/i18nLink";
 
@@ -32,6 +33,13 @@ export const References = ({
 							</span>
 							<I18nLink
 								to={`/w/${workspaceId}/projects/${projectId}/conversation/${citation?.conversation?.id || citation?.conversation}`}
+								onClick={() => {
+									posthog.capture("chat_citation_clicked", {
+										conversation_id:
+											citation?.conversation?.id || citation?.conversation,
+										project_id: projectId,
+									});
+								}}
 							>
 								<Badge
 									size="sm"

--- a/echo/frontend/src/components/chat/hooks/index.ts
+++ b/echo/frontend/src/components/chat/hooks/index.ts
@@ -7,6 +7,7 @@ import {
 	useSuspenseInfiniteQuery,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
+import posthog from "posthog-js";
 import { toast } from "@/components/common/Toaster";
 import {
 	type ChatMode,
@@ -65,6 +66,10 @@ export const useDeleteChatMutation = () => {
 		mutationFn: (payload: { chatId: string; projectId: string }) =>
 			deleteChatById(payload.chatId),
 		onSuccess: (_, vars) => {
+			posthog.capture("chat_deleted", {
+				chat_id: vars.chatId,
+				project_id: vars.projectId,
+			});
 			queryClient.invalidateQueries({
 				queryKey: ["projects", vars.projectId, "chats"],
 			});

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mantine/core";
 import { useDisclosure, useDocumentTitle } from "@mantine/hooks";
 import { formatRelative } from "date-fns";
+import posthog from "posthog-js";
 import { Suspense, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import { useParams } from "react-router";
@@ -183,6 +184,12 @@ export const NewChatRoute = () => {
 			if (!chat?.id) {
 				throw new Error("Failed to create chat");
 			}
+
+			posthog.capture("chat_started", {
+				chat_id: chat.id,
+				mode,
+				project_id: projectId,
+			});
 
 			// Step 2: Initialize the mode (this attaches conversations for overview mode)
 			await initializeModeMutation.mutateAsync({

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -160,6 +160,18 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 			if (lastInput.current) {
 				setInput(lastInput.current);
 			}
+			// This is the non-agentic chat path, so the browser is the only place
+			// that sees a failed response. Split out rate limits (the explore /
+			// usage-cap signal) from other errors.
+			const msg = (error?.message ?? "").toLowerCase();
+			const isRateLimited =
+				msg.includes("429") ||
+				msg.includes("rate limit") ||
+				msg.includes("too many");
+			posthog?.capture(isRateLimited ? "chat_rate_limited" : "chat_error", {
+				chat_id: chatId,
+				message: error?.message?.slice(0, 300),
+			});
 			console.log("onError", error);
 		},
 		onFinish: async (message) => {

--- a/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
+++ b/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
@@ -63,6 +63,7 @@ import {
 import { ReportRenderer } from "@/components/report/ReportRenderer";
 import { ReportTimeline } from "@/components/report/ReportTimeline";
 import { UpdateReportModalButton } from "@/components/report/UpdateReportModalButton";
+import posthog from "posthog-js";
 import { PARTICIPANT_BASE_URL } from "@/config";
 import useCopyToRichText from "@/hooks/useCopyToRichText";
 import { useLanguage } from "@/hooks/useLanguage";
@@ -1107,6 +1108,10 @@ export const ProjectReportRoute = () => {
 														checked={data.show_portal_link ?? true}
 														size="sm"
 														onChange={(e) => {
+															posthog.capture("report_made_public", {
+																enabled: !!e.target.checked,
+																report_id: data.id,
+															});
 															updateReport({
 																payload: {
 																	show_portal_link: !!e.target.checked,
@@ -1144,6 +1149,9 @@ export const ProjectReportRoute = () => {
 														leftSection={<IconLink size={14} />}
 														onClick={() => {
 															if (data.status === "published") {
+																posthog.capture("report_link_copied", {
+																	report_id: data.id,
+																});
 																copyLink(getSharingLink(projectId ?? ""));
 															}
 														}}
@@ -1192,6 +1200,10 @@ export const ProjectReportRoute = () => {
 														onClick={() => {
 															const url = getSharingLink(projectId ?? "");
 															if (data.status === "published") {
+																posthog.capture("report_exported", {
+																	method: "share",
+																	report_id: data.id,
+																});
 																if (url && navigator.canShare?.({ url })) {
 																	navigator.share({ url });
 																} else {
@@ -1208,6 +1220,10 @@ export const ProjectReportRoute = () => {
 														leftSection={<IconPrinter size={16} />}
 														onClick={() => {
 															if (data.status === "published") {
+																posthog.capture("report_exported", {
+																	method: "print",
+																	report_id: data.id,
+																});
 																window.open(
 																	`${getSharingLink(projectId ?? "")}?print=true`,
 																	"_blank",

--- a/echo/server/dembrane/agentic_worker.py
+++ b/echo/server/dembrane/agentic_worker.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, AsyncGenerator
 from logging import getLogger
 
 from dembrane.service import chat_service, agentic_run_service
+from dembrane.analytics import capture_event
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.agentic_client import (
     AgenticTimeoutError,
@@ -426,6 +427,22 @@ async def _append_assistant_message(
         )
 
 
+async def _chat_distinct_id(run: dict, run_id: str) -> str:
+    """Resolve a PostHog distinct_id (the chat user's email) so server chat
+    events merge with the user's frontend person. Falls back to the directus
+    user id, then the run id. Best-effort."""
+    directus_user_id = str(run.get("directus_user_id") or "")
+    if not directus_user_id:
+        return run_id
+    try:
+        from dembrane.app_user import resolve_app_user
+
+        app_user = await resolve_app_user(directus_user_id)
+        return ((app_user or {}).get("email") or "").lower() or directus_user_id
+    except Exception:  # noqa: BLE001 — analytics is best-effort
+        return directus_user_id
+
+
 async def process_agentic_run(
     *,
     run_id: str,
@@ -439,6 +456,19 @@ async def process_agentic_run(
     svc = run_service or agentic_run_service
     run = await run_in_thread_pool(svc.get_by_id_or_raise, run_id)
     project_chat_id = str(run.get("project_chat_id") or "")
+    chat_distinct_id = await _chat_distinct_id(run, run_id)
+
+    async def _emit_chat_error(error_code: str, message: str) -> None:
+        await capture_event(
+            chat_distinct_id,
+            "server_chat_error",
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "error_code": error_code,
+                "message": message[:300],
+            },
+        )
     latest_output: str | None = None
     total_tool_start_count = 0
     counted_tool_start_count = 0
@@ -613,8 +643,18 @@ async def process_agentic_run(
             "completed",
             latest_output=latest_output,
         )
+        await capture_event(
+            chat_distinct_id,
+            "server_chat_response_received",
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "has_output": latest_output is not None,
+            },
+        )
     except (AgenticRunCancelledError, asyncio.CancelledError):
         logger.info("Run %s cancelled for turn %s", run_id, turn_seq)
+        await _emit_chat_error(AGENT_CANCELLED_ERROR_CODE, AGENT_CANCELLED_MESSAGE)
         await _append_event_and_publish(
             svc,
             run_id,
@@ -633,6 +673,7 @@ async def process_agentic_run(
         )
     except AgenticTimeoutError as exc:
         logger.warning("Run %s timed out: %s", run_id, exc)
+        await _emit_chat_error("AGENT_TIMEOUT", str(exc))
         await _append_event_and_publish(
             svc,
             run_id,
@@ -648,6 +689,7 @@ async def process_agentic_run(
         )
     except AgenticUpstreamError as exc:
         logger.warning("Run %s failed upstream: %s", run_id, exc)
+        await _emit_chat_error(exc.error_code, exc.message)
         await _append_event_and_publish(
             svc,
             run_id,
@@ -667,6 +709,7 @@ async def process_agentic_run(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Run %s failed unexpectedly", run_id)
+        await _emit_chat_error("AGENT_UNEXPECTED_ERROR", str(exc))
         await _append_event_and_publish(
             svc,
             run_id,

--- a/echo/server/dembrane/analytics.py
+++ b/echo/server/dembrane/analytics.py
@@ -94,3 +94,14 @@ async def capture_event(
         )
     except Exception:  # noqa: BLE001
         logger.exception("capture_event wrapper failed for %s", event)
+
+
+def capture_event_sync(
+    distinct_id: str,
+    event: str,
+    properties: Optional[dict[str, Any]] = None,
+) -> None:
+    """Synchronous fire-and-forget capture for Dramatiq actors (gevent, no
+    asyncio allowed). Mirror of capture_event for sync worker contexts. The
+    underlying HTTP call has a short timeout and never raises."""
+    _capture_sync(distinct_id, event, properties or {})

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -1243,6 +1243,27 @@ def task_report_summarization_done(report_id: int) -> None:
         client.close()
 
 
+def _report_event_distinct_id(report_id_str: str, project_id: str) -> str:
+    """Resolve the PostHog distinct_id for server-side report events: the
+    report creator's email, so these merge with the creator's frontend person.
+    Falls back to the directus user id, then the project id. Best-effort."""
+    log = getLogger("dembrane.tasks.analytics")
+    try:
+        from dembrane.app_user import resolve_app_user
+
+        with directus_client_context() as client:
+            report_row = client.get_item("project_report", report_id_str)
+        report_data = (report_row or {}).get("data") or report_row or {}
+        creator_directus_id = report_data.get("user_created")
+        if creator_directus_id:
+            creator = run_async_in_new_loop(resolve_app_user(creator_directus_id))
+            email = ((creator or {}).get("email") or "").lower()
+            return email or str(creator_directus_id)
+    except Exception:  # noqa: BLE001 — analytics is best-effort
+        log.warning("could not resolve report distinct_id for %s", report_id_str)
+    return project_id
+
+
 @dramatiq.actor(queue_name="network", priority=50)
 def task_create_report(project_id: str, report_id: int, language: str, user_instructions: str = "") -> None:
     """
@@ -1293,6 +1314,14 @@ def task_create_report(project_id: str, report_id: int, language: str, user_inst
                 publish_report_progress(report_id, event_type, message, detail)
             except Exception as e:
                 logger.warning(f"Failed to publish progress event: {e}")
+
+        from dembrane.analytics import capture_event_sync
+
+        capture_event_sync(
+            _report_event_distinct_id(report_id_str, project_id),
+            "server_report_generation_started",
+            {"project_id": project_id, "report_id": report_id, "language": language},
+        )
 
         try:
             # Store params in Redis so the completion callback can retrieve
@@ -1436,6 +1465,17 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
             publish_report_progress(report_id, "completed", "Report ready")
             logger.info(f"Report {report_id} generated for project {project_id}")
 
+            # Server-side success event: the client report_generated is fired
+            # from the browser on SSE completion, so it misses every host who
+            # closed the tab. This is the reliable count + generation-time anchor.
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generated",
+                {"project_id": project_id, "report_id": report_id, "language": language},
+            )
+
             # Notify the report's creator. Keep the audience tight —
             # fanning to every workspace member on every report would
             # spam inboxes. If we want a wider broadcast later, derive
@@ -1511,10 +1551,32 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
                         )
             except Exception as notif_err:
                 logger.warning(f"Failed to emit REPORT_FAILED: {notif_err}")
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generation_failed",
+                {
+                    "project_id": project_id,
+                    "report_id": report_id,
+                    "error_code": "GENERATION_FAILED",
+                },
+            )
             return
 
         except Exception as e:
             logger.error(f"Unexpected error generating report {report_id}: {e}")
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generation_failed",
+                {
+                    "project_id": project_id,
+                    "report_id": report_id,
+                    "error_code": "UNEXPECTED_ERROR",
+                },
+            )
             try:
                 with directus_client_context() as client:
                     client.update_item("project_report", report_id_str, {


### PR DESCRIPTION
## What

Fills the chat and report analytics gaps surfaced by the PostHog audit. One PR, client + server. Built against the live event set (deduped, no name collisions).

## Why

Audit found chat/report only capture "the thing happened", and the lifecycle events that belong on the backend are client-only and lossy. The clearest proof: in production `report_generated` fired **5** times vs `report_edited` **198** times, because it only fires from an open browser on SSE completion, so it misses every host who closes the tab before the (slow) generation finishes.

## Client events (intent + depth)

- Chat: `chat_started` (new chat created), `chat_rate_limited` / `chat_error` (non-agentic chat `onError`, splitting the usage-cap signal from other failures), `chat_citation_clicked`, `chat_deleted`.
- Report: `report_made_public` (portal-link toggle), `report_link_copied`, `report_exported` (share + print).

## Server events (ad-blocker-proof, reuse `analytics.py`)

- Report generation lifecycle, in the Dramatiq worker (`tasks.py`): `server_report_generation_started`, `server_report_generated`, `server_report_generation_failed`. This is the reliable generation count + a funnel whose started→generated time gives generation duration. `distinct_id` resolves to the report creator's email so it merges with their frontend person.
- Chat responses, in the agentic worker (`agentic_worker.py`): `server_chat_response_received` and `server_chat_error` across all failure paths (cancel / timeout / upstream / unexpected).
- Added `capture_event_sync` to `analytics.py` for sync (gevent) worker contexts; async paths keep using `capture_event`.

## Notes / scope

- Convention: server events carry the `server_` prefix and `$lib=dembrane-server`, so they don't double-count against the existing client `report_generated` / `chat_message_sent`.
- Server chat events fire from the agentic runtime, which is currently echo-next only (agentic chat is gated off in prod). Correct for where chat is heading; coverage widens when it's enabled.
- Phase-1 report dispatch failures (rare) aren't separately tracked; the phase-2 generation failures (the meaningful ones) are.
- Touches `ProjectReportRoute.tsx`, which #721 also edits on a different line; expected to auto-merge.

## Verification

`tsc --noEmit` clean, `biome lint --diagnostic-level=error` clean, `ruff check` clean, server modules import + parse OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
