### PR TITLE
feat(analytics): billing conversion funnel + upgrade-wall attribution + creation events

### DIFF
--- a/echo/frontend/src/components/chat/FreeTierChatGate.tsx
+++ b/echo/frontend/src/components/chat/FreeTierChatGate.tsx
@@ -46,6 +46,7 @@ export function ChatUpgradeModal({
 			}
 			canRequestUpgrade={isAdmin}
 			workspaceId={workspace?.id ?? ""}
+			source={isChatLimit ? "chat_cap" : "chat_turn_cap"}
 		/>
 	);
 }

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -1003,6 +1003,7 @@ export const ProjectConversationsPanel = ({
 					workspace?.role === "admin" || workspace?.role === "owner"
 				}
 				workspaceId={resolvedWorkspaceId ?? ""}
+				source="transcript_locked"
 			/>
 		</Stack>
 	);

--- a/echo/frontend/src/components/organisation/CreateOrganisationModal.tsx
+++ b/echo/frontend/src/components/organisation/CreateOrganisationModal.tsx
@@ -10,6 +10,7 @@ import {
 	TextInput,
 } from "@mantine/core";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import posthog from "posthog-js";
 import { useState } from "react";
 import { toast } from "@/components/common/Toaster";
 import { API_BASE_URL } from "@/config";
@@ -88,6 +89,10 @@ export const CreateOrganisationModal = ({
 		onError: (err: Error) =>
 			toast.error(err.message || t`Could not create the organisation`),
 		onSuccess: (result) => {
+			posthog.capture("org_created", {
+				org_id: result.org_id,
+				workspace_id: result.workspace_id,
+			});
 			setCreated(result);
 			// New org + workspace: refresh the sidebar (orgs are derived from the
 			// workspaces context) and the me payload.

--- a/echo/frontend/src/components/project/UploadLockedCard.tsx
+++ b/echo/frontend/src/components/project/UploadLockedCard.tsx
@@ -79,6 +79,7 @@ export function UploadLockedCard({
 				benefit="Upload recordings once your workspace is upgraded."
 				canRequestUpgrade={canRequestUpgrade}
 				workspaceId={workspaceId}
+				source="upload_cap"
 			/>
 		</>
 	);

--- a/echo/frontend/src/components/report/CreateReportForm.tsx
+++ b/echo/frontend/src/components/report/CreateReportForm.tsx
@@ -389,6 +389,7 @@ export const CreateReportForm = ({ onSuccess }: { onSuccess: () => void }) => {
 					workspace?.role === "admin" || workspace?.role === "owner"
 				}
 				workspaceId={workspace?.id ?? ""}
+				source="report_cap"
 			/>
 		</Stack>
 	);

--- a/echo/frontend/src/components/workspace/FeatureGate.tsx
+++ b/echo/frontend/src/components/workspace/FeatureGate.tsx
@@ -170,6 +170,9 @@ interface UpgradeModalProps {
 	/** Admin/owner sees Request Upgrade. Member sees message-only per D9. */
 	canRequestUpgrade: boolean;
 	workspaceId: string;
+	/** Which wall opened this modal, so the upgrade funnel is attributable
+	 * (chat_cap, chat_turn_cap, upload_cap, report_cap, workspace_cap, ...). */
+	source?: string;
 }
 
 /**
@@ -276,6 +279,7 @@ export function UpgradeModal({
 	featureName,
 	benefit,
 	canRequestUpgrade,
+	source,
 }: UpgradeModalProps) {
 	const { workspace } = useWorkspace();
 	const navigate = useI18nNavigate();
@@ -307,9 +311,10 @@ export function UpgradeModal({
 				current_tier: currentTier,
 				feature_name: featureName,
 				required_tier: requiredTier,
+				source: source ?? "feature_gate",
 			});
 		}
-	}, [opened, canRequestUpgrade, currentTier, featureName, requiredTier]);
+	}, [opened, canRequestUpgrade, currentTier, featureName, requiredTier, source]);
 
 	const goToBilling = () => {
 		if (!workspace?.org_id) {
@@ -319,6 +324,7 @@ export function UpgradeModal({
 		posthog.capture("upgrade_billing_opened", {
 			feature_name: featureName,
 			proposed_tier: selectedTier,
+			source: source ?? "feature_gate",
 		});
 		onClose();
 		// Billing is managed at the organisation level; send them there to pick

--- a/echo/frontend/src/routes/workspaces/CreateWorkspaceRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/CreateWorkspaceRoute.tsx
@@ -137,6 +137,14 @@ export const CreateWorkspaceRoute = () => {
 
 	useDocumentTitle(t`Create workspace | dembrane`);
 
+	// Funnel entry for the create-workspace wizard (pairs with workspace_created
+	// and workspace_ownership_changed to show drop-off and internal/external
+	// backtracking).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: fire once on open
+	useEffect(() => {
+		posthog.capture("workspace_create_started");
+	}, []);
+
 	const adminOrganisations = useMemo(
 		() =>
 			(meV2?.orgs ?? []).filter(
@@ -477,7 +485,13 @@ export const CreateWorkspaceRoute = () => {
 									</Text>
 									<Radio.Group
 										value={billFor}
-										onChange={(v) => setBillFor(v as BillFor)}
+										onChange={(v) => {
+											posthog.capture("workspace_ownership_changed", {
+												from: billFor,
+												to: v,
+											});
+											setBillFor(v as BillFor);
+										}}
 									>
 										<Stack gap={10} mt={8}>
 											<Radio
@@ -756,6 +770,7 @@ export const CreateWorkspaceRoute = () => {
 				benefit={t`Upgrade your plan to create more workspaces in this organisation.`}
 				canRequestUpgrade
 				workspaceId=""
+				source="workspace_cap"
 			/>
 		</Container>
 	);

--- a/echo/server/dembrane/billing_service.py
+++ b/echo/server/dembrane/billing_service.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone, timedelta
 
 from dembrane import mollie
 from dembrane.settings import get_settings
+from dembrane.analytics import capture_event
 from dembrane.redis_async import get_redis_client
 from dembrane.seat_capacity import count_pending_invites
 from dembrane.tier_capacity import (
@@ -897,6 +898,22 @@ async def _activate_from_first_payment(account_id: str, meta: dict, customer_id:
             account_id,
             tier,
             sub.get("id"),
+        )
+        # Revenue conversion source of truth: a first payment cleared and the
+        # account is now active. Fired from the webhook so it can't be blocked
+        # or lost (unlike the client checkout_started). distinct_id is the org
+        # billing account; tying it to the checkout initiator's person is a
+        # follow-up (would thread the user id through Mollie metadata).
+        await capture_event(
+            account_id,
+            "server_subscription_activated",
+            {
+                "billing_account_id": account_id,
+                "tier": tier,
+                "billing_period": billing_period,
+                "amount_eur": amount,
+                "seats": seats,
+            },
         )
     finally:
         await _release_activation_lock(account_id, client, token)


### PR DESCRIPTION
## What

Billing conversion funnel + upgrade-wall attribution + creation-flow events. Built against the free-tier gates already on main (#710/#716). Separate from the events PR (#723) because it touches the Mollie webhook.

## Upgrade walls are now attributable

The shared `UpgradeModal` already fired `upgrade_prompt_viewed` / `upgrade_billing_opened`, but only `FeatureGate` used it with any context. Added a `source` prop and passed it from every wall:

`feature_gate`, `chat_cap`, `chat_turn_cap`, `upload_cap`, `report_cap`, `workspace_cap`, `transcript_locked`.

So we can finally answer **which wall drives upgrades**, the core conversion question.

## Paid conversion (server, source of truth)

`server_subscription_activated` fired from the Mollie webhook activation path (`_activate_from_first_payment`) with `tier`, `billing_period`, `amount_eur`, `seats`. This is the actual revenue moment, can't be ad-blocked (unlike the client `checkout_started`). Completes the funnel:

`upgrade_prompt_viewed {source}` → `upgrade_billing_opened {source}` → `checkout_started` → `server_subscription_activated`, with fall-off sliced by which wall.

## Creation funnels

- `workspace_create_started` + `workspace_ownership_changed` (the internal↔external backtrack you asked about)
- `org_created`
- (project create_started/created already existed.)

## Notes

- `distinct_id` on the paid event is the org billing account; tying it to the checkout initiator's person is a follow-up (would thread the user id through Mollie metadata).
- Free-tier spec confirmed already implemented as you described (1 transcript visible, rest blurred → upgrade; 1 chat/3 turns; 1 report; 1 ws/org). Open question unrelated to this PR: Upload is gated by a 1-hour cap, not a hard block, flag if you want it fully off for free.
- Touches the payment webhook, so worth a `/security-review` before merge.

## Verification

`ruff check` clean; `biome lint` clean on all 7 frontend files. `tsc` couldn't run locally (sandbox OOM-kills it); CI runs the full `tsc && vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
