### PR TITLE
revert: copilotkit 0.1.94 AG-UI upgrade (#754) — incompatible protocol

### DIFF
--- a/echo/agent/main.py
+++ b/echo/agent/main.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
-from copilotkit import CopilotKitRemoteEndpoint, LangGraphAGUIAgent
+from copilotkit import CopilotKitRemoteEndpoint, LangGraphAgent
 from copilotkit.integrations.fastapi import handler as copilotkit_handler
 
 from agent import create_agent_graph
@@ -57,12 +57,13 @@ async def copilotkit_endpoint(request: Request, project_id: str, path: Optional[
     request.scope.setdefault("path_params", {})
     request.scope["path_params"]["path"] = path or ""
 
-    agent = LangGraphAGUIAgent(
+    agent = LangGraphAgent(
         name="default",
         description="Echo Agentic Chat default agent",
         graph=create_agent_graph(project_id=project_id, bearer_token=bearer_token),
     )
-    # Pass agents as a callable (CopilotKit rejects a literal list here).
+    # CopilotKit currently rejects LangGraphAgent only for literal list inputs.
+    # Supplying a callable preserves expected runtime behavior in this SDK version.
     endpoint = CopilotKitRemoteEndpoint(agents=lambda _context: [agent])
     return await copilotkit_handler(request, endpoint)
 

--- a/echo/agent/pyproject.toml
+++ b/echo/agent/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Isolated CopilotKit runtime for Echo Agentic Chat"
 requires-python = ">=3.11"
 dependencies = [
-    "copilotkit>=0.1.94,<0.2",
+    "copilotkit>=0.1.77",
     "langgraph>=0.2",
     "langchain-google-vertexai>=3.2.2",
     "google-auth>=2.35",

--- a/echo/agent/tests/test_main_routes.py
+++ b/echo/agent/tests/test_main_routes.py
@@ -25,7 +25,7 @@ async def _fake_handler(request, _endpoint):
 
 def test_copilotkit_root_post_rewrites_to_default_path(monkeypatch):
     monkeypatch.setattr(main, "copilotkit_handler", _fake_handler)
-    monkeypatch.setattr(main, "LangGraphAGUIAgent", _DummyLangGraphAgent)
+    monkeypatch.setattr(main, "LangGraphAgent", _DummyLangGraphAgent)
     monkeypatch.setattr(main, "CopilotKitRemoteEndpoint", _DummyEndpoint)
 
     client = TestClient(main.app)
@@ -42,7 +42,7 @@ def test_copilotkit_root_post_rewrites_to_default_path(monkeypatch):
 
 def test_copilotkit_nested_path_is_preserved(monkeypatch):
     monkeypatch.setattr(main, "copilotkit_handler", _fake_handler)
-    monkeypatch.setattr(main, "LangGraphAGUIAgent", _DummyLangGraphAgent)
+    monkeypatch.setattr(main, "LangGraphAgent", _DummyLangGraphAgent)
     monkeypatch.setattr(main, "CopilotKitRemoteEndpoint", _DummyEndpoint)
 
     client = TestClient(main.app)

--- a/echo/agent/uv.lock
+++ b/echo/agent/uv.lock
@@ -9,29 +9,19 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "ag-ui-a2ui-toolkit"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ce/85f3960a83d962e5690bc0f27a3baf3bf1602edc2b0603085928c964ea14/ag_ui_a2ui_toolkit-0.0.4.tar.gz", hash = "sha256:172e2724e53df8173685a3fb896a6e5175eea06e1dc166c715db110ba4beba76", size = 18960, upload-time = "2026-06-17T13:34:28.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/7a/acf85b01cd996bd011b71e181fd9f3daff5396fc3b7d78ba9445bfc08ecf/ag_ui_a2ui_toolkit-0.0.4-py3-none-any.whl", hash = "sha256:236fc511e1ec2399bcda0c14a109b3fb0a0c3e3988c18ef1918745b1c1535e30", size = 21315, upload-time = "2026-06-17T13:34:29.505Z" },
-]
-
-[[package]]
 name = "ag-ui-langgraph"
-version = "0.0.42"
+version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ag-ui-a2ui-toolkit" },
     { name = "ag-ui-protocol" },
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/d5/648338b5ff8f90c488217297a8656b6c133a251a39af2d62bada142b7819/ag_ui_langgraph-0.0.42.tar.gz", hash = "sha256:5384647b9b7b098189530c59b26741581dd009c8dfda907fbfaa9bafa8d21249", size = 330419, upload-time = "2026-06-19T15:07:01.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/c6/48bf48fb20eb128ca87058ba7cc22785c272ca5d162236f534a8fdb4b8cb/ag_ui_langgraph-0.0.25.tar.gz", hash = "sha256:ee100631fe57026d331f695c939826d470f3f9564e0956ff46be391f87d9498c", size = 13198, upload-time = "2026-02-10T16:07:11.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c0/32fea8de7ac50a90ea150f999318f4d121cd22d58e446c8fdb420fc2a11e/ag_ui_langgraph-0.0.42-py3-none-any.whl", hash = "sha256:4fd19f0da6d0e16d727ec89e99b692916cbba2b0302f96aba2497043cbfec5db", size = 37969, upload-time = "2026-06-19T15:07:00.517Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d5/041803505ec2258790b82d45090a3e38aa5f32a60026f97718822c9bc86e/ag_ui_langgraph-0.0.25-py3-none-any.whl", hash = "sha256:a48cde3723578c32a6610e5f5e2bcf1f31ddb711ec1dd1b2c6486a7a64abe1cd", size = 14943, upload-time = "2026-02-10T16:07:10.561Z" },
 ]
 
 [package.optional-dependencies]
@@ -41,14 +31,14 @@ fastapi = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.19"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/10/4ad299267a7d04b89935aa99eef62979758fcf95aee9f8bb5d70c35b1be1/ag_ui_protocol-0.1.19.tar.gz", hash = "sha256:43c27f60d41712dcad0e9e0a203cbdf1c8e248b22417374c5c68321c448af4ea", size = 10720, upload-time = "2026-06-02T17:26:15.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/c1/33ab11dc829c6c28d0d346988b2f394aa632d3ad63d1d2eb5f16eccd769b/ag_ui_protocol-0.1.11.tar.gz", hash = "sha256:b336dfebb5751e9cc2c676a3008a4bce4819004e6f6f8cba73169823564472ae", size = 6249, upload-time = "2026-02-11T12:41:36.085Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/0a/bcad8116eb058e4b4a305e3fc37ebd7efc879deeb86b854f1c5b8b6e97dd/ag_ui_protocol-0.1.19-py3-none-any.whl", hash = "sha256:898843b1410d378824da0c6a776486288b9c5828689d0bf563118868e37f390f", size = 13490, upload-time = "2026-06-02T17:26:16.313Z" },
+    { url = "https://files.pythonhosted.org/packages/14/83/5c6f4cb24d27d9cbe0c31ba2f3b4d1ff42bc6f87ba9facfa9e9d44046c6b/ag_ui_protocol-0.1.11-py3-none-any.whl", hash = "sha256:b0cc25570462a8eba8e57a098e0a2d6892a1f571a7bea7da2d4b60efd5d66789", size = 8392, upload-time = "2026-02-11T12:41:35.303Z" },
 ]
 
 [[package]]
@@ -302,21 +292,19 @@ wheels = [
 
 [[package]]
 name = "copilotkit"
-version = "0.1.94"
+version = "0.1.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ag-ui-langgraph", extra = ["fastapi"] },
-    { name = "ag-ui-protocol" },
     { name = "fastapi" },
     { name = "langchain" },
     { name = "langgraph" },
     { name = "partialjson" },
-    { name = "pydantic-core" },
     { name = "toml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/e3/d40a7f8698e29efaa5eeb2064a68c1d8a51f1346390021d5cc76fc08d8a2/copilotkit-0.1.94.tar.gz", hash = "sha256:a60a56aeba8127f3eb382337e5799a9bc4b31fb506bc308045c0050abc6a4488", size = 49487, upload-time = "2026-06-04T17:41:36.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/33/4ff1f1d732f89f8a08f08a20c6288af8d407438221b44748967f10df88f8/copilotkit-0.1.78.tar.gz", hash = "sha256:d27c303d61539eab3dc168ada6ec0a0ecb02f770da8aa4f1f9bbd9488235c556", size = 37578, upload-time = "2026-02-06T11:56:04.523Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/48/b22f4cbd7f8a6e2f3e80260e6aef06d845fa38f469ac4dd1bf2e14e44766/copilotkit-0.1.94-py3-none-any.whl", hash = "sha256:424e657118bebc055d5f89d1e93290773ff33c05860a3da242653ed8446affa8", size = 58434, upload-time = "2026-06-04T17:41:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5c/81bcea99f0da7d6b43f5bbdce13943da260ea94cd5d61c0d8bb1d047e50c/copilotkit-0.1.78-py3-none-any.whl", hash = "sha256:d4230094c96de708a58c9d5da82258a4bfda6ce85846b2fb154a1837ed0a92f5", size = 46919, upload-time = "2026-02-06T11:56:03.318Z" },
 ]
 
 [[package]]
@@ -430,7 +418,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "copilotkit", specifier = ">=0.1.94,<0.2" },
+    { name = "copilotkit", specifier = ">=0.1.77" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "google-auth", specifier = ">=2.35" },


### PR DESCRIPTION
Reverts #754. The AG-UI upgrade turned out to be a 4-layer protocol migration, not a dep bump, and I verified the event vocabularies are incompatible:

- copilotkit 0.1.94 `LangGraphAGUIAgent` serves via `.run()` + `EventEncoder`, emitting **AG-UI protocol** events (RUN_STARTED / TEXT_MESSAGE_CONTENT / STEP_STARTED, LangGraph events buried in `RAW` envelopes) as **SSE**.
- `agentic_client.py` parses **bare NDJSON** lines, and `agentic_worker.py` consumes **raw LangGraph event names** (`on_tool_start`, `on_tool_end`, `on_chat_model_end`), which the frontend event parser also depends on.

So the AG-UI stream doesn't match the client/worker/frontend contract — proven live on echo-next (run.failed / no assistant output). Restoring copilotkit 0.1.78 + LangGraphAgent (the format the pipeline was built for). The base64 GCP_SA_JSON fix (#755) is independent and stays.

The AG-UI migration is worth doing but as a scoped, tested project across all four layers (agent → client → worker → frontend), tracked in the backlog — not a reactive dep bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)