### PR TITLE
  fix(workspace-logo): allow all paid tiers to upload logos

### DIFF
--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -1181,6 +1181,7 @@ interface MyWorkspace {
 	members_preview?: WorkspaceMemberPreview[];
 	usage?: { audio_hours?: number; conversation_count?: number };
 	created_at?: string | null;
+	logo_url?: string | null;
 }
 
 async function fetchMyWorkspaces(): Promise<{
@@ -1207,6 +1208,7 @@ interface WorkspaceCardModel {
 	is_private: boolean;
 	visibility: string;
 	bills_separately: boolean;
+	logo_url: string | null;
 	pinned_projects: WorkspacePinnedProject[];
 	recently_approved: boolean;
 }
@@ -1309,6 +1311,7 @@ function OrganisationOverviewPanel({
 					id: w.id,
 					is_private: roster?.is_private ?? false,
 					visibility: roster?.visibility ?? "open_to_organisation",
+					logo_url: w.logo_url ?? null,
 					member_count: w.member_count,
 					members_preview: w.members_preview ?? [],
 					name: w.name,
@@ -1551,6 +1554,16 @@ function OrganisationWorkspaceCard({
 		>
 			<Stack gap={12}>
 				<Group gap="xs" wrap="nowrap" align="center">
+					{workspace.logo_url && (
+						<Image
+							src={resolveLogoUrl(workspace.logo_url)}
+							alt={t`${workspace.name} logo`}
+							h={24}
+							w="auto"
+							fit="contain"
+							style={{ flexShrink: 0, maxWidth: 80 }}
+						/>
+					)}
 					<Text
 						fw={500}
 						size="md"

--- a/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
+++ b/echo/frontend/src/routes/workspaces/WorkspaceSettingsRoute.tsx
@@ -1536,13 +1536,10 @@ function PrivacyAndDefaultsSection({
 						maxLength={500}
 					/>
 					{(() => {
-						// Whitelabel branding is changemaker+ AND a per-workspace logo
-						// override is only for external-client workspaces (ISSUE-032);
-						// internal workspaces inherit the org's branding.
+						// Whitelabel branding is gated on tier (changemaker+).
+						// Any paid workspace can set a per-workspace logo.
 						const whitelabelTiers = ["changemaker", "guardian"];
-						const canWhitelabel =
-							whitelabelTiers.includes(settings.tier) &&
-							settings.is_external_client;
+						const canWhitelabel = whitelabelTiers.includes(settings.tier);
 
 						if (canWhitelabel) {
 							return (

--- a/echo/server/dembrane/api/v2/workspace_settings.py
+++ b/echo/server/dembrane/api/v2/workspace_settings.py
@@ -21,21 +21,6 @@ router = APIRouter()
 logger = getLogger("api.v2.workspace_settings")
 
 
-def _require_external_for_whitelabel(ctx: WorkspaceContext) -> None:
-    """Per-workspace whitelabel logo override is only for external-client
-    workspaces (ISSUE-032). Internal workspaces inherit the org's branding."""
-    from dembrane.billing_account import workspace_is_external_client
-
-    if not workspace_is_external_client(ctx.workspace):
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "A per-workspace logo is only available for external-client "
-                "workspaces. Internal workspaces use the organisation's branding."
-            ),
-        )
-
-
 # Reusable Annotated alias keeps handler signatures readable and avoids
 # Ruff B008 ("Depends() in arg defaults"). Mirrors the convention in
 # dembrane/api/v2/workspaces.py.
@@ -385,9 +370,6 @@ async def update_workspace_settings(
         current_logo = ctx.workspace.get("logo_url") or ""
         if cleaned_logo != current_logo:
             ctx.require_policy("workspace:whitelabel")
-            # Setting/overriding a logo is external-only; clearing it is allowed.
-            if cleaned_logo:
-                _require_external_for_whitelabel(ctx)
         payload["logo_url"] = cleaned_logo or None
 
     # Privacy: the `visibility` enum is the source of truth (discovery and
@@ -700,7 +682,6 @@ async def upload_workspace_logo(
     """
     ctx.require_policy("settings:manage")
     ctx.require_policy("workspace:whitelabel")
-    _require_external_for_whitelabel(ctx)
 
     if file.content_type and file.content_type not in _ALLOWED_LOGO_TYPES:
         raise HTTPException(

--- a/echo/server/tests/test_partner_wave_fg.py
+++ b/echo/server/tests/test_partner_wave_fg.py
@@ -324,34 +324,6 @@ def test_usage_context_not_in_update_request():
     assert "data_owner_email" not in UpdateWorkspaceRequest.model_fields
 
 
-# ── ISSUE-032: per-workspace whitelabel is external-only ────────────────
-
-
-def test_whitelabel_gate_external_only():
-    from fastapi import HTTPException as _HTTPExc
-
-    from dembrane.api.v2.workspace_settings import _require_external_for_whitelabel
-
-    def ctx_for(ws: dict):
-        return WorkspaceContext(
-            workspace_id=ws["id"],
-            workspace=ws,
-            app_user_id="au-1",
-            role="admin",
-            custom_policies=[],
-            source="direct",
-        )
-
-    # Internal workspace → blocked (403).
-    with pytest.raises(_HTTPExc) as exc:
-        _require_external_for_whitelabel(
-            ctx_for({"id": "w", "usage_context": "internal"})
-        )
-    assert exc.value.status_code == 403
-    # External-client workspace → allowed (no raise).
-    _require_external_for_whitelabel(ctx_for({"id": "w", "usage_context": "external"}))
-
-
 # ── Generalization: no bill_separately flag; data owner implies external ─
 
 


### PR DESCRIPTION
…them on org overview

  Logo upload was gated on tier AND is_external_client, so paid (changemaker+)
  internal workspaces saw "Requires changemaker tier or above" even though they
  had the tier. Drop the external-client requirement; the changemaker+ tier gate
  (workspace:whitelabel) still applies on both the upload and patch-settings
  endpoints. Remove the now-unused _require_external_for_whitelabel helper and its
  test.

  Also surface the workspace logo on the org overview cards (o/<org_id>/overview),
  which never rendered one. Thread logo_url from the /v2/workspaces list through
  MyWorkspace and WorkspaceCardModel, and show it next to the workspace name.