### PR TITLE
feat(agentic): read previous chats (listProjectChats + readChat)

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -64,6 +64,7 @@ Use tools when the question needs project data or product knowledge:
 - "How does the portal work?" -> grepDocs and readDoc; cite the doc path.
 - "Help me set up my project" -> readSkill(project-onboarding.md), then
   getProjectSettings, then proposeProjectUpdate.
+- "What did we discuss before / continue that chat" -> listProjectChats, then readChat.
 Do not use tools for greetings, small talk, or questions about this chat.
 When intent is unclear, ask one focused question instead of guessing.
 
@@ -684,6 +685,31 @@ def create_agent_graph(
             "visible_to_user": True,
         }
 
+    @tool
+    async def listProjectChats(limit: int = 20, workspace_wide: bool = False) -> dict[str, Any]:
+        """List previous chats in this project so you can build on earlier work. Set workspace_wide=true only when the host explicitly asks about other projects in their workspace. Returns each chat's id, title, and when it was last active. Use readChat to read one."""
+        normalized_limit = max(1, min(limit, 100))
+        client = _create_echo_client()
+        try:
+            chats = await client.list_project_chats(
+                project_id,
+                limit=normalized_limit,
+                workspace_wide=workspace_wide,
+            )
+        finally:
+            await client.close()
+        return {"chats": chats}
+
+    @tool
+    async def readChat(chat_id: str) -> dict[str, Any]:
+        """Read the messages of a previous chat by its id (from listProjectChats). Returns the messages in order."""
+        client = _create_echo_client()
+        try:
+            messages = await client.read_chat(chat_id)
+        finally:
+            await client.close()
+        return {"messages": messages}
+
     tools = [
         get_project_scope,
         findConvosByKeywords,
@@ -698,6 +724,8 @@ def create_agent_graph(
         getProjectSettings,
         proposeProjectUpdate,
         sendProgressUpdate,
+        listProjectChats,
+        readChat,
     ]
     system_prompt = SYSTEM_PROMPT + knowledge.prompt_section()
     configured_llm = llm or _build_llm()

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -114,3 +114,26 @@ class EchoClient:
         if not isinstance(payload, dict):
             raise ValueError("Unexpected list project conversations response shape")
         return cast(AgentProjectConversationsResponse, payload)
+
+    async def list_project_chats(
+        self,
+        project_id: str,
+        limit: int = 30,
+        workspace_wide: bool = False,
+    ) -> list[dict[str, Any]]:
+        response = await self._client.get(
+            f"/agentic/projects/{project_id}/chats",
+            params={"limit": limit, "workspace_wide": workspace_wide},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, list) else []
+
+    async def read_chat(self, chat_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        response = await self._client.get(
+            f"/agentic/chats/{chat_id}/messages",
+            params={"limit": limit},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, list) else []

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -27,6 +27,8 @@ class _FakeEchoClient:
         project_conversations_payload: dict | None,
         project_conversations_payload_by_id: dict[str, dict] | None,
         project_conversations_payload_by_transcript_query: dict[str, dict] | None,
+        project_chats_payload: list[dict] | None = None,
+        chat_messages_payload: list[dict] | None = None,
     ):
         self.bearer_token = bearer_token
         self.search_payload = search_payload or {}
@@ -37,9 +39,13 @@ class _FakeEchoClient:
         self.project_conversations_payload_by_transcript_query = (
             project_conversations_payload_by_transcript_query or {}
         )
+        self.project_chats_payload = project_chats_payload or []
+        self.chat_messages_payload = chat_messages_payload or []
         self.search_calls: list[dict[str, object]] = []
         self.transcript_calls: list[str] = []
         self.project_conversations_calls: list[dict[str, object]] = []
+        self.project_chats_calls: list[dict[str, object]] = []
+        self.read_chat_calls: list[dict[str, object]] = []
         self.closed = False
 
     async def search_home(self, query: str, limit: int = 5) -> dict:
@@ -74,6 +80,25 @@ class _FakeEchoClient:
             return self.project_conversations_payload_by_transcript_query[transcript_query]
         return self.project_conversations_payload
 
+    async def list_project_chats(
+        self,
+        project_id: str,
+        limit: int = 30,
+        workspace_wide: bool = False,
+    ) -> list[dict]:
+        self.project_chats_calls.append(
+            {
+                "project_id": project_id,
+                "limit": limit,
+                "workspace_wide": workspace_wide,
+            }
+        )
+        return self.project_chats_payload
+
+    async def read_chat(self, chat_id: str, limit: int = 100) -> list[dict]:
+        self.read_chat_calls.append({"chat_id": chat_id, "limit": limit})
+        return self.chat_messages_payload
+
     async def close(self) -> None:
         self.closed = True
 
@@ -88,6 +113,8 @@ class _FakeEchoClientFactory:
         project_conversations_payload: dict | None = None,
         project_conversations_payload_by_id: dict[str, dict] | None = None,
         project_conversations_payload_by_transcript_query: dict[str, dict] | None = None,
+        project_chats_payload: list[dict] | None = None,
+        chat_messages_payload: list[dict] | None = None,
     ):
         self.search_payload = search_payload
         self.search_payload_by_query = search_payload_by_query
@@ -97,6 +124,8 @@ class _FakeEchoClientFactory:
         self.project_conversations_payload_by_transcript_query = (
             project_conversations_payload_by_transcript_query
         )
+        self.project_chats_payload = project_chats_payload
+        self.chat_messages_payload = chat_messages_payload
         self.instances: list[_FakeEchoClient] = []
 
     def __call__(self, bearer_token: str) -> _FakeEchoClient:
@@ -108,6 +137,8 @@ class _FakeEchoClientFactory:
             project_conversations_payload=self.project_conversations_payload,
             project_conversations_payload_by_id=self.project_conversations_payload_by_id,
             project_conversations_payload_by_transcript_query=self.project_conversations_payload_by_transcript_query,
+            project_chats_payload=self.project_chats_payload,
+            chat_messages_payload=self.chat_messages_payload,
         )
         self.instances.append(client)
         return client
@@ -668,3 +699,74 @@ async def test_list_convo_summary_raises_for_out_of_scope_or_missing_conversatio
         await tools["grepConvoSnippets"].ainvoke(
             {"conversation_id": "conv-9", "query": "representation", "limit": 3}
         )
+
+
+@pytest.mark.asyncio
+async def test_list_project_chats_scopes_to_current_project():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        project_chats_payload=[
+            {
+                "id": "chat-1",
+                "name": "Budget discussion",
+                "chat_mode": "agent",
+                "is_private": False,
+                "is_own": True,
+                "date_updated": "2026-02-01T00:00:00Z",
+                "project_id": "project-1",
+            }
+        ],
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["listProjectChats"].ainvoke({"limit": 5})
+
+    assert result["chats"][0]["id"] == "chat-1"
+    assert factory.instances[0].project_chats_calls == [
+        {"project_id": "project-1", "limit": 5, "workspace_wide": False}
+    ]
+    assert factory.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_read_chat_passes_chat_id_and_returns_messages():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        chat_messages_payload=[
+            {
+                "message_from": "user",
+                "text": "what did we decide",
+                "date_created": "2026-02-01T00:00:00Z",
+            },
+            {
+                "message_from": "assistant",
+                "text": "we decided to widen the scope",
+                "date_created": "2026-02-01T00:01:00Z",
+            },
+        ],
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["readChat"].ainvoke({"chat_id": "chat-1"})
+
+    assert [m["message_from"] for m in result["messages"]] == ["user", "assistant"]
+    assert factory.instances[0].read_chat_calls == [{"chat_id": "chat-1", "limit": 100}]
+    assert factory.instances[0].closed is True

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -19,6 +19,7 @@ from dembrane.settings import get_settings
 from dembrane.chat_utils import generate_title
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.agentic_worker import process_agentic_run
+from dembrane.directus_async import async_directus
 from dembrane.agentic_runtime import (
     request_cancel,
     read_live_event,
@@ -108,6 +109,99 @@ async def _assert_project_access(project_id: str, auth: DirectusSession) -> None
 
     access = await resolve_project_access(project_id, auth)
     access.require("chat:use")
+
+
+def _exclude_others_private_chats(base_filter: dict[str, Any], auth: DirectusSession) -> dict[str, Any]:
+    """Hide chats that are private and owned by someone else.
+
+    A chat is hidden when `is_private == true` AND `user_created != caller`.
+    Implemented as an AND with an OR of the visible cases: not-private
+    (false or legacy-null) OR owned-by-caller. Admins bypass, matching the
+    admin bypass in _assert_project_access."""
+    if auth.is_admin:
+        return base_filter
+    return {
+        **base_filter,
+        "_or": [
+            {"is_private": {"_neq": True}},
+            {"is_private": {"_null": True}},
+            {"user_created": {"_eq": auth.user_id}},
+        ],
+    }
+
+
+async def _visible_workspace_project_ids(workspace_id: str, auth: DirectusSession) -> list[str]:
+    """Project ids in `workspace_id` this caller may see.
+
+    Mirrors workspace_projects.list_workspace_projects visibility so a
+    workspace-wide chat listing can't leak chats from private projects the
+    caller isn't on. Uses the same helpers that endpoint relies on
+    (_visibility_filter_for_caller + _shared_private_project_ids), resolving
+    the caller's workspace role via inheritance.user_can_access rather than a
+    WorkspaceContext dependency (which agentic routes don't build). Admins
+    see every project in the workspace, consistent with _assert_project_access.
+    Callers who aren't workspace members (only a project-level share) see just
+    the projects they were explicitly shared on."""
+
+    async def _project_ids(filter_: dict[str, Any]) -> list[str]:
+        rows = await async_directus.get_items(
+            "project",
+            {"query": {"filter": filter_, "fields": ["id"], "limit": -1}},
+        )
+        if not isinstance(rows, list):
+            return []
+        return [row["id"] for row in rows if isinstance(row, dict) and row.get("id")]
+
+    base_filter: dict[str, Any] = {
+        "workspace_id": {"_eq": workspace_id},
+        "deleted_at": {"_null": True},
+    }
+
+    if auth.is_admin:
+        return await _project_ids(base_filter)
+
+    from dembrane.app_user import get_app_user_or_raise
+    from dembrane.policies import _normalize_legacy_role
+    from dembrane.inheritance import user_can_access
+    from dembrane.api.v2.workspace_projects import (
+        _shared_private_project_ids,
+        _visibility_filter_for_caller,
+    )
+
+    app_user = await get_app_user_or_raise(auth.user_id)
+    app_user_id = app_user["id"]
+    shared_ids = await _shared_private_project_ids(app_user_id)
+
+    resolved = await user_can_access(workspace_id, app_user_id)
+    if resolved is None:
+        # Not a workspace member: only privately-shared projects are visible,
+        # never the workspace pool.
+        if not shared_ids:
+            return []
+        return await _project_ids({**base_filter, "id": {"_in": list(shared_ids)}})
+
+    role, _source = resolved
+    role = _normalize_legacy_role(role) or role
+    visibility_clause = _visibility_filter_for_caller(
+        caller_role=role,
+        shared_ids=shared_ids,
+        creator_directus_id=auth.user_id,
+    )
+    effective = base_filter if visibility_clause is None else {**base_filter, **visibility_clause}
+    return await _project_ids(effective)
+
+
+def _trim_agent_chat(row: dict[str, Any], auth: DirectusSession) -> dict[str, Any]:
+    """Shape a project_chat row for the agent, mirroring list_chats' trim."""
+    return {
+        "id": row.get("id"),
+        "name": row.get("name"),
+        "chat_mode": row.get("chat_mode"),
+        "is_private": bool(row.get("is_private")),
+        "is_own": row.get("user_created") == auth.user_id,
+        "date_updated": row.get("date_updated"),
+        "project_id": row.get("project_id"),
+    }
 
 
 def _assert_run_authorized(run: dict[str, Any], auth: DirectusSession) -> None:
@@ -804,6 +898,102 @@ async def list_project_conversations(
         transcript_query=transcript_query,
         directus_client=directus,
     )
+
+
+@AgenticRouter.get("/projects/{project_id}/chats")
+async def list_project_chats_for_agent(
+    project_id: str,
+    auth: DependencyDirectusSession,
+    limit: int = Query(default=30, ge=1, le=200),
+    workspace_wide: bool = Query(default=False),
+) -> list[dict[str, Any]]:
+    """List previous chats the caller may see, so the agent can build on them.
+
+    Default is project-scoped. workspace_wide widens to every project in the
+    workspace the caller can access (visibility-filtered). Private chats owned
+    by other people are excluded in both modes (admins see all)."""
+    await _assert_project_access(project_id, auth)
+
+    from dembrane.api.v2.bff._access import filter_exclude_deleted
+
+    if workspace_wide:
+        project = await async_directus.get_item("project", project_id)
+        workspace_id = project.get("workspace_id") if isinstance(project, dict) else None
+        if not workspace_id:
+            base_filter = filter_exclude_deleted({"project_id": {"_eq": project_id}})
+        else:
+            visible_ids = await _visible_workspace_project_ids(workspace_id, auth)
+            if not visible_ids:
+                return []
+            base_filter = filter_exclude_deleted({"project_id": {"_in": visible_ids}})
+    else:
+        base_filter = filter_exclude_deleted({"project_id": {"_eq": project_id}})
+
+    filt = _exclude_others_private_chats(base_filter, auth)
+
+    chats = await async_directus.get_items(
+        "project_chat",
+        {
+            "query": {
+                "filter": filt,
+                "fields": [
+                    "id",
+                    "name",
+                    "chat_mode",
+                    "is_private",
+                    "user_created",
+                    "date_updated",
+                    "project_id",
+                ],
+                "sort": ["-date_updated"],
+                "limit": limit,
+            }
+        },
+    )
+    chats_list = chats if isinstance(chats, list) else []
+    return [_trim_agent_chat(row, auth) for row in chats_list if isinstance(row, dict)]
+
+
+@AgenticRouter.get("/chats/{chat_id}/messages")
+async def read_chat_for_agent(
+    chat_id: str,
+    auth: DependencyDirectusSession,
+    limit: int = Query(default=100, ge=1, le=500),
+) -> list[dict[str, Any]]:
+    """Read a previous chat's messages in order. Private chats owned by
+    someone else 404 (existence-hiding), matching the access ladder."""
+    from dembrane.api.v2.bff._access import resolve_chat_access
+
+    _access, chat = await resolve_chat_access(chat_id, auth)
+
+    if (
+        not auth.is_admin
+        and bool(chat.get("is_private"))
+        and chat.get("user_created") != auth.user_id
+    ):
+        raise HTTPException(status_code=404, detail="Chat not found")
+
+    msgs = await async_directus.get_items(
+        "project_chat_message",
+        {
+            "query": {
+                "filter": {"project_chat_id": {"_eq": chat_id}},
+                "fields": ["message_from", "text", "date_created"],
+                "sort": ["date_created"],
+                "limit": limit,
+            }
+        },
+    )
+    msgs_list = msgs if isinstance(msgs, list) else []
+    return [
+        {
+            "message_from": m.get("message_from"),
+            "text": m.get("text"),
+            "date_created": m.get("date_created"),
+        }
+        for m in msgs_list
+        if isinstance(m, dict)
+    ]
 
 
 @AgenticRouter.post("/runs/{run_id}/stream")


### PR DESCRIPTION
Step 1 of the build-out. Gives the assistant two read-only tools to build on earlier chats — the "add tools to read previous chats" ask.

## Tools
- **`listProjectChats(limit, workspace_wide)`** — previous chats in this project; `workspace_wide=true` (only when the host explicitly asks) widens to other projects in the workspace.
- **`readChat(chat_id)`** — the messages of a prior chat, in order.

## Server endpoints (host-scoped)
- `GET /agentic/projects/{project_id}/chats` — `_assert_project_access` gate. Excludes chats that are `is_private` and owned by someone else (admins see all). `workspace_wide` computes the caller-visible project set with the **same visibility helpers as `workspace_projects`** (`_visibility_filter_for_caller` + `_shared_private_project_ids`), deliberately **not** `free_tier._workspace_project_ids` (no visibility filter → would leak private-project chats).
- `GET /agentic/chats/{chat_id}/messages` — `resolve_chat_access` gate + a private-chat **404 existence-hiding** check when the caller isn't the owner.

## Notes
- **Depends on #765** (`project_chat.is_private`). Code runs without the column applied (the private filter is simply a no-op until then); tests use fakes.
- Access uses the identical `chat:use` gate as the chat BFF, so the tools inherit the host's workspace/project scope automatically.
- Known edge: a staff admin with **no `app_user` row** 404s on the messages endpoint (`resolve_chat_access` doesn't admin-bypass app-user resolution). Hosts always have one; flag if you want an admin bypass there.

## Verification
- Runtime call sites independently verified against source (resolve_chat_access returns `(access, chat)`; `_visibility_filter_for_caller`/`_normalize_legacy_role`/`async_directus.get_item(s)`/`get_app_user_or_raise` signatures all match) — not just imports.
- `ruff check` clean; agent unit tests **15 passed** (2 new).

## Follow-up (not here)
- A "make private / shared" toggle in the chat menu so `is_private` becomes host-settable (currently the field exists and is enforced, but nothing sets it yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH