### PR TITLE
feat(sidebar): make collapsible sidebar the default for everyone

### DIFF
--- a/echo/frontend/src/components/layout/BaseLayout.tsx
+++ b/echo/frontend/src/components/layout/BaseLayout.tsx
@@ -5,7 +5,6 @@ import { AppSidebar, useSidebarView } from "@/features/sidebar";
 import { AppBreadcrumbs } from "@/features/sidebar/breadcrumbs/AppBreadcrumbs";
 import { InboxView } from "@/features/sidebar/views/InboxView";
 import { useSidebarState } from "@/features/sidebar/hooks/useSidebarState";
-import { useV2Me } from "@/hooks/useV2Me";
 import { ActionIcon } from "@mantine/core";
 import { List } from "@phosphor-icons/react";
 import { Toaster } from "../common/Toaster";
@@ -36,8 +35,6 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 	const { isAuthenticated } = useAuthenticated();
 	const { overlay } = useSidebarView();
 	const { collapsed, setCollapsed } = useSidebarState();
-	const { data: me } = useV2Me();
-	const isCollapsible = !!me?.settings?.enable_collapsible_sidebar;
 
 	return (
 		<TransitionCurtainProvider>
@@ -49,7 +46,7 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 				) : null}
 				<ErrorBoundary>
 					<main className="relative flex flex-1 flex-col overflow-hidden">
-						{isAuthenticated && isCollapsible && collapsed && (
+						{isAuthenticated && collapsed && (
 							<div className="absolute left-3 top-[12.5px] z-40">
 								<ActionIcon
 									variant="subtle"

--- a/echo/frontend/src/components/settings/BetaFeaturesCard.tsx
+++ b/echo/frontend/src/components/settings/BetaFeaturesCard.tsx
@@ -2,19 +2,31 @@ import { Trans } from "@lingui/react/macro";
 import { Card, Checkbox, Group, Stack, Text, Title } from "@mantine/core";
 import { IconFlask } from "@tabler/icons-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { useV2Me } from "@/hooks/useV2Me";
 import { API_BASE_URL } from "@/config";
 import { toast } from "../common/Toaster";
+
+interface BetaFlag {
+	/** Key stored under `app_user.settings`. */
+	key: string;
+	label: ReactNode;
+	description: ReactNode;
+}
+
+// Registry of opt-in beta feature flags. Add an entry here and a toggle appears
+// automatically under Settings -> Appearance; the whole card (heading included)
+// stays hidden while this list is empty.
+const BETA_FLAGS: BetaFlag[] = [];
 
 export const BetaFeaturesCard = () => {
 	const { data: me } = useV2Me();
 	const queryClient = useQueryClient();
 
 	const settings = me?.settings ?? {};
-	const enableCollapsibleSidebar = !!settings.enable_collapsible_sidebar;
 
 	const updateSettingsMutation = useMutation({
-		mutationFn: async (newSettings: Record<string, any>) => {
+		mutationFn: async (newSettings: Record<string, boolean>) => {
 			const response = await fetch(`${API_BASE_URL}/v2/me`, {
 				body: JSON.stringify({ settings: newSettings }),
 				credentials: "include",
@@ -32,11 +44,8 @@ export const BetaFeaturesCard = () => {
 		},
 	});
 
-	const handleToggleSidebar = (checked: boolean) => {
-		updateSettingsMutation.mutate({
-			enable_collapsible_sidebar: checked,
-		});
-	};
+	// Nothing to opt into yet — render nothing so no empty heading shows.
+	if (BETA_FLAGS.length === 0) return null;
 
 	return (
 		<Card withBorder p="lg" radius="md">
@@ -47,17 +56,24 @@ export const BetaFeaturesCard = () => {
 						<Trans>Beta features</Trans>
 					</Title>
 				</Group>
-				<Text size="sm" c="dimmed">
+				<Text size="sm">
 					<Trans>Opt-in to experimental features and help shape dembrane. These features might change or be removed at any time.</Trans>
 				</Text>
 
-				<Checkbox
-					checked={enableCollapsibleSidebar}
-					onChange={(event) => handleToggleSidebar(event.currentTarget.checked)}
-					label={<Trans>Enable collapsible sidebar</Trans>}
-					description={<Trans>Allows the sidebar to be collapsed to save screen space, particularly useful on mobile screens.</Trans>}
-					disabled={updateSettingsMutation.isPending}
-				/>
+				{BETA_FLAGS.map((flag) => (
+					<Checkbox
+						key={flag.key}
+						checked={!!settings[flag.key]}
+						onChange={(event) =>
+							updateSettingsMutation.mutate({
+								[flag.key]: event.currentTarget.checked,
+							})
+						}
+						label={flag.label}
+						description={flag.description}
+						disabled={updateSettingsMutation.isPending}
+					/>
+				))}
 			</Stack>
 		</Card>
 	);

--- a/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
+++ b/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
@@ -8,7 +8,6 @@ import { useProjectById } from "@/components/project/hooks";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useSidebarView } from "../hooks/useSidebarView";
 import { useSidebarState } from "../hooks/useSidebarState";
-import { useV2Me } from "@/hooks/useV2Me";
 
 interface Crumb {
 	label: string;
@@ -84,8 +83,6 @@ const ORG_SETTINGS_LABELS: Record<string, string> = {
 export const AppBreadcrumbs = () => {
 	const { view, params } = useSidebarView();
 	const { collapsed } = useSidebarState();
-	const { data: me } = useV2Me();
-	const isCollapsible = !!me?.settings?.enable_collapsible_sidebar;
 	const { orgId: routeOrgId, organisationId } = useParams<{
 		orgId?: string;
 		organisationId?: string;
@@ -276,7 +273,7 @@ export const AppBreadcrumbs = () => {
 			aria-label="Breadcrumb"
 			style={{
 				color: "rgba(45, 45, 44, 0.55)",
-				paddingLeft: isCollapsible && collapsed ? "52px" : "16px",
+				paddingLeft: collapsed ? "52px" : "16px",
 				paddingRight: "16px",
 			}}
 		>

--- a/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
+++ b/echo/frontend/src/features/sidebar/shell/SidebarHeader.tsx
@@ -2,13 +2,10 @@ import { I18nLink } from "@/components/common/i18nLink";
 import { Logo } from "@/components/common/Logo";
 import { ActionIcon } from "@mantine/core";
 import { CaretLeft } from "@phosphor-icons/react";
-import { useV2Me } from "@/hooks/useV2Me";
 import { useSidebarState } from "../hooks/useSidebarState";
 
 export const SidebarHeader = () => {
-	const { data: me } = useV2Me();
 	const { setCollapsed } = useSidebarState();
-	const isCollapsible = !!me?.settings?.enable_collapsible_sidebar;
 
 	return (
 		<div
@@ -23,17 +20,15 @@ export const SidebarHeader = () => {
 				<Logo hideTitle={false} />
 			</I18nLink>
 
-			{isCollapsible && (
-				<ActionIcon
-					variant="subtle"
-					color="gray"
-					onClick={() => setCollapsed(true)}
-					aria-label="Collapse sidebar"
-					size={28}
-				>
-					<CaretLeft size={18} />
-				</ActionIcon>
-			)}
+			<ActionIcon
+				variant="subtle"
+				color="gray"
+				onClick={() => setCollapsed(true)}
+				aria-label="Collapse sidebar"
+				size={28}
+			>
+				<CaretLeft size={18} />
+			</ActionIcon>
 		</div>
 	);
 };


### PR DESCRIPTION
## What
Makes the collapsible sidebar the default for **all** users and removes the per-user opt-in flag introduced in #714.

## Changes
- **Always-on collapse/expand.** `SidebarHeader`, `BaseLayout`, and `AppBreadcrumbs` no longer gate on `me.settings.enable_collapsible_sidebar` — the collapse button (and the floating expand button when collapsed) always render.
- **Removed the flag mapping.** The `enable_collapsible_sidebar` toggle is gone from the Beta features card.
- **Beta features card is now registry-driven.** Add an entry to the `BETA_FLAGS` array and a toggle appears automatically under Settings → Appearance. While the registry is empty (as it is now), the card renders `null` — so no empty "Beta features" heading shows.

## Notes
- The generic `app_user.settings` JSON field (from #714) is kept for future flags — only the sidebar-specific mapping/gating was removed.
- Any stored `enable_collapsible_sidebar` values become harmless no-ops.
- No i18n catalog changes required (only removed `<Trans>` strings; CI doesn't enforce catalog sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)