### PR TITLE
fix(agent): build image from uv.lock; fix knowledge docs_root path

### DIFF
--- a/echo/agent/Dockerfile
+++ b/echo/agent/Dockerfile
@@ -10,8 +10,12 @@ RUN apt-get update \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
-COPY echo/agent/pyproject.toml ./
-RUN uv sync --frozen || uv sync
+# Copy the lockfile too so the build resolves the SAME, tested dependency
+# set (uv sync --frozen). Without the lock at this step, uv resolves fresh
+# against pyproject ranges and can pull a newer copilotkit that dropped
+# LangGraphAgent — which then gets baked in and served (CMD uses --no-sync).
+COPY echo/agent/pyproject.toml echo/agent/uv.lock ./
+RUN uv sync --frozen
 
 COPY echo/agent/ .
 # Product docs corpus for the agent's read-only knowledge FS

--- a/echo/agent/knowledge.py
+++ b/echo/agent/knowledge.py
@@ -29,10 +29,11 @@ def docs_root() -> Optional[Path]:
     if override:
         return Path(override) if Path(override).is_dir() else None
     here = Path(__file__).resolve().parent
-    return _first_existing(
-        here / "knowledge" / "docs",       # container image
-        here.parents[1] / "docs",          # repo checkout (echo/agent -> repo root)
-    )
+    candidates = [here / "knowledge" / "docs"]  # container image (/app/knowledge/docs)
+    if len(here.parents) >= 2:
+        # repo checkout: echo/agent/knowledge.py -> <repo>/docs
+        candidates.append(here.parents[1] / "docs")
+    return _first_existing(*candidates)
 
 
 def skills_root() -> Optional[Path]:
@@ -72,7 +73,10 @@ def read_doc(path: str, offset: int = 1, limit: int = _MAX_READ_LINES) -> str:
     start = max(offset, 1)
     end = min(start - 1 + max(1, min(limit, _MAX_READ_LINES)), len(lines))
     numbered = [f"{i}: {lines[i - 1]}" for i in range(start, end + 1)]
-    suffix = "" if end >= len(lines) else f"\n... ({len(lines) - end} more lines; call readDoc with offset={end + 1})"
+    if end >= len(lines):
+        suffix = ""
+    else:
+        suffix = f"\n... ({len(lines) - end} more lines; call readDoc with offset={end + 1})"
     return "\n".join(numbered) + suffix
 
 

--- a/echo/agent/tests/test_knowledge.py
+++ b/echo/agent/tests/test_knowledge.py
@@ -1,0 +1,67 @@
+"""Knowledge VFS tests. Uses the KNOWLEDGE_*_DIR env overrides so the suite
+is hermetic and independent of where the module file sits — the container
+path bug (here.parents[1] out of range at /app/knowledge.py) slipped past
+the earlier tests precisely because they relied on the checkout layout."""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def knowledge_dirs(tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    (docs / "features").mkdir(parents=True)
+    (docs / "features" / "portal-editor.md").write_text(
+        "# Portal editor\nThe key terms field feeds transcription.\n", encoding="utf-8"
+    )
+    (docs / "index.md").write_text("# Docs\n", encoding="utf-8")
+
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    (skills / "onboarding.md").write_text(
+        "---\nname: onboarding\ndescription: Guide setup.\n"
+        "when_to_use: setup questions.\n---\nbody\n",
+        encoding="utf-8",
+    )
+    (skills / "no-frontmatter.md").write_text("just a body\n", encoding="utf-8")
+
+    monkeypatch.setenv("KNOWLEDGE_DOCS_DIR", str(docs))
+    monkeypatch.setenv("KNOWLEDGE_SKILLS_DIR", str(skills))
+    import knowledge
+
+    return importlib.reload(knowledge)
+
+
+def test_docs_root_resolves_without_index_error(knowledge_dirs):
+    # Regression: must not raise regardless of the module's own path depth.
+    assert knowledge_dirs.docs_root() is not None
+    assert sorted(knowledge_dirs.list_docs()) == ["features/portal-editor.md", "index.md"]
+
+
+def test_grep_and_read(knowledge_dirs):
+    hits = knowledge_dirs.grep_docs("key terms")
+    assert hits and hits[0]["path"] == "features/portal-editor.md"
+    body = knowledge_dirs.read_doc("features/portal-editor.md")
+    assert "Portal editor" in body
+    # Path traversal is refused.
+    with pytest.raises(ValueError):
+        knowledge_dirs.read_doc("../../etc/passwd")
+
+
+def test_skill_catalog_requires_full_frontmatter(knowledge_dirs):
+    catalog = knowledge_dirs.skill_catalog()
+    names = [s["name"] for s in catalog]
+    assert names == ["onboarding"]  # the frontmatter-less file is excluded
+    assert "Guide setup." in knowledge_dirs.prompt_section()
+
+
+def test_missing_corpus_degrades_gracefully(tmp_path, monkeypatch):
+    monkeypatch.setenv("KNOWLEDGE_DOCS_DIR", str(tmp_path / "nope"))
+    monkeypatch.setenv("KNOWLEDGE_SKILLS_DIR", str(tmp_path / "nope"))
+    import knowledge
+
+    k = importlib.reload(knowledge)
+    assert k.list_docs() == []
+    assert k.skill_catalog() == []
+    assert k.prompt_section() == ""


### PR DESCRIPTION
Fixes the echo-next agent CrashLoopBackOff introduced by the VFS deploy (#752).

**1. copilotkit ImportError (LangGraphAgent).** The Dockerfile ran `uv sync` without the lockfile at that build step, so it resolved a newer copilotkit (>0.1.78) that dropped `LangGraphAgent`; my `--no-sync` CMD then served that broken build venv (the old image accidentally worked because runtime `uv run` re-synced against the copied lock). Now copies `uv.lock` and uses `uv sync --frozen` → image matches the tested lock (copilotkit 0.1.78).

**2. knowledge docs_root IndexError.** `here.parents[1]` is out of range at `/app/knowledge.py` in the container. Guarded; the container path `/app/knowledge/docs` is checked first regardless.

Adds hermetic knowledge tests (the earlier suite relied on the checkout layout, which is why the container path bug slipped through). **Validated by building the image locally and importing main + reading the 82 baked doc pages + the project-onboarding skill.** Agent tests 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)