### PR TITLE
 feat(invite): org admins can pick org members from the email field

### DIFF
--- a/echo/frontend/src/components/invite/EmailChipsInput.tsx
+++ b/echo/frontend/src/components/invite/EmailChipsInput.tsx
@@ -1,8 +1,17 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
-import { ActionIcon, Box, Group, Stack, Text, TextInput } from "@mantine/core";
+import {
+	ActionIcon,
+	Box,
+	Combobox,
+	Group,
+	Stack,
+	Text,
+	TextInput,
+	useCombobox,
+} from "@mantine/core";
 import { IconX } from "@tabler/icons-react";
-import { type ChangeEvent, type KeyboardEvent, useState } from "react";
+import { type ChangeEvent, type KeyboardEvent, useMemo, useState } from "react";
 
 export interface EmailChip {
 	id: string;
@@ -11,11 +20,20 @@ export interface EmailChip {
 	state: "valid" | "invalid" | "self";
 }
 
+// A person already known to the org, offered as an autocomplete suggestion.
+export interface MemberSuggestion {
+	email: string;
+	displayName?: string | null;
+}
+
 interface Props {
 	chips: EmailChip[];
 	onChipsChange: (next: EmailChip[]) => void;
 	selfEmail?: string | null;
 	autoFocus?: boolean;
+	// When provided (org admins), the input offers these people as a dropdown.
+	// Absent → plain free-text behaviour, unchanged for everyone else.
+	suggestions?: MemberSuggestion[];
 	"data-testid"?: string;
 }
 
@@ -59,16 +77,52 @@ function dedupeAppend(
 }
 
 // Splits on commas/spaces/newlines, renders chips with per-chip validation. Self-invite caught inline.
+// When `suggestions` is passed, the input also offers an autocomplete dropdown of
+// known people (org admins). Typing an email that isn't a known person still works:
+// it just becomes a chip on Enter/comma, and never appears as a dropdown option.
 export function EmailChipsInput({
 	chips,
 	onChipsChange,
 	selfEmail,
 	autoFocus,
+	suggestions,
 	"data-testid": dataTestId,
 }: Props) {
 	const [draft, setDraft] = useState("");
 	// Two-step Backspace delete: first highlights the last chip, second removes it.
 	const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+	const suggestionsEnabled = Boolean(suggestions && suggestions.length > 0);
+	const combobox = useCombobox({
+		onDropdownClose: () => combobox.resetSelectedOption(),
+		onDropdownOpen: () => combobox.resetSelectedOption(),
+	});
+
+	// Already-added emails so we don't re-offer someone the admin just picked.
+	const addedLookup = useMemo(
+		() => new Set(chips.map((c) => c.value.toLowerCase())),
+		[chips],
+	);
+
+	// Suggestions matching the current draft, minus self and already-added. New
+	// (unknown) emails never enter this list, so they can't show in the dropdown.
+	const filteredSuggestions = useMemo(() => {
+		if (!suggestionsEnabled) return [];
+		const self = selfEmail?.toLowerCase();
+		const q = draft.trim().toLowerCase();
+		return (suggestions ?? [])
+			.filter((s) => {
+				const email = s.email.toLowerCase();
+				if (self && email === self) return false;
+				if (addedLookup.has(email)) return false;
+				if (!q) return true;
+				return (
+					email.includes(q) ||
+					(s.displayName ? s.displayName.toLowerCase().includes(q) : false)
+				);
+			})
+			.slice(0, 50);
+	}, [suggestionsEnabled, suggestions, selfEmail, draft, addedLookup]);
 
 	const commitDraft = (raw: string) => {
 		const tokens = raw.split(SEPARATORS).filter((tok) => tok.length > 0);
@@ -81,6 +135,13 @@ export function EmailChipsInput({
 		setDraft("");
 	};
 
+	// Add a single email picked from the dropdown; keep the dropdown open for multi-pick.
+	const commitEmail = (email: string) => {
+		onChipsChange(dedupeAppend(chips, [makeChip(email, selfEmail)]));
+		setDraft("");
+		combobox.resetSelectedOption();
+	};
+
 	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
 		const value = e.currentTarget.value;
 		if (pendingDeleteId) setPendingDeleteId(null);
@@ -90,9 +151,43 @@ export function EmailChipsInput({
 			return;
 		}
 		setDraft(value);
+		if (suggestionsEnabled) {
+			combobox.openDropdown();
+			combobox.resetSelectedOption();
+		}
 	};
 
 	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (suggestionsEnabled) {
+			if (e.key === "ArrowDown") {
+				combobox.openDropdown();
+				combobox.selectNextOption();
+				e.preventDefault();
+				return;
+			}
+			if (e.key === "ArrowUp") {
+				combobox.openDropdown();
+				combobox.selectPreviousOption();
+				e.preventDefault();
+				return;
+			}
+			if (e.key === "Escape" && combobox.dropdownOpened) {
+				combobox.closeDropdown();
+				return;
+			}
+			// Enter only picks a suggestion when one is actively highlighted; otherwise
+			// it falls through to commit the typed draft (the invite-new path).
+			if (
+				e.key === "Enter" &&
+				combobox.dropdownOpened &&
+				combobox.getSelectedOptionIndex() >= 0 &&
+				filteredSuggestions.length > 0
+			) {
+				e.preventDefault();
+				combobox.clickSelectedOption();
+				return;
+			}
+		}
 		if (e.key === "Enter" || e.key === "Tab") {
 			if (draft.trim().length > 0) {
 				e.preventDefault();
@@ -124,10 +219,15 @@ export function EmailChipsInput({
 		}
 	};
 
+	const handleFocus = () => {
+		if (suggestionsEnabled) combobox.openDropdown();
+	};
+
 	const handleBlur = () => {
 		if (draft.trim().length > 0) {
 			commitDraft(draft);
 		}
+		if (suggestionsEnabled) combobox.closeDropdown();
 	};
 
 	const removeChip = (id: string) => {
@@ -136,56 +236,98 @@ export function EmailChipsInput({
 
 	const invalidCount = chips.filter((c) => c.state !== "valid").length;
 
+	const inputBox = (
+		<Box
+			p={6}
+			style={{
+				border: "1px solid var(--mantine-color-gray-3)",
+				borderRadius: 6,
+				minHeight: 44,
+			}}
+		>
+			<Group gap={6} wrap="wrap">
+				{chips.map((chip) => (
+					<EmailChipPill
+						key={chip.id}
+						chip={chip}
+						highlighted={chip.id === pendingDeleteId}
+						onRemove={() => removeChip(chip.id)}
+					/>
+				))}
+				<TextInput
+					variant="unstyled"
+					placeholder={
+						chips.length === 0
+							? suggestionsEnabled
+								? t`Search people, or type an email`
+								: t`name@example.com, name2@example.com`
+							: ""
+					}
+					value={draft}
+					onChange={handleChange}
+					onKeyDown={handleKeyDown}
+					onPaste={handlePaste}
+					onFocus={handleFocus}
+					onBlur={handleBlur}
+					autoFocus={autoFocus}
+					styles={{ input: { minWidth: 220 } }}
+					style={{ flex: 1 }}
+					data-testid={dataTestId ? `${dataTestId}-input` : undefined}
+				/>
+			</Group>
+		</Box>
+	);
+
+	const helper = (
+		<Group justify="space-between">
+			<Text size="xs" c="dimmed">
+				{suggestionsEnabled ? (
+					<Trans>
+						Pick from your organisation, or type an email to invite.
+					</Trans>
+				) : (
+					<Trans>Separate with commas, spaces, or new lines.</Trans>
+				)}
+			</Text>
+			{invalidCount > 0 && (
+				<Text size="xs" c="red">
+					{invalidCount === 1 ? (
+						<Trans>1 address needs attention</Trans>
+					) : (
+						<Trans>{invalidCount} addresses need attention</Trans>
+					)}
+				</Text>
+			)}
+		</Group>
+	);
+
+	if (!suggestionsEnabled) {
+		return (
+			<Stack gap={6} data-testid={dataTestId}>
+				{inputBox}
+				{helper}
+			</Stack>
+		);
+	}
+
 	return (
 		<Stack gap={6} data-testid={dataTestId}>
-			<Box
-				p={6}
-				style={{
-					border: "1px solid var(--mantine-color-gray-3)",
-					borderRadius: 6,
-					minHeight: 44,
-				}}
-			>
-				<Group gap={6} wrap="wrap">
-					{chips.map((chip) => (
-						<EmailChipPill
-							key={chip.id}
-							chip={chip}
-							highlighted={chip.id === pendingDeleteId}
-							onRemove={() => removeChip(chip.id)}
-						/>
-					))}
-					<TextInput
-						variant="unstyled"
-						placeholder={
-							chips.length === 0 ? t`name@example.com, name2@example.com` : ""
-						}
-						value={draft}
-						onChange={handleChange}
-						onKeyDown={handleKeyDown}
-						onPaste={handlePaste}
-						onBlur={handleBlur}
-						autoFocus={autoFocus}
-						styles={{ input: { minWidth: 220 } }}
-						style={{ flex: 1 }}
-						data-testid={dataTestId ? `${dataTestId}-input` : undefined}
-					/>
-				</Group>
-			</Box>
-			<Group justify="space-between">
-				<Text size="xs" c="dimmed">
-					<Trans>Separate with commas, spaces, or new lines.</Trans>
-				</Text>
-				{invalidCount > 0 && (
-					<Text size="xs" c="red">
-						{invalidCount === 1 ? (
-							<Trans>1 address needs attention</Trans>
-						) : (
-							<Trans>{invalidCount} addresses need attention</Trans>
-						)}
-					</Text>
-				)}
-			</Group>
+			<Combobox store={combobox} onOptionSubmit={(value) => commitEmail(value)}>
+				<Combobox.DropdownTarget>{inputBox}</Combobox.DropdownTarget>
+				<Combobox.Dropdown hidden={filteredSuggestions.length === 0}>
+					<Combobox.Options mah={240} style={{ overflowY: "auto" }}>
+						{filteredSuggestions.map((s) => (
+							<Combobox.Option value={s.email} key={s.email}>
+								<Group gap="xs" wrap="nowrap">
+									<Text size="sm">{s.displayName || s.email}</Text>
+									{s.displayName && <Text size="xs">- {s.email}</Text>}
+								</Group>
+							</Combobox.Option>
+						))}
+					</Combobox.Options>
+				</Combobox.Dropdown>
+			</Combobox>
+			{helper}
 		</Stack>
 	);
 }

--- a/echo/frontend/src/components/invite/InviteModal.tsx
+++ b/echo/frontend/src/components/invite/InviteModal.tsx
@@ -18,6 +18,7 @@ import { toast } from "@/components/common/Toaster";
 import {
 	type EmailChip,
 	EmailChipsInput,
+	type MemberSuggestion,
 } from "@/components/invite/EmailChipsInput";
 import {
 	type InviteResultRow,
@@ -36,6 +37,7 @@ import {
 	invalidateOrgMembersEverywhere,
 	invalidateOrgWorkspacesEverywhere,
 	invalidatePendingInvitesEverywhere,
+	orgQueryKeys,
 } from "@/lib/orgQueryKeys";
 
 interface Props {
@@ -62,6 +64,24 @@ async function fetchOrgWorkspaces(
 		throw new Error("Workspaces response was not an array");
 	}
 	return data as InviteableWorkspace[];
+}
+
+// Minimal shape of GET /v2/orgs/:id/members — only the fields the autocomplete needs.
+type OrgMemberLite = {
+	email: string;
+	display_name: string;
+	is_external?: boolean;
+};
+
+// Best-effort: suggestions are a convenience, so a failed/forbidden fetch yields
+// an empty list rather than breaking the modal.
+async function fetchOrgMembers(orgId: string): Promise<OrgMemberLite[]> {
+	const res = await fetch(`${API_BASE_URL}/v2/orgs/${orgId}/members`, {
+		credentials: "include",
+	});
+	if (!res.ok) return [];
+	const data = await res.json().catch(() => null);
+	return Array.isArray(data) ? (data as OrgMemberLite[]) : [];
 }
 
 type WorkspaceInvitePayload = {
@@ -245,6 +265,24 @@ export function InviteModal({
 		staleTime: 30_000,
 	});
 
+	// Org admins/owners get a people-picker so they can add existing org members
+	// without retyping emails. Everyone else keeps the plain free-text input.
+	const { data: orgMembers = [] } = useQuery({
+		enabled: opened && canInviteOrgOnly && Boolean(orgId),
+		queryFn: () => fetchOrgMembers(orgId),
+		queryKey: orgQueryKeys.members(orgId),
+		staleTime: 60_000,
+	});
+
+	const memberSuggestions = useMemo<MemberSuggestion[] | undefined>(() => {
+		if (!canInviteOrgOnly) return undefined;
+		const selfLower = me?.email?.toLowerCase();
+		return orgMembers
+			.filter((m) => !m.is_external && m.email)
+			.filter((m) => m.email.toLowerCase() !== selfLower)
+			.map((m) => ({ displayName: m.display_name, email: m.email }));
+	}, [canInviteOrgOnly, orgMembers, me?.email]);
+
 	// Org admins/owners can invite everywhere; workspace admins only to workspaces they admin.
 	const inviteableWorkspaces = useMemo<InviteableWorkspace[]>(() => {
 		if (canInviteOrgOnly) return allWorkspaces;
@@ -304,7 +342,9 @@ export function InviteModal({
 			(id) => inviteableWorkspaces.find((w) => w.id === id)?.bills_separately,
 		);
 	const observerNeedsExternalWorkspace =
-		role === "observer" && !zeroWorkspaceSubmit && !selectedAreAllExternalClient;
+		role === "observer" &&
+		!zeroWorkspaceSubmit &&
+		!selectedAreAllExternalClient;
 
 	const canSubmit =
 		validChips.length > 0 &&
@@ -574,7 +614,7 @@ export function InviteModal({
 							chips={chips}
 							onChipsChange={setChips}
 							selfEmail={me?.email ?? null}
-							autoFocus
+							suggestions={memberSuggestions}
 							data-testid="invite-modal-emails"
 						/>
 
@@ -657,9 +697,9 @@ export function InviteModal({
 							<Alert color="yellow" variant="light" p="xs">
 								<Text size="xs">
 									<Trans>
-										Observers are only available in workspaces for an
-										external client. Pick only external-client workspaces,
-										or choose a different role.
+										Observers are only available in workspaces for an external
+										client. Pick only external-client workspaces, or choose a
+										different role.
 									</Trans>
 								</Text>
 							</Alert>


### PR DESCRIPTION
  The invite modal's email field only accepted typed-out addresses, which
  was painful when adding people already in the org. For org admins/owners,
  it now offers a searchable dropdown of existing org members.

  - EmailChipsInput takes an optional `suggestions` prop. When present (admins), the chip input is wrapped in a Combobox; when absent, it renders exactly as before for everyone else.
  - The list opens only on click/focus and closes on blur (no autofocus).
  - Suggestions filter live by name or email and exclude self and already-added people. Unknown emails never appear as options; typing one still adds it as a chip (the invite-new path), unchanged.
  - InviteModal fetches org members (best-effort, gated on admin + open) and builds the suggestion list, excluding externals and self.