### PR TITLE
feat(agentic): impersonal empty state, editable title, redesigned composer

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -993,6 +993,9 @@ export const AgenticChatPanel = ({
 			}
 		} catch (submitError) {
 			setPendingUserMessage(null);
+			// Don't strand the host's message when the send fails: restore it to
+			// the composer so it isn't lost (unless they've already typed a new one).
+			setInput((current) => (current.length === 0 ? message : current));
 			// Backend safety net: free-tier turn cap returns 402.
 			if (isFreeTierLimitError(submitError) === "chat_turns") {
 				upgradeHandlers.open();

--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -14,6 +14,7 @@ import {
 	Stack,
 	Text,
 	Textarea,
+	TextInput,
 	Title,
 	Tooltip,
 } from "@mantine/core";
@@ -25,6 +26,7 @@ import {
 	IconChevronRight,
 	IconPlayerStop,
 	IconSend,
+	IconSparkles,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
@@ -36,6 +38,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useUpdateChatMutation } from "@/components/chat/hooks";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { useElementOnScreen } from "@/hooks/useElementOnScreen";
 import { useLanguage } from "@/hooks/useLanguage";
@@ -1022,6 +1025,19 @@ export const AgenticChatPanel = ({
 
 	const isRunInFlight = isInFlightStatus(runStatus);
 	const chatTitle = chatQuery.data?.name ?? t`Chat`;
+	const updateChatMutation = useUpdateChatMutation();
+	const [isEditingTitle, setIsEditingTitle] = useState(false);
+	const [titleDraft, setTitleDraft] = useState("");
+	const commitTitle = () => {
+		const next = titleDraft.trim();
+		setIsEditingTitle(false);
+		if (!chatId || !projectId || !next || next === chatTitle) return;
+		updateChatMutation.mutate({
+			chatId,
+			payload: { name: next },
+			projectId,
+		});
+	};
 	const liveToolActivity = useMemo(
 		() =>
 			[...timeline]
@@ -1053,14 +1069,46 @@ export const AgenticChatPanel = ({
 		>
 			<Stack className="top-0 w-full pt-6">
 				<Group justify="space-between">
-					<Group gap="sm">
-						<Title order={1} {...testId("chat-title")}>
-							{chatTitle}
-						</Title>
+					<Group gap="xs" className="min-w-0 flex-1">
+						{isEditingTitle ? (
+							<TextInput
+								autoFocus
+								variant="unstyled"
+								size="xl"
+								className="min-w-0 flex-1"
+								value={titleDraft}
+								onChange={(event) => setTitleDraft(event.currentTarget.value)}
+								onBlur={commitTitle}
+								onKeyDown={(event) => {
+									if (event.key === "Enter") {
+										event.preventDefault();
+										commitTitle();
+									} else if (event.key === "Escape") {
+										setIsEditingTitle(false);
+									}
+								}}
+								{...testId("chat-title-input")}
+							/>
+						) : (
+							<Tooltip label={t`Rename chat`} openDelay={400}>
+								<Title
+									order={1}
+									className="cursor-text truncate"
+									onClick={() => {
+										setTitleDraft(chatTitle);
+										setIsEditingTitle(true);
+									}}
+									{...testId("chat-title")}
+								>
+									{chatTitle}
+								</Title>
+							</Tooltip>
+						)}
 						<ChatModeIndicator mode="agentic" size="sm" />
 					</Group>
 					<Group>
 						<CopyRichTextIconButton
+							size="md"
 							markdown={`# ${chatTitle}\n\n${computedChatForCopy}`}
 						/>
 						<ErrorBoundary>
@@ -1133,11 +1181,31 @@ export const AgenticChatPanel = ({
 						</Stack>
 					)}
 
-					{!showExistingChatLoading && timeline.length === 0 && (
-						<Text c="dimmed" size="sm">
-							<Trans>Ask about your conversations to get started.</Trans>
-						</Text>
-					)}
+					{!showExistingChatLoading &&
+						timeline.length === 0 &&
+						!pendingUserMessage && (
+							<Stack
+								align="center"
+								gap="xs"
+								className="min-h-[40vh] max-w-md self-center px-4 pt-[12vh] text-center"
+								{...testId("agentic-empty-state")}
+							>
+								<IconSparkles
+									size={28}
+									className="text-[var(--mantine-color-primary-6)]"
+								/>
+								<Title order={3} fw={500}>
+									<Trans>Where would you like to start?</Trans>
+								</Title>
+								<Text size="sm" c="dimmed">
+									<Trans>
+										Ask a question about the conversations in this project, or
+										get help setting it up. Any change is proposed for review
+										first, and nothing is saved until it's approved.
+									</Trans>
+								</Text>
+							</Stack>
+						)}
 
 					{timelineNodes.map((node) => {
 						if (node.kind === "message") {
@@ -1255,11 +1323,11 @@ export const AgenticChatPanel = ({
 							void handleSubmit();
 						}}
 					>
-						<Group align="end" wrap="nowrap">
+						<Box className="rounded-lg border border-slate-300 bg-white px-3 pb-2 pt-2 transition-colors focus-within:border-[var(--mantine-color-primary-5)]">
 							<Textarea
-								className="flex-1"
+								variant="unstyled"
 								autosize
-								minRows={4}
+								minRows={2}
 								maxRows={10}
 								value={input}
 								onChange={(event) => setInput(event.currentTarget.value)}
@@ -1273,22 +1341,29 @@ export const AgenticChatPanel = ({
 								}}
 								{...testId("chat-input-textarea")}
 							/>
-							<Button
-								type="submit"
-								leftSection={
-									isSubmitting ? <Loader size={14} /> : <IconSend size={14} />
-								}
-								disabled={
-									isSubmitting ||
-									isRunInFlight ||
-									input.trim().length === 0 ||
-									atTurnLimit
-								}
-								{...testId("chat-send-button")}
-							>
-								<Trans>Send</Trans>
-							</Button>
-						</Group>
+							<Group justify="space-between" align="center" gap="xs">
+								<Text size="xs" c="dimmed" className="select-none">
+									<Trans>Enter to send, Shift+Enter for a new line</Trans>
+								</Text>
+								<Button
+									type="submit"
+									size="sm"
+									radius="md"
+									leftSection={
+										isSubmitting ? <Loader size={14} /> : <IconSend size={14} />
+									}
+									disabled={
+										isSubmitting ||
+										isRunInFlight ||
+										input.trim().length === 0 ||
+										atTurnLimit
+									}
+									{...testId("chat-send-button")}
+								>
+									<Trans>Send</Trans>
+								</Button>
+							</Group>
+						</Box>
 					</form>
 				</Stack>
 			</Box>

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -1662,12 +1662,12 @@ msgstr "Advanced (Tips and best practices)"
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -2141,6 +2141,10 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr "Ask a team admin to request this upgrade."
@@ -2150,10 +2154,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr "Ask a workspace admin for an invite, or pick a different workspace from your list."
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4251,7 +4255,7 @@ msgstr "Doe"
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr "Done"
 
@@ -4700,6 +4704,10 @@ msgstr "Enter the 6-digit code from your authenticator app."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Enter the current six-digit code from your authenticator app."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/routes/participant/ParticipantLogin.tsx:196
 #~ msgid "Enter your access code"
 #~ msgstr "Enter your access code"
@@ -4722,9 +4730,9 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Error"
 
@@ -5166,11 +5174,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5783,8 +5791,8 @@ msgstr "Hide data"
 msgid "Hide detail"
 msgstr "Hide detail"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5801,7 +5809,7 @@ msgstr "Hide projects"
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -6023,7 +6031,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr "Innovator or higher"
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6693,7 +6701,7 @@ msgstr "Live audio level:"
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6759,7 +6767,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8450,7 +8458,7 @@ msgstr "outcomes"
 msgid "Outcomes"
 msgstr "Outcomes"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9922,6 +9930,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -10366,7 +10375,7 @@ msgstr "Rows per page"
 #~ msgid "Run status:"
 #~ msgstr "Run status:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10841,7 +10850,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Send"
 
@@ -11115,8 +11124,8 @@ msgstr "Show data"
 msgid "Show detail"
 msgstr "Show detail"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -11160,7 +11169,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11459,7 +11468,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr "Still stuck? Email <0>support@dembrane.com</0>."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stop"
 
@@ -11744,7 +11753,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template applied"
 
@@ -12538,7 +12547,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcribing..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12554,7 +12563,7 @@ msgstr "Transcript"
 msgid "Transcript copied to clipboard"
 msgstr "Transcript copied to clipboard"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12794,7 +12803,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Undo"
 
@@ -13802,6 +13811,10 @@ msgstr "When the summary is ready (includes both transcript and summary)"
 msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr "Which organisation does this workspace belong to?"
@@ -13861,11 +13874,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -1473,12 +1473,12 @@ msgstr "Erweitert (Tipps und best practices)"
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -1933,6 +1933,10 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr ""
@@ -1942,10 +1946,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2647,7 +2651,7 @@ msgstr "Das Ändern der Sprache während eines aktiven Chats kann unerwartete Er
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4034,7 +4038,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr ""
 
@@ -4470,6 +4474,10 @@ msgstr "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Geben Sie den aktuellen 6-stelligen Code aus Ihrer Authentifizierungs-App ein."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/components/settings/TwoFactorSettingsCard.tsx:177
 msgid "Enter your password"
 msgstr "Geben Sie Ihr Passwort ein"
@@ -4488,9 +4496,9 @@ msgstr "Von dem Teilnehmer auf dem Portal eingetragen"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Fehler"
 
@@ -4917,11 +4925,11 @@ msgstr "Ergebnis konnte nicht überarbeitet werden. Bitte versuchen Sie es erneu
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fehler beim Beenden der Aufnahme bei Änderung des Mikrofons. Bitte versuchen Sie es erneut."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5521,8 +5529,8 @@ msgstr "Daten verbergen"
 msgid "Hide detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5539,7 +5547,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Revisionsdaten verbergen"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -5747,7 +5755,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6419,7 +6427,7 @@ msgstr "Live Audiopegel:"
 msgid "Live Preview"
 msgstr "Live Vorschau"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6485,7 +6493,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8158,7 +8166,7 @@ msgstr "Ergebnisse"
 msgid "Outcomes"
 msgstr "Ergebnisse"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9692,6 +9700,7 @@ msgstr "Umbenennen"
 #~ msgstr "Umbenennen"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Chat umbenennen"
 
@@ -10128,7 +10137,7 @@ msgstr "Zeilen pro Seite"
 #~ msgid "Run status:"
 #~ msgstr "Ausführungsstatus:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10600,7 +10609,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Senden"
 
@@ -10871,8 +10880,8 @@ msgstr "Daten anzeigen"
 msgid "Show detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -10915,7 +10924,7 @@ msgstr "Referenzen anzeigen"
 msgid "Show revision data"
 msgstr "Revisionsdaten anzeigen"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11205,7 +11214,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stopp"
 
@@ -11487,7 +11496,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template übernommen"
 
@@ -12250,7 +12259,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcribieren..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12266,7 +12275,7 @@ msgstr "Transkript"
 msgid "Transcript copied to clipboard"
 msgstr "Transkript in die Zwischenablage kopiert"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12497,7 +12506,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -13483,6 +13492,10 @@ msgstr "Wenn die Zusammenfassung bereit ist (beinhaltet Transkript und Zusammenf
 msgid "Where would you like to go?"
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr ""
@@ -13542,11 +13555,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -1662,12 +1662,12 @@ msgstr "Advanced (Tips and best practices)"
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr "Agent is working..."
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr "Agent run failed"
 
@@ -2141,6 +2141,10 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr "Ask a team admin to request this upgrade."
@@ -2150,10 +2154,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr "Ask a workspace admin for an invite, or pick a different workspace from your list."
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr "Ask about your conversations to get started."
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr "Ask about your conversations to get started."
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr "Ask about your conversations..."
 
@@ -2865,7 +2869,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4251,7 +4255,7 @@ msgstr "Doe"
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr "Done"
 
@@ -4700,6 +4704,10 @@ msgstr "Enter the 6-digit code from your authenticator app."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Enter the current six-digit code from your authenticator app."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr "Enter to send, Shift+Enter for a new line"
+
 #: src/routes/participant/ParticipantLogin.tsx:196
 #~ msgid "Enter your access code"
 #~ msgstr "Enter your access code"
@@ -4722,9 +4730,9 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Error"
 
@@ -5166,11 +5174,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr "Failed to stop run"
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr "Failed to submit agentic message"
 
@@ -5783,8 +5791,8 @@ msgstr "Hide data"
 msgid "Hide detail"
 msgstr "Hide detail"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr "Hide details"
 
@@ -5801,7 +5809,7 @@ msgstr "Hide projects"
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr "Hide steps"
 
@@ -6023,7 +6031,7 @@ msgstr "Initial"
 msgid "Innovator or higher"
 msgstr "Innovator or higher"
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr "Input"
 
@@ -6693,7 +6701,7 @@ msgstr "Live audio level:"
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live stream interrupted. Falling back to polling."
 
@@ -6759,7 +6767,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr "Loading this chat..."
 
@@ -8450,7 +8458,7 @@ msgstr "outcomes"
 msgid "Outcomes"
 msgstr "Outcomes"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr "Output"
 
@@ -9922,6 +9930,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -10366,7 +10375,7 @@ msgstr "Rows per page"
 #~ msgid "Run status:"
 #~ msgstr "Run status:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr "Running"
 
@@ -10841,7 +10850,7 @@ msgid "Self-serve"
 msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Send"
 
@@ -11115,8 +11124,8 @@ msgstr "Show data"
 msgid "Show detail"
 msgstr "Show detail"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr "Show details"
 
@@ -11160,7 +11169,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr "Show steps"
 
@@ -11459,7 +11468,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr "Still stuck? Email <0>support@dembrane.com</0>."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stop"
 
@@ -11744,7 +11753,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr "Teams in the EU using dembrane in scenarios classified as high risk under the EU AI Act must complete a training before using their workspace."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template applied"
 
@@ -12538,7 +12547,7 @@ msgstr "Trainings"
 msgid "Transcribing..."
 msgstr "Transcribing..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr "transcript"
 
@@ -12554,7 +12563,7 @@ msgstr "Transcript"
 msgid "Transcript copied to clipboard"
 msgstr "Transcript copied to clipboard"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr "transcript excerpt"
 
@@ -12794,7 +12803,7 @@ msgid "Under your organisation"
 msgstr "Under your organisation"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Undo"
 
@@ -13802,6 +13811,10 @@ msgstr "When the summary is ready (includes both transcript and summary)"
 msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr "Where would you like to start?"
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr "Which organisation does this workspace belong to?"
@@ -13861,11 +13874,11 @@ msgid "Within my organisation"
 msgstr "Within my organisation"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr "Worked through {0} steps"
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr "Working..."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -1473,12 +1473,12 @@ msgstr "Avanzado (Consejos y best practices)"
 msgid "Advanced Settings"
 msgstr "Configuración Avanzada"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -1936,6 +1936,10 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr ""
@@ -1945,10 +1949,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2650,7 +2654,7 @@ msgstr "Cambiar el idioma durante una conversación activa puede provocar result
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr ""
 
@@ -4473,6 +4477,10 @@ msgstr "Ingresa el código de 6 dígitos de tu aplicación de autenticación."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Ingresa el código actual de seis dígitos de tu aplicación de autenticación."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/components/settings/TwoFactorSettingsCard.tsx:177
 msgid "Enter your password"
 msgstr "Ingresa tu contraseña"
@@ -4491,9 +4499,9 @@ msgstr "Ingresado por el participante en el portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Error"
 
@@ -4920,11 +4928,11 @@ msgstr "Error al revisar el resultado. Por favor, inténtalo de nuevo."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Error al detener la grabación al cambiar el dispositivo. Por favor, inténtalo de nuevo."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5524,8 +5532,8 @@ msgstr "Ocultar datos"
 msgid "Hide detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5542,7 +5550,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Ocultar datos de revisión"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -5750,7 +5758,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6422,7 +6430,7 @@ msgstr "Nivel de audio en vivo"
 msgid "Live Preview"
 msgstr "Vista Previa en Vivo"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6488,7 +6496,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8161,7 +8169,7 @@ msgstr "resultados"
 msgid "Outcomes"
 msgstr "Resultados"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9698,6 +9706,7 @@ msgstr "Renombrar"
 #~ msgstr "Renombrar"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Renombrar chat"
 
@@ -10134,7 +10143,7 @@ msgstr "Filas por página"
 #~ msgid "Run status:"
 #~ msgstr "Estado de la ejecución:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10606,7 +10615,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Enviar"
 
@@ -10877,8 +10886,8 @@ msgstr "Mostrar datos"
 msgid "Show detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -10921,7 +10930,7 @@ msgstr "Mostrar referencias"
 msgid "Show revision data"
 msgstr "Mostrar datos de revisión"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11211,7 +11220,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Detener"
 
@@ -11493,7 +11502,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Plantilla aplicada"
 
@@ -12253,7 +12262,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcribiendo..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12269,7 +12278,7 @@ msgstr "Transcripción"
 msgid "Transcript copied to clipboard"
 msgstr "Transcripción copiada al portapapeles"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12501,7 +12510,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Deshacer"
 
@@ -13487,6 +13496,10 @@ msgstr "Cuando el resumen esté listo (incluye tanto la transcripción como el r
 msgid "Where would you like to go?"
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr ""
@@ -13546,11 +13559,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -1488,12 +1488,12 @@ msgstr "Avancé (Astuces et conseils)"
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -1951,6 +1951,10 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr ""
@@ -1960,10 +1964,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2665,7 +2669,7 @@ msgstr "Changer de langue pendant une conversation active peut provoquer des ré
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Discussion"
 
@@ -4052,7 +4056,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr ""
 
@@ -4488,6 +4492,10 @@ msgstr "Entrez le code à 6 chiffres de votre application d'authentification."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Entrez le code actuel à six chiffres de votre application d'authentification."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/components/settings/TwoFactorSettingsCard.tsx:177
 msgid "Enter your password"
 msgstr "Entrez votre mot de passe"
@@ -4506,9 +4514,9 @@ msgstr "Entré par le participant sur le portail"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Erreur"
 
@@ -4935,11 +4943,11 @@ msgstr "Échec de la révision du résultat. Veuillez réessayer."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Échec de l'arrêt de l'enregistrement lors du changement de périphérique. Veuillez réessayer."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5539,8 +5547,8 @@ msgstr "Masquer les données"
 msgid "Hide detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5557,7 +5565,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Masquer les données de révision"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -5765,7 +5773,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6437,7 +6445,7 @@ msgstr "Niveau audio en direct:"
 msgid "Live Preview"
 msgstr "Vue en direct"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6503,7 +6511,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8176,7 +8184,7 @@ msgstr "résultats"
 msgid "Outcomes"
 msgstr "Résultats"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9713,6 +9721,7 @@ msgstr "Renommer"
 #~ msgstr "Renommer"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Renommer le chat"
 
@@ -10149,7 +10158,7 @@ msgstr "Lignes par page"
 #~ msgid "Run status:"
 #~ msgstr "Statut de l'exécution:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10621,7 +10630,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Envoyer"
 
@@ -10892,8 +10901,8 @@ msgstr "Afficher les données"
 msgid "Show detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -10936,7 +10945,7 @@ msgstr "Afficher les références"
 msgid "Show revision data"
 msgstr "Afficher les données de révision"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11226,7 +11235,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Arrêter"
 
@@ -11508,7 +11517,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template appliqué"
 
@@ -12268,7 +12277,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcription en cours..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12284,7 +12293,7 @@ msgstr "Transcription"
 msgid "Transcript copied to clipboard"
 msgstr "Transcription copiée dans le presse-papiers"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12516,7 +12525,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Annuler"
 
@@ -13506,6 +13515,10 @@ msgstr "Lorsque le résumé est prêt (inclut à la fois le transcript et le ré
 msgid "Where would you like to go?"
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr ""
@@ -13565,11 +13578,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -1662,12 +1662,12 @@ msgstr "Advanced (Tips and best practices)"
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -2141,6 +2141,10 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr ""
@@ -2150,10 +2154,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4251,7 +4255,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr ""
 
@@ -4700,6 +4704,10 @@ msgstr "Enter the 6-digit code from your authenticator app."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Enter the current six-digit code from your authenticator app."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/routes/participant/ParticipantLogin.tsx:196
 #~ msgid "Enter your access code"
 #~ msgstr "Enter your access code"
@@ -4722,9 +4730,9 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Error"
 
@@ -5166,11 +5174,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5783,8 +5791,8 @@ msgstr "Hide data"
 msgid "Hide detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5801,7 +5809,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -6023,7 +6031,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6693,7 +6701,7 @@ msgstr "Live audio level:"
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6759,7 +6767,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8450,7 +8458,7 @@ msgstr "outcomes"
 msgid "Outcomes"
 msgstr "Outcomes"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9922,6 +9930,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -10366,7 +10375,7 @@ msgstr "Rows per page"
 #~ msgid "Run status:"
 #~ msgstr "Run status:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10841,7 +10850,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Send"
 
@@ -11115,8 +11124,8 @@ msgstr "Show data"
 msgid "Show detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -11160,7 +11169,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11459,7 +11468,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stop"
 
@@ -11744,7 +11753,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template applied"
 
@@ -12538,7 +12547,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcribing..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12554,7 +12563,7 @@ msgstr "Transcript"
 msgid "Transcript copied to clipboard"
 msgstr "Transcript copied to clipboard"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12794,7 +12803,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Undo"
 
@@ -13802,6 +13811,10 @@ msgstr "When the summary is ready (includes both transcript and summary)"
 msgid "Where would you like to go?"
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr ""
@@ -13861,11 +13874,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -1238,12 +1238,12 @@ msgstr "Geavanceerd (Tips en best practices)"
 msgid "Advanced Settings"
 msgstr "Geavanceerde instellingen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -1705,6 +1705,10 @@ msgstr "Vragen | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Vraag een organisatie-admin om deze upgrade aan te vragen."
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #~ msgid "Ask a question..."
 #~ msgstr "Stel een vraag..."
 
@@ -1716,10 +1720,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr "Vraag een admin van de werkruimte om een uitnodiging, of kies een andere werkruimte uit je lijst."
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2401,7 +2405,7 @@ msgstr "Wijziging van de taal tijdens een actief gesprek kan onverwachte resulta
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -3758,7 +3762,7 @@ msgstr "Doe"
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr "Klaar"
 
@@ -4173,6 +4177,10 @@ msgstr "Voer de 6-cijferige code uit je authenticator-app in."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Voer de huidige zescijferige code uit je authenticator-app in."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #~ msgid "Enter your access code"
 #~ msgstr "Voer uw toegangscode in"
 
@@ -4193,9 +4201,9 @@ msgstr "Ingevoerd door de deelnemer op het portaal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Fout"
 
@@ -4607,11 +4615,11 @@ msgstr "Fout bij het herzien van het resultaat. Probeer het opnieuw."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fout bij het stoppen van de opname bij wijziging van het apparaat. Probeer het opnieuw."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5189,8 +5197,8 @@ msgstr "Gegevens verbergen"
 msgid "Hide detail"
 msgstr "Details verbergen"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5207,7 +5215,7 @@ msgstr "Projecten verbergen"
 msgid "Hide revision data"
 msgstr "Revisiegegevens verbergen"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -5401,7 +5409,7 @@ msgstr "Begin"
 msgid "Innovator or higher"
 msgstr "Innovator of hoger"
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6044,7 +6052,7 @@ msgstr "Live audio niveau:"
 msgid "Live Preview"
 msgstr "Live Voorbeeld"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6108,7 +6116,7 @@ msgstr "Projecten laden..."
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -7694,7 +7702,7 @@ msgstr "resultaten"
 msgid "Outcomes"
 msgstr "Resultaten"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9228,6 +9236,7 @@ msgstr "Naam wijzigen"
 #~ msgstr "Naam wijzigen"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Chat hernoemen"
 
@@ -9643,7 +9652,7 @@ msgstr "Rijen per pagina"
 #~ msgid "Run status:"
 #~ msgstr "Uitvoeringsstatus:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10109,7 +10118,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Verzenden"
 
@@ -10361,8 +10370,8 @@ msgstr "Gegevens tonen"
 msgid "Show detail"
 msgstr "Toon details"
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -10404,7 +10413,7 @@ msgstr "Toon referenties"
 msgid "Show revision data"
 msgstr "Revisiegegevens tonen"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -10677,7 +10686,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr "Kom je er nog niet uit? Mail <0>support@dembrane.com</0>."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stop"
 
@@ -10929,7 +10938,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr "Teams in de EU die dembrane gebruiken in scenario's die volgens de EU AI Act als hoog risico worden aangemerkt, moeten een training volgen voordat ze hun werkruimte gebruiken."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template toegepast"
 
@@ -11688,7 +11697,7 @@ msgstr "Trainingen"
 msgid "Transcribing..."
 msgstr "Transcriptie wordt uitgevoerd..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -11704,7 +11713,7 @@ msgstr "Transcriptie"
 msgid "Transcript copied to clipboard"
 msgstr "Transcript gekopieerd naar klembord"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -11939,7 +11948,7 @@ msgid "Under your organisation"
 msgstr "Onder je organisatie"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Ongedaan maken"
 
@@ -12871,6 +12880,10 @@ msgstr "Wanneer de samenvatting klaar is (bevat zowel transcript als samenvattin
 msgid "Where would you like to go?"
 msgstr "Waar wil je naartoe?"
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr "Bij welke organisatie hoort deze werkruimte?"
@@ -12924,11 +12937,11 @@ msgid "Within my organisation"
 msgstr "Binnen mijn organisatie"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -1662,12 +1662,12 @@ msgstr "Advanced (Tips and best practices)"
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
-#: src/components/chat/AgenticChatPanel.tsx:1013
+#: src/components/chat/AgenticChatPanel.tsx:1052
 msgid "Agent is working..."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:210
-#: src/components/chat/AgenticChatPanel.tsx:235
+#: src/components/chat/AgenticChatPanel.tsx:213
+#: src/components/chat/AgenticChatPanel.tsx:238
 msgid "Agent run failed"
 msgstr ""
 
@@ -2141,6 +2141,10 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1201
+msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
+msgstr ""
+
 #: src/components/workspace/FeatureGate.tsx:257
 #~ msgid "Ask a team admin to request this upgrade."
 #~ msgstr ""
@@ -2150,10 +2154,10 @@ msgid "Ask a workspace admin for an invite, or pick a different workspace from y
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:1115
-msgid "Ask about your conversations to get started."
-msgstr ""
+#~ msgid "Ask about your conversations to get started."
+#~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1222
+#: src/components/chat/AgenticChatPanel.tsx:1334
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1001
+#: src/components/chat/AgenticChatPanel.tsx:1027
 msgid "Chat"
 msgstr "Chat"
 
@@ -4251,7 +4255,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:525
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/AgenticChatPanel.tsx:254
+#: src/components/chat/AgenticChatPanel.tsx:257
 msgid "Done"
 msgstr ""
 
@@ -4700,6 +4704,10 @@ msgstr "Enter the 6-digit code from your authenticator app."
 msgid "Enter the current six-digit code from your authenticator app."
 msgstr "Enter the current six-digit code from your authenticator app."
 
+#: src/components/chat/AgenticChatPanel.tsx:1346
+msgid "Enter to send, Shift+Enter for a new line"
+msgstr ""
+
 #: src/routes/participant/ParticipantLogin.tsx:196
 #~ msgid "Enter your access code"
 #~ msgstr "Enter your access code"
@@ -4722,9 +4730,9 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/chat/AgenticChatPanel.tsx:259
-#: src/components/chat/AgenticChatPanel.tsx:390
-#: src/components/chat/AgenticChatPanel.tsx:1077
+#: src/components/chat/AgenticChatPanel.tsx:262
+#: src/components/chat/AgenticChatPanel.tsx:393
+#: src/components/chat/AgenticChatPanel.tsx:1148
 msgid "Error"
 msgstr "Error"
 
@@ -5166,11 +5174,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:993
+#: src/components/chat/AgenticChatPanel.tsx:1019
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:977
+#: src/components/chat/AgenticChatPanel.tsx:1003
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5783,8 +5791,8 @@ msgstr "Hide data"
 msgid "Hide detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Hide details"
 msgstr ""
 
@@ -5801,7 +5809,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Hide steps"
 msgstr ""
 
@@ -6023,7 +6031,7 @@ msgstr ""
 msgid "Innovator or higher"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:359
+#: src/components/chat/AgenticChatPanel.tsx:362
 msgid "Input"
 msgstr ""
 
@@ -6693,7 +6701,7 @@ msgstr "Live audio level:"
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/chat/AgenticChatPanel.tsx:745
+#: src/components/chat/AgenticChatPanel.tsx:766
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -6759,7 +6767,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1088
+#: src/components/chat/AgenticChatPanel.tsx:1159
 msgid "Loading this chat..."
 msgstr ""
 
@@ -8450,7 +8458,7 @@ msgstr "outcomes"
 msgid "Outcomes"
 msgstr "Outcomes"
 
-#: src/components/chat/AgenticChatPanel.tsx:373
+#: src/components/chat/AgenticChatPanel.tsx:376
 msgid "Output"
 msgstr ""
 
@@ -9922,6 +9930,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:158
+#: src/components/chat/AgenticChatPanel.tsx:1093
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -10366,7 +10375,7 @@ msgstr "Rows per page"
 #~ msgid "Run status:"
 #~ msgstr "Run status:"
 
-#: src/components/chat/AgenticChatPanel.tsx:264
+#: src/components/chat/AgenticChatPanel.tsx:267
 msgid "Running"
 msgstr ""
 
@@ -10841,7 +10850,7 @@ msgid "Self-serve"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:1002
-#: src/components/chat/AgenticChatPanel.tsx:1245
+#: src/components/chat/AgenticChatPanel.tsx:1363
 msgid "Send"
 msgstr "Send"
 
@@ -11115,8 +11124,8 @@ msgstr "Show data"
 msgid "Show detail"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:334
-#: src/components/chat/AgenticChatPanel.tsx:340
+#: src/components/chat/AgenticChatPanel.tsx:337
+#: src/components/chat/AgenticChatPanel.tsx:343
 msgid "Show details"
 msgstr ""
 
@@ -11160,7 +11169,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:467
+#: src/components/chat/AgenticChatPanel.tsx:470
 msgid "Show steps"
 msgstr ""
 
@@ -11459,7 +11468,7 @@ msgid "Still stuck? Email <0>support@dembrane.com</0>."
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:769
-#: src/components/chat/AgenticChatPanel.tsx:1064
+#: src/components/chat/AgenticChatPanel.tsx:1135
 msgid "Stop"
 msgstr "Stop"
 
@@ -11744,7 +11753,7 @@ msgid "Teams in the EU using dembrane in scenarios classified as high risk under
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:554
-#: src/components/chat/AgenticChatPanel.tsx:904
+#: src/components/chat/AgenticChatPanel.tsx:925
 msgid "Template applied"
 msgstr "Template applied"
 
@@ -12538,7 +12547,7 @@ msgstr ""
 msgid "Transcribing..."
 msgstr "Transcribing..."
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript"
 msgstr ""
 
@@ -12554,7 +12563,7 @@ msgstr "Transcript"
 msgid "Transcript copied to clipboard"
 msgstr "Transcript copied to clipboard"
 
-#: src/components/chat/AgenticChatPanel.tsx:155
+#: src/components/chat/AgenticChatPanel.tsx:158
 msgid "transcript excerpt"
 msgstr ""
 
@@ -12794,7 +12803,7 @@ msgid "Under your organisation"
 msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:556
-#: src/components/chat/AgenticChatPanel.tsx:906
+#: src/components/chat/AgenticChatPanel.tsx:927
 msgid "Undo"
 msgstr "Undo"
 
@@ -13802,6 +13811,10 @@ msgstr "When the summary is ready (includes both transcript and summary)"
 msgid "Where would you like to go?"
 msgstr ""
 
+#: src/components/chat/AgenticChatPanel.tsx:1198
+msgid "Where would you like to start?"
+msgstr ""
+
 #: src/routes/workspaces/CreateWorkspaceRoute.tsx:460
 msgid "Which organisation does this workspace belong to?"
 msgstr ""
@@ -13861,11 +13874,11 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:431
+#: src/components/chat/AgenticChatPanel.tsx:434
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:428
+#: src/components/chat/AgenticChatPanel.tsx:431
 msgid "Working..."
 msgstr ""
 


### PR DESCRIPTION
Composer/empty-state polish slice for the agentic chat (hosts are non-technical; the panel should read professional, not hobby).

## Changes
- **Impersonal centered empty state** — replaces the left-aligned "Ask about your conversations to get started." with a centered hero: "Where would you like to start?" plus a line naming the propose-and-review contract (nothing saves until approved). Hidden once a message or optimistic echo exists.
- **Click-to-edit title** — clicking the title turns it into an inline input; Enter/blur saves via the existing `useUpdateChatMutation`, Escape cancels. No longer rename-only via the three-dots menu.
- **Redesigned composer** — the send button was stranded in the corner beside a 4-row textarea. Now a bordered box (focus ring) with an action bar: Enter/Shift+Enter hint on the left, Send on the right. Resting height dropped to two rows.
- **Bigger copy button** — header copy `size` xs → md.

## Verification
- `tsc --noEmit` clean
- `biome check` clean
- `lingui extract` (catalogs updated)
- `vite build` passes

Deferred (needs your call, per chat): a real **Duplicate** menu item — no backend duplicate endpoint exists, so it belongs with the fork/ledger work rather than shipping a shallow copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH