### PR TITLE
fix(agent): stop 'Do not send empty messages.' degenerate replies

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -115,16 +115,19 @@ The first message may include Project Name and Project Context. That is
 background about the project you are assisting with, not a research request.
 """
 
-AUTOMATIC_NUDGE_TOOL_CALL_INTERVAL = 4
+AUTOMATIC_NUDGE_TOOL_CALL_INTERVAL = 6
 AUTOMATIC_NUDGE_TEMPLATE = (
-    "<Automatic Nudge> You have made {tool_call_count} tool calls without sending an assistant update. "
-    "Call `sendProgressUpdate` now with a concise update and next steps, then continue research with another "
-    "tool call if evidence is still missing. Only return plain text with no tool call if you are concluding."
+    "<Automatic Nudge> This is a system reminder, not a message from the host. "
+    "You have made {tool_call_count} tool calls without telling the host anything. "
+    "Choose exactly one: (a) if you have enough evidence, write your final answer "
+    "to the host now, or (b) call `sendProgressUpdate` with one short sentence on "
+    "what you found so far, then continue. Never reply to this reminder itself."
 )
 POST_NUDGE_CONTINUATION_SYSTEM_PROMPT = (
-    "You just produced a text-only response immediately after an automatic nudge. "
-    "If the task is not complete, call `sendProgressUpdate` and then continue with the next tool call. "
-    "Only respond without tool calls when you are actually done."
+    "Your last message may have been a reaction to the system reminder rather "
+    "than an answer for the host. If the task is complete, write your final "
+    "answer to the host now. If not, call `sendProgressUpdate` and continue "
+    "with the next tool call."
 )
 
 
@@ -709,15 +712,30 @@ def create_agent_graph(
             return "tools"
         return END
 
+    def _with_placeholder_content(message: Any) -> Any:
+        """Gemini reacts badly to its own empty tool-call turns in history
+        (observed: it answers "Do not send empty messages."). Give those
+        turns a short placeholder; tool_calls are preserved untouched."""
+        if (
+            getattr(message, "type", None) == "ai"
+            and _message_has_tool_calls(message)
+            and not _coerce_message_text(getattr(message, "content", None))
+        ):
+            return message.model_copy(update={"content": "(calling tools)"})
+        return message
+
     async def call_model(state: dict) -> dict:
-        messages = state.get("messages", [])
+        raw_messages = state.get("messages", [])
+        messages = [_with_placeholder_content(message) for message in raw_messages]
         # Build invocation list with system prompt, but don't persist duplicates
         if not messages or not isinstance(messages[0], SystemMessage):
             invocation_messages = [SystemMessage(content=system_prompt)] + messages
         else:
             invocation_messages = list(messages)
 
-        automatic_nudge = _build_automatic_nudge(messages)
+        # Count on the raw history: the placeholder text must not read as
+        # an assistant update.
+        automatic_nudge = _build_automatic_nudge(raw_messages)
         nudge_milestone: int | None = None
         if automatic_nudge:
             nudge_content, nudge_milestone = automatic_nudge

--- a/echo/agent/tests/test_agent_graph.py
+++ b/echo/agent/tests/test_agent_graph.py
@@ -188,8 +188,10 @@ async def test_create_agent_graph_nudge_flow_can_continue_via_progress_tool_call
             _tool_call_response(2),
             _tool_call_response(3),
             _tool_call_response(4),
+            _tool_call_response(5),
+            _tool_call_response(6),
             _tool_call_response(
-                5,
+                7,
                 tool_name="sendProgressUpdate",
                 args={
                     "update": "I have a rough picture now.",
@@ -212,7 +214,7 @@ async def test_create_agent_graph_nudge_flow_can_continue_via_progress_tool_call
 
     nudges = _extract_automatic_nudges(llm.invocations)
     assert len(nudges) == 1
-    assert "4 tool calls" in nudges[0]
+    assert "6 tool calls" in nudges[0]
     assert result["messages"][-1].content == "done"
     assert not any(
         isinstance(getattr(message, "content", None), str)
@@ -229,6 +231,8 @@ async def test_create_agent_graph_retries_once_after_nudge_when_model_returns_te
             _tool_call_response(2),
             _tool_call_response(3),
             _tool_call_response(4),
+            _tool_call_response(5),
+            _tool_call_response(6),
             AIMessage(content="Progress update but no tool call."),
             AIMessage(content="Still text-only after retry."),
         ]
@@ -246,5 +250,30 @@ async def test_create_agent_graph_retries_once_after_nudge_when_model_returns_te
 
     nudges = _extract_automatic_nudges(llm.invocations)
     assert len(nudges) >= 1
-    assert all("4 tool calls" in nudge for nudge in nudges)
+    assert all("6 tool calls" in nudge for nudge in nudges)
     assert _count_corrective_retry_invocations(llm.invocations) == 1
+
+
+@pytest.mark.asyncio
+async def test_model_never_sees_its_own_empty_tool_call_turns():
+    """Regression: Gemini reacted to empty AI tool-call turns in history with
+    "Do not send empty messages." — the model input must carry placeholder
+    text on those turns (tool_calls preserved)."""
+    llm = SequenceLLM(
+        responses=[
+            _tool_call_response(1),
+            AIMessage(content="done"),
+        ]
+    )
+    graph = create_agent_graph(project_id="project-1", bearer_token="token-1", llm=llm)
+    await graph.ainvoke(
+        {"messages": [HumanMessage(content="hello")]},
+        config={"configurable": {"thread_id": "thread-placeholder"}},
+    )
+
+    final_invocation = llm.invocations[-1]
+    ai_turns = [m for m in final_invocation if getattr(m, "type", None) == "ai"]
+    assert ai_turns, "expected the prior tool-call turn in the model input"
+    for turn in ai_turns:
+        assert turn.content, "AI tool-call turn reached the model with empty content"
+        assert turn.tool_calls, "tool_calls must be preserved on the placeholder turn"


### PR DESCRIPTION
Live bug from today's host testing (screenshot in session): 4 tool calls, then the agent's only reply was **'Do not send empty messages.'**

Root-caused from the persisted `on_chat_model_start` payload of the failing run: Gemini sees its own empty tool-call AI turns, and the automatic nudge firing at exactly 4 tool calls tips it into that degenerate admonition, which gets persisted as the answer.

Fixes: placeholder content on empty tool-call turns in the model input (tool_calls untouched, raw history unchanged), a rewritten unambiguous nudge (final answer OR one-line progress; never reply to the reminder), interval 4→6. Regression test included. 44/44 agent tests; image built + validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)