### PR TITLE
feat(analytics): portal journey, source attribution, chat + report events

### DIFF
--- a/echo/frontend/src/components/chat/References.tsx
+++ b/echo/frontend/src/components/chat/References.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { Badge, Box, Text } from "@mantine/core";
+import posthog from "posthog-js";
 import { useParams } from "react-router";
 import { I18nLink } from "@/components/common/i18nLink";
 
@@ -32,6 +33,13 @@ export const References = ({
 							</span>
 							<I18nLink
 								to={`/w/${workspaceId}/projects/${projectId}/conversation/${citation?.conversation?.id || citation?.conversation}`}
+								onClick={() => {
+									posthog.capture("chat_citation_clicked", {
+										conversation_id:
+											citation?.conversation?.id || citation?.conversation,
+										project_id: projectId,
+									});
+								}}
 							>
 								<Badge
 									size="sm"

--- a/echo/frontend/src/components/chat/hooks/index.ts
+++ b/echo/frontend/src/components/chat/hooks/index.ts
@@ -7,6 +7,7 @@ import {
 	useSuspenseInfiniteQuery,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
+import posthog from "posthog-js";
 import { toast } from "@/components/common/Toaster";
 import {
 	type ChatMode,
@@ -65,6 +66,10 @@ export const useDeleteChatMutation = () => {
 		mutationFn: (payload: { chatId: string; projectId: string }) =>
 			deleteChatById(payload.chatId),
 		onSuccess: (_, vars) => {
+			posthog.capture("chat_deleted", {
+				chat_id: vars.chatId,
+				project_id: vars.projectId,
+			});
 			queryClient.invalidateQueries({
 				queryKey: ["projects", vars.projectId, "chats"],
 			});

--- a/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
@@ -130,7 +130,7 @@ export const ParticipantConversationAudio = () => {
 
 	// Navigation and language
 	const navigate = useI18nNavigate();
-	const newConversationLink = useProjectSharingLink(projectQuery.data);
+	const newConversationLink = useProjectSharingLink(projectQuery.data, "portal");
 	const wakeLock = useWakeLock();
 
 	// Ref to store callback that will be set after audioRecorder is created
@@ -280,6 +280,10 @@ export const ParticipantConversationAudio = () => {
 			}
 
 			await finishConversation(conversationId ?? "");
+			posthog.capture("conversation_finished", {
+				conversation_id: conversationId,
+				project_id: projectId,
+			});
 			close();
 			navigate(finishUrl);
 		} catch (error) {
@@ -347,6 +351,16 @@ export const ParticipantConversationAudio = () => {
 				totalChunks: chunkHistory.length,
 			},
 		);
+
+		// Also emit a plain event so we can chart a recording-error rate (the
+		// exception above lands in error tracking, which doesn't funnel cleanly).
+		posthog.capture("portal_recording_error", {
+			conversation_id: conversationId,
+			issue_type: "audio_interruption",
+			project_id: projectId,
+			recording_duration_seconds: interruptionRecordingTimeRef.current,
+			total_chunks: chunkHistory.length,
+		});
 	};
 
 	// Handler for reconnect button - waits for uploads, reports error, then reloads
@@ -387,6 +401,10 @@ export const ParticipantConversationAudio = () => {
 		}
 
 		startRecording();
+		posthog.capture("recording_started", {
+			conversation_id: conversationId,
+			project_id: projectId,
+		});
 		if (wakeLock.isSupported) {
 			wakeLock.obtainWakeLock();
 			wakeLock.enableAutoReacquire();

--- a/echo/frontend/src/components/participant/ParticipantConversationText.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationText.tsx
@@ -40,7 +40,7 @@ export const ParticipantConversationText = () => {
 	const conversationQuery = useConversationQuery(projectId, conversationId);
 	const chunks = useConversationChunksQuery(projectId, conversationId);
 	const uploadChunkMutation = useUploadConversationTextChunk();
-	const newConversationLink = useProjectSharingLink(projectQuery.data);
+	const newConversationLink = useProjectSharingLink(projectQuery.data, "portal");
 
 	const [text, setText] = useState("");
 	const [

--- a/echo/frontend/src/components/participant/ParticipantInitiateForm.tsx
+++ b/echo/frontend/src/components/participant/ParticipantInitiateForm.tsx
@@ -10,6 +10,7 @@ import {
 	TextInput,
 } from "@mantine/core";
 import { AxiosError } from "axios";
+import posthog from "posthog-js";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -41,6 +42,10 @@ export const ParticipantInitiateForm = ({ project }: { project: Project }) => {
 		useInitiateConversationMutation();
 
 	const onSubmit = (data: FormValues) => {
+		posthog.capture("conversation_started", {
+			project_id: project.id,
+			source: "PORTAL_AUDIO",
+		});
 		initiateConversationMutation.mutate({
 			name: data.name ?? t`Participant`,
 			pin: "",

--- a/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
+++ b/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import posthog from "posthog-js";
 // Start of Selection
 import React, { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
@@ -246,6 +247,10 @@ const ParticipantOnboardingCards = ({
 			!checkboxStates[`${currentSlideIndex}`]
 		) {
 			return;
+		}
+		// Advancing past a required checkbox is the participant accepting consent.
+		if (currentCard.checkbox?.required) {
+			posthog.capture("consent_given", { project_id: project.id });
 		}
 		if (currentSlideIndex < allSlides.length - 1) {
 			setAnimationDirection("slide-left");

--- a/echo/frontend/src/components/project/ProjectQRCode.tsx
+++ b/echo/frontend/src/components/project/ProjectQRCode.tsx
@@ -12,8 +12,23 @@ interface ProjectQRCodeProps {
 	project?: Project;
 }
 
+// Where a participant link was handed out, carried as `utm_source` so PostHog
+// auto-attributes the landing. Lets us split "came from a QR vs a copied link
+// vs the printed host guide" the instant a participant lands.
+export type ShareLinkSource =
+	| "qr_scan"
+	| "qr_click"
+	| "copy_link"
+	| "qr_download"
+	| "host_guide"
+	| "report"
+	| "portal";
+
 // eslint-disable-next-line react-refresh/only-export-components
-export const useProjectSharingLink = (project?: Project) => {
+export const useProjectSharingLink = (
+	project?: Project,
+	source?: ShareLinkSource,
+) => {
 	const { preferences } = useAppPreferences();
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: not an issue
@@ -62,28 +77,38 @@ export const useProjectSharingLink = (project?: Project) => {
 
 		// Include theme in URL so participant portal uses the same theme
 		const baseLink = `${PARTICIPANT_BASE_URL}/${languageCode}/${project.id}/start`;
-		const theme = preferences.fontFamily;
-		const link = `${baseLink}?theme=${theme}`;
-		return link;
-	}, [project?.language, project?.id, preferences.fontFamily]);
+		const params = new URLSearchParams({ theme: preferences.fontFamily });
+		if (source) {
+			params.set("utm_source", source);
+		}
+		return `${baseLink}?${params.toString()}`;
+	}, [project?.language, project?.id, preferences.fontFamily, source]);
 };
 
 export const ProjectQRCode = ({ project }: ProjectQRCodeProps) => {
-	const link = useProjectSharingLink(project);
-	const qrRef = useRef<HTMLDivElement>(null);
+	// Each surface gets its own utm_source. The QR's encoded value (scanned off
+	// the screen) and its click target are distinct, so we can tell a scan from
+	// a host clicking the code. The downloaded PNG is rendered from a separate
+	// hidden QR so it carries its own `qr_download` tag instead of the on-screen
+	// scan link.
+	const scanLink = useProjectSharingLink(project, "qr_scan");
+	const clickLink = useProjectSharingLink(project, "qr_click");
+	const copyLink = useProjectSharingLink(project, "copy_link");
+	const downloadLink = useProjectSharingLink(project, "qr_download");
+	const downloadQrRef = useRef<HTMLDivElement>(null);
 
 	const handleDownloadQR = () => {
-		if (!qrRef.current) return;
-		const canvas = qrRef.current.querySelector("canvas");
+		if (!downloadQrRef.current) return;
+		const canvas = downloadQrRef.current.querySelector("canvas");
 		if (!canvas) return;
 
-		const downloadLink = document.createElement("a");
-		downloadLink.download = `qr-${project?.name || "code"}.png`;
-		downloadLink.href = canvas.toDataURL("image/png");
-		downloadLink.click();
+		const downloadAnchor = document.createElement("a");
+		downloadAnchor.download = `qr-${project?.name || "code"}.png`;
+		downloadAnchor.href = canvas.toDataURL("image/png");
+		downloadAnchor.click();
 	};
 
-	if (!link) {
+	if (!scanLink) {
 		return <Skeleton height={200} />;
 	}
 
@@ -100,14 +125,21 @@ export const ProjectQRCode = ({ project }: ProjectQRCodeProps) => {
 	return (
 		<Stack gap="sm" align="center" w="100%">
 			<QRCode
-				value={link}
-				href={link}
-				ref={qrRef}
+				value={scanLink}
+				href={clickLink ?? undefined}
 				className="h-auto w-full"
 				{...testId("project-qr-code")}
 			/>
+			{/* Offscreen QR carrying the qr_download tag; only used to export the PNG. */}
+			<div
+				ref={downloadQrRef}
+				aria-hidden
+				className="pointer-events-none absolute -left-[9999px] top-0 h-64 w-64 print:hidden"
+			>
+				{downloadLink && <QRCode value={downloadLink} />}
+			</div>
 			<Stack gap="xs" w="100%">
-				<CopyButton value={link} timeout={2000}>
+				<CopyButton value={copyLink ?? ""} timeout={2000}>
 					{({ copied, copy }) => (
 						<Button
 							size="sm"

--- a/echo/frontend/src/main.tsx
+++ b/echo/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import {
 	POSTHOG_HOST,
 	POSTHOG_TOKEN,
 	POSTHOG_UI_HOST,
+	USE_PARTICIPANT_ROUTER,
 } from "./config";
 
 posthog.init(POSTHOG_TOKEN, {
@@ -17,6 +18,10 @@ posthog.init(POSTHOG_TOKEN, {
 	// api_host is our reverse proxy; ui_host must stay the real PostHog host so
 	// the toolbar and in-app links resolve (required when api_host is proxied).
 	ui_host: POSTHOG_UI_HOST,
+	// The portal serves anonymous participants on a privacy-sensitive flow, so
+	// never record their sessions. We track the journey with explicit events
+	// instead. The dashboard (hosts) is unaffected.
+	disable_session_recording: USE_PARTICIPANT_ROUTER,
 	// Share the cookie across .dembrane.com so a visitor's distinct id carries
 	// over from the marketing site, stitching both into one person profile.
 	cross_subdomain_cookie: true,

--- a/echo/frontend/src/routes/participant/ParticipantReport.tsx
+++ b/echo/frontend/src/routes/participant/ParticipantReport.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { LoadingOverlay, Stack, Text } from "@mantine/core";
+import posthog from "posthog-js";
 import { useCallback, useEffect } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { Logo } from "@/components/common/Logo";
@@ -24,7 +25,7 @@ export const ParticipantReport = () => {
 		projectId ?? "",
 	);
 
-	const contributeLink = `${window.location.origin}/${language}/${projectId}/start`;
+	const contributeLink = `${window.location.origin}/${language}/${projectId}/start?utm_source=report`;
 
 	const recordView = useCallback(
 		(reportId: number) => {
@@ -56,6 +57,10 @@ export const ParticipantReport = () => {
 	useEffect(() => {
 		if (report) {
 			recordView(Number(report.id));
+			posthog.capture("report_viewed", {
+				project_id: projectId,
+				report_id: Number(report.id),
+			});
 
 			if (print) {
 				setTimeout(() => {
@@ -63,7 +68,7 @@ export const ParticipantReport = () => {
 				}, 1000);
 			}
 		}
-	}, [report, print, recordView]);
+	}, [report, print, recordView, projectId]);
 
 	if (isLoading) {
 		return <LoadingOverlay visible />;

--- a/echo/frontend/src/routes/participant/ParticipantStart.tsx
+++ b/echo/frontend/src/routes/participant/ParticipantStart.tsx
@@ -1,6 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Alert } from "@mantine/core";
-import { useEffect } from "react";
+import posthog from "posthog-js";
+import { useEffect, useRef } from "react";
 import { useParams } from "react-router";
 import useSessionStorageState from "use-session-storage-state";
 import DembraneLoadingSpinner from "@/components/common/DembraneLoadingSpinner";
@@ -24,11 +25,23 @@ export const ParticipantStartRoute = () => {
 		},
 	);
 
+	const landedCaptured = useRef(false);
 	useEffect(() => {
 		if (!isLoadingProject) {
 			setLoadingFinished(true);
+			// Funnel entry, fired once per mount. Skip when embedded (the host's
+			// portal-editor preview loads this in an iframe) so previews don't
+			// inflate participant landings. utm_source rides along from the URL.
+			if (
+				!landedCaptured.current &&
+				typeof window !== "undefined" &&
+				window.self === window.top
+			) {
+				landedCaptured.current = true;
+				posthog.capture("portal_landed", { project_id: projectId });
+			}
 		}
-	}, [isLoadingProject, setLoadingFinished]);
+	}, [isLoadingProject, setLoadingFinished, projectId]);
 
 	if (loadingFinished && projectError) {
 		return (

--- a/echo/frontend/src/routes/project/HostGuidePage.tsx
+++ b/echo/frontend/src/routes/project/HostGuidePage.tsx
@@ -1084,7 +1084,7 @@ export const HostGuidePage = () => {
 		},
 	});
 
-	const sharingLink = useProjectSharingLink(project);
+	const sharingLink = useProjectSharingLink(project, "host_guide");
 	const langCode = (project?.language?.slice(0, 2) || "en") as LanguageCode;
 	const defaults = defaultTranslations[langCode] || defaultTranslations.en;
 	const askForName =

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mantine/core";
 import { useDisclosure, useDocumentTitle } from "@mantine/hooks";
 import { formatRelative } from "date-fns";
+import posthog from "posthog-js";
 import { Suspense, useEffect, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import { useParams } from "react-router";
@@ -183,6 +184,12 @@ export const NewChatRoute = () => {
 			if (!chat?.id) {
 				throw new Error("Failed to create chat");
 			}
+
+			posthog.capture("chat_started", {
+				chat_id: chat.id,
+				mode,
+				project_id: projectId,
+			});
 
 			// Step 2: Initialize the mode (this attaches conversations for overview mode)
 			await initializeModeMutation.mutateAsync({

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -160,6 +160,18 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 			if (lastInput.current) {
 				setInput(lastInput.current);
 			}
+			// This is the non-agentic chat path, so the browser is the only place
+			// that sees a failed response. Split out rate limits (the explore /
+			// usage-cap signal) from other errors.
+			const msg = (error?.message ?? "").toLowerCase();
+			const isRateLimited =
+				msg.includes("429") ||
+				msg.includes("rate limit") ||
+				msg.includes("too many");
+			posthog?.capture(isRateLimited ? "chat_rate_limited" : "chat_error", {
+				chat_id: chatId,
+				message: error?.message?.slice(0, 300),
+			});
 			console.log("onError", error);
 		},
 		onFinish: async (message) => {

--- a/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
+++ b/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
@@ -793,7 +793,7 @@ export const ProjectReportRoute = () => {
 		closeDeleteModal();
 	};
 
-	const contributionLink = `${PARTICIPANT_BASE_URL}/${language}/${projectId}/start`;
+	const contributionLink = `${PARTICIPANT_BASE_URL}/${language}/${projectId}/start?utm_source=report`;
 
 	const getSharingLink = (pid: string) =>
 		`${PARTICIPANT_BASE_URL}/${language}/${pid}/report`;

--- a/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
+++ b/echo/frontend/src/routes/project/report/ProjectReportRoute.tsx
@@ -63,6 +63,7 @@ import {
 import { ReportRenderer } from "@/components/report/ReportRenderer";
 import { ReportTimeline } from "@/components/report/ReportTimeline";
 import { UpdateReportModalButton } from "@/components/report/UpdateReportModalButton";
+import posthog from "posthog-js";
 import { PARTICIPANT_BASE_URL } from "@/config";
 import useCopyToRichText from "@/hooks/useCopyToRichText";
 import { useLanguage } from "@/hooks/useLanguage";
@@ -1107,6 +1108,10 @@ export const ProjectReportRoute = () => {
 														checked={data.show_portal_link ?? true}
 														size="sm"
 														onChange={(e) => {
+															posthog.capture("report_made_public", {
+																enabled: !!e.target.checked,
+																report_id: data.id,
+															});
 															updateReport({
 																payload: {
 																	show_portal_link: !!e.target.checked,
@@ -1144,6 +1149,9 @@ export const ProjectReportRoute = () => {
 														leftSection={<IconLink size={14} />}
 														onClick={() => {
 															if (data.status === "published") {
+																posthog.capture("report_link_copied", {
+																	report_id: data.id,
+																});
 																copyLink(getSharingLink(projectId ?? ""));
 															}
 														}}
@@ -1192,6 +1200,10 @@ export const ProjectReportRoute = () => {
 														onClick={() => {
 															const url = getSharingLink(projectId ?? "");
 															if (data.status === "published") {
+																posthog.capture("report_exported", {
+																	method: "share",
+																	report_id: data.id,
+																});
 																if (url && navigator.canShare?.({ url })) {
 																	navigator.share({ url });
 																} else {
@@ -1208,6 +1220,10 @@ export const ProjectReportRoute = () => {
 														leftSection={<IconPrinter size={16} />}
 														onClick={() => {
 															if (data.status === "published") {
+																posthog.capture("report_exported", {
+																	method: "print",
+																	report_id: data.id,
+																});
 																window.open(
 																	`${getSharingLink(projectId ?? "")}?print=true`,
 																	"_blank",

--- a/echo/server/dembrane/agentic_worker.py
+++ b/echo/server/dembrane/agentic_worker.py
@@ -467,6 +467,7 @@ async def process_agentic_run(
                 "project_id": project_id,
                 "error_code": error_code,
                 "message": message[:300],
+                "mode": "agentic",
             },
         )
     latest_output: str | None = None
@@ -650,6 +651,7 @@ async def process_agentic_run(
                 "run_id": run_id,
                 "project_id": project_id,
                 "has_output": latest_output is not None,
+                "mode": "agentic",
             },
         )
     except (AgenticRunCancelledError, asyncio.CancelledError):

--- a/echo/server/dembrane/agentic_worker.py
+++ b/echo/server/dembrane/agentic_worker.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, AsyncGenerator
 from logging import getLogger
 
 from dembrane.service import chat_service, agentic_run_service
+from dembrane.analytics import capture_event
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.agentic_client import (
     AgenticTimeoutError,
@@ -426,6 +427,22 @@ async def _append_assistant_message(
         )
 
 
+async def _chat_distinct_id(run: dict, run_id: str) -> str:
+    """Resolve a PostHog distinct_id (the chat user's email) so server chat
+    events merge with the user's frontend person. Falls back to the directus
+    user id, then the run id. Best-effort."""
+    directus_user_id = str(run.get("directus_user_id") or "")
+    if not directus_user_id:
+        return run_id
+    try:
+        from dembrane.app_user import resolve_app_user
+
+        app_user = await resolve_app_user(directus_user_id)
+        return ((app_user or {}).get("email") or "").lower() or directus_user_id
+    except Exception:  # noqa: BLE001 — analytics is best-effort
+        return directus_user_id
+
+
 async def process_agentic_run(
     *,
     run_id: str,
@@ -439,6 +456,19 @@ async def process_agentic_run(
     svc = run_service or agentic_run_service
     run = await run_in_thread_pool(svc.get_by_id_or_raise, run_id)
     project_chat_id = str(run.get("project_chat_id") or "")
+    chat_distinct_id = await _chat_distinct_id(run, run_id)
+
+    async def _emit_chat_error(error_code: str, message: str) -> None:
+        await capture_event(
+            chat_distinct_id,
+            "server_chat_error",
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "error_code": error_code,
+                "message": message[:300],
+            },
+        )
     latest_output: str | None = None
     total_tool_start_count = 0
     counted_tool_start_count = 0
@@ -613,8 +643,18 @@ async def process_agentic_run(
             "completed",
             latest_output=latest_output,
         )
+        await capture_event(
+            chat_distinct_id,
+            "server_chat_response_received",
+            {
+                "run_id": run_id,
+                "project_id": project_id,
+                "has_output": latest_output is not None,
+            },
+        )
     except (AgenticRunCancelledError, asyncio.CancelledError):
         logger.info("Run %s cancelled for turn %s", run_id, turn_seq)
+        await _emit_chat_error(AGENT_CANCELLED_ERROR_CODE, AGENT_CANCELLED_MESSAGE)
         await _append_event_and_publish(
             svc,
             run_id,
@@ -633,6 +673,7 @@ async def process_agentic_run(
         )
     except AgenticTimeoutError as exc:
         logger.warning("Run %s timed out: %s", run_id, exc)
+        await _emit_chat_error("AGENT_TIMEOUT", str(exc))
         await _append_event_and_publish(
             svc,
             run_id,
@@ -648,6 +689,7 @@ async def process_agentic_run(
         )
     except AgenticUpstreamError as exc:
         logger.warning("Run %s failed upstream: %s", run_id, exc)
+        await _emit_chat_error(exc.error_code, exc.message)
         await _append_event_and_publish(
             svc,
             run_id,
@@ -667,6 +709,7 @@ async def process_agentic_run(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Run %s failed unexpectedly", run_id)
+        await _emit_chat_error("AGENT_UNEXPECTED_ERROR", str(exc))
         await _append_event_and_publish(
             svc,
             run_id,

--- a/echo/server/dembrane/analytics.py
+++ b/echo/server/dembrane/analytics.py
@@ -94,3 +94,14 @@ async def capture_event(
         )
     except Exception:  # noqa: BLE001
         logger.exception("capture_event wrapper failed for %s", event)
+
+
+def capture_event_sync(
+    distinct_id: str,
+    event: str,
+    properties: Optional[dict[str, Any]] = None,
+) -> None:
+    """Synchronous fire-and-forget capture for Dramatiq actors (gevent, no
+    asyncio allowed). Mirror of capture_event for sync worker contexts. The
+    underlying HTTP call has a short timeout and never raises."""
+    _capture_sync(distinct_id, event, properties or {})

--- a/echo/server/dembrane/api/chat.py
+++ b/echo/server/dembrane/api/chat.py
@@ -16,6 +16,7 @@ from dembrane.service import (
     conversation_service,
 )
 from dembrane.settings import get_settings
+from dembrane.analytics import capture_event
 from dembrane.chat_utils import (
     CHAT_LLM,
     MAX_CHAT_CONTEXT_LENGTH,
@@ -1258,6 +1259,17 @@ async def post_chat(
         else:
             formatted_messages = await build_formatted_messages(chat_context.conversation_id_list)
 
+        # Resolve a distinct_id (email) so this server event merges with the
+        # user's frontend person. This is the prod chat path (agentic is gated
+        # off), so the server-side response/error events live here, not only in
+        # the agentic worker.
+        from dembrane.app_user import resolve_app_user
+
+        _chat_user = await resolve_app_user(auth.user_id)
+        chat_distinct_id = (
+            (_chat_user or {}).get("email") or ""
+        ).lower() or auth.user_id
+
         async def stream_response_async(
             formatted: List[Dict[str, str]],
             references: Optional[dict[str, List[Dict[str, str]]]] = None,
@@ -1281,8 +1293,24 @@ async def post_chat(
                             yield delta
                         else:
                             yield f"0:{json.dumps(delta)}\n"
+                await capture_event(
+                    chat_distinct_id,
+                    "server_chat_response_received",
+                    {"chat_id": chat_id, "project_id": project_id, "mode": "context"},
+                )
             except Exception as exc:  # pragma: no cover - runtime safeguard
                 logger.error("Error in litellm stream response: %s", exc)
+                await capture_event(
+                    chat_distinct_id,
+                    "server_chat_error",
+                    {
+                        "chat_id": chat_id,
+                        "project_id": project_id,
+                        "error_code": "STREAM_ERROR",
+                        "message": str(exc)[:300],
+                        "mode": "context",
+                    },
+                )
                 await run_in_thread_pool(chat_svc.delete_message, user_message_id)
                 if protocol == "text":
                     yield "Error: An error occurred while processing the chat response."

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -1243,6 +1243,27 @@ def task_report_summarization_done(report_id: int) -> None:
         client.close()
 
 
+def _report_event_distinct_id(report_id_str: str, project_id: str) -> str:
+    """Resolve the PostHog distinct_id for server-side report events: the
+    report creator's email, so these merge with the creator's frontend person.
+    Falls back to the directus user id, then the project id. Best-effort."""
+    log = getLogger("dembrane.tasks.analytics")
+    try:
+        from dembrane.app_user import resolve_app_user
+
+        with directus_client_context() as client:
+            report_row = client.get_item("project_report", report_id_str)
+        report_data = (report_row or {}).get("data") or report_row or {}
+        creator_directus_id = report_data.get("user_created")
+        if creator_directus_id:
+            creator = run_async_in_new_loop(resolve_app_user(creator_directus_id))
+            email = ((creator or {}).get("email") or "").lower()
+            return email or str(creator_directus_id)
+    except Exception:  # noqa: BLE001 — analytics is best-effort
+        log.warning("could not resolve report distinct_id for %s", report_id_str)
+    return project_id
+
+
 @dramatiq.actor(queue_name="network", priority=50)
 def task_create_report(project_id: str, report_id: int, language: str, user_instructions: str = "") -> None:
     """
@@ -1293,6 +1314,14 @@ def task_create_report(project_id: str, report_id: int, language: str, user_inst
                 publish_report_progress(report_id, event_type, message, detail)
             except Exception as e:
                 logger.warning(f"Failed to publish progress event: {e}")
+
+        from dembrane.analytics import capture_event_sync
+
+        capture_event_sync(
+            _report_event_distinct_id(report_id_str, project_id),
+            "server_report_generation_started",
+            {"project_id": project_id, "report_id": report_id, "language": language},
+        )
 
         try:
             # Store params in Redis so the completion callback can retrieve
@@ -1436,6 +1465,17 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
             publish_report_progress(report_id, "completed", "Report ready")
             logger.info(f"Report {report_id} generated for project {project_id}")
 
+            # Server-side success event: the client report_generated is fired
+            # from the browser on SSE completion, so it misses every host who
+            # closed the tab. This is the reliable count + generation-time anchor.
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generated",
+                {"project_id": project_id, "report_id": report_id, "language": language},
+            )
+
             # Notify the report's creator. Keep the audience tight —
             # fanning to every workspace member on every report would
             # spam inboxes. If we want a wider broadcast later, derive
@@ -1511,10 +1551,32 @@ def task_create_report_continue(project_id: str, report_id: int, language: str, 
                         )
             except Exception as notif_err:
                 logger.warning(f"Failed to emit REPORT_FAILED: {notif_err}")
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generation_failed",
+                {
+                    "project_id": project_id,
+                    "report_id": report_id,
+                    "error_code": "GENERATION_FAILED",
+                },
+            )
             return
 
         except Exception as e:
             logger.error(f"Unexpected error generating report {report_id}: {e}")
+            from dembrane.analytics import capture_event_sync
+
+            capture_event_sync(
+                _report_event_distinct_id(report_id_str, project_id),
+                "server_report_generation_failed",
+                {
+                    "project_id": project_id,
+                    "report_id": report_id,
+                    "error_code": "UNEXPECTED_ERROR",
+                },
+            )
             try:
                 with directus_client_context() as client:
                     client.update_item("project_report", report_id_str, {


### PR DESCRIPTION
## What

All the new analytics events in one PR (supersedes #721 and #722). Built against the live PostHog event set (audited via API), so names don't collide with or double-count existing events. Client events ride the `r.dembrane.com` proxy (#720) and survive ad blockers; server events use `analytics.py` (`$lib=dembrane-server`).

## Portal participant journey (client)

`portal_landed` → `consent_given` → `conversation_started` → `recording_started` → `conversation_finished` → `report_viewed`, plus `portal_recording_error`.
- `portal_landed` is guarded to top-level windows so the host's portal-editor preview iframe doesn't inflate landings.
- Session recording disabled on the portal (anonymous participants, sensitive flow). Needs a privacy/DPA nod before shipping.

## Link source attribution (`utm_source`)

`useProjectSharingLink(project, source)` stamps `utm_source` so PostHog auto-attributes the landing: `qr_scan` vs `qr_click` (encoded QR vs its click target), `copy_link`, `qr_download` (own offscreen QR), `host_guide`, `report`, in-portal `portal`. Answers "QR vs link vs printed guide" the instant someone lands.

## Chat (client)

`chat_started`, `chat_rate_limited` / `chat_error` (non-agentic chat onError, splitting the usage-cap signal), `chat_citation_clicked`, `chat_deleted`.

## Report (client)

`report_made_public`, `report_link_copied`, `report_exported` (share + print).

## Server-side (ad-blocker-proof)

- Report generation lifecycle in the Dramatiq worker: `server_report_generation_started` / `server_report_generated` / `server_report_generation_failed`. Fixes the worst data gap, prod `report_generated` fired 5× vs `report_edited` 198× because the client event needs a tab open at SSE completion. `distinct_id` resolves to the report creator's email so it merges with their frontend person; started→generated gives generation time.
- Chat responses in the agentic worker: `server_chat_response_received` + `server_chat_error` across all failure paths. (Agentic runtime is echo-next only for now.)
- Added `capture_event_sync` for the gevent worker context.

## Conventions / notes

- Server events use the `server_` prefix so they never double-count existing client `report_generated` / `chat_message_sent`.
- `consent_given` can re-fire if a participant navigates back/forward across the consent card; funnels key on first occurrence, so cosmetic.

## Verification

`tsc --noEmit`, `biome lint --diagnostic-level=error`, `ruff check` all clean; server modules import + parse OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
