### PR TITLE
feat(agentic): reach out to the dembrane team (reachOutToDembrane)

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -67,6 +67,13 @@ Use tools when the question needs project data or product knowledge:
 Do not use tools for greetings, small talk, or questions about this chat.
 When intent is unclear, ask one focused question instead of guessing.
 
+## Getting help from the dembrane team
+When the host needs something you cannot give: something looks broken, a billing
+or account question, or a question about dembrane the documentation does not
+answer, offer to pass their question to the dembrane team. Tell the host what you
+will send first, send it in their own words where you can, and let them know the
+team will follow up. Do not promise a timeline.
+
 ## Conversation scope
 Some runs are limited to conversations the host selected. When the context
 contains a "Conversation scope" block:
@@ -684,6 +691,20 @@ def create_agent_graph(
             "visible_to_user": True,
         }
 
+    @tool
+    async def reachOutToDembrane(message: str, context: str = "") -> dict[str, Any]:
+        """Pass a question or problem to the dembrane team on the host's behalf. Use this when the host needs help you cannot give: something looks broken, a billing or account question, or a question about dembrane the documentation does not answer. `message` is what the host wants to ask, in their own words where you can. `context` is a short note about what they were doing. Tell the host what you are sending before you send it, and let them know the team will follow up."""
+        client = _create_echo_client()
+        try:
+            result = await client.create_support_request(
+                project_id,
+                message=message,
+                page_context=context or None,
+            )
+        finally:
+            await client.close()
+        return {"sent": True, "support_request_id": result.get("id")}
+
     tools = [
         get_project_scope,
         findConvosByKeywords,
@@ -698,6 +719,7 @@ def create_agent_graph(
         getProjectSettings,
         proposeProjectUpdate,
         sendProgressUpdate,
+        reachOutToDembrane,
     ]
     system_prompt = SYSTEM_PROMPT + knowledge.prompt_section()
     configured_llm = llm or _build_llm()

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -114,3 +114,17 @@ class EchoClient:
         if not isinstance(payload, dict):
             raise ValueError("Unexpected list project conversations response shape")
         return cast(AgentProjectConversationsResponse, payload)
+
+    async def create_support_request(
+        self,
+        project_id: str,
+        message: str,
+        page_context: Optional[str] = None,
+    ) -> dict[str, Any]:
+        response = await self._client.post(
+            f"/agentic/projects/{project_id}/support-request",
+            json={"message": message, "page_context": page_context},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -40,6 +40,7 @@ class _FakeEchoClient:
         self.search_calls: list[dict[str, object]] = []
         self.transcript_calls: list[str] = []
         self.project_conversations_calls: list[dict[str, object]] = []
+        self.support_request_calls: list[dict[str, object]] = []
         self.closed = False
 
     async def search_home(self, query: str, limit: int = 5) -> dict:
@@ -73,6 +74,21 @@ class _FakeEchoClient:
         ):
             return self.project_conversations_payload_by_transcript_query[transcript_query]
         return self.project_conversations_payload
+
+    async def create_support_request(
+        self,
+        project_id: str,
+        message: str,
+        page_context: str | None = None,
+    ) -> dict:
+        self.support_request_calls.append(
+            {
+                "project_id": project_id,
+                "message": message,
+                "page_context": page_context,
+            }
+        )
+        return {"id": "sr-1", "status": "new"}
 
     async def close(self) -> None:
         self.closed = True
@@ -668,3 +684,41 @@ async def test_list_convo_summary_raises_for_out_of_scope_or_missing_conversatio
         await tools["grepConvoSnippets"].ainvoke(
             {"conversation_id": "conv-9", "query": "representation", "limit": 3}
         )
+
+
+@pytest.mark.asyncio
+async def test_reach_out_to_dembrane_sends_support_request_for_current_project():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["reachOutToDembrane"].ainvoke(
+        {"message": "My exports are failing", "context": "on the reports page"}
+    )
+
+    assert result["sent"] is True
+    assert result["support_request_id"] == "sr-1"
+    assert factory.instances[0].support_request_calls == [
+        {
+            "project_id": "project-1",
+            "message": "My exports are failing",
+            "page_context": "on the reports page",
+        }
+    ]
+    assert factory.instances[0].closed is True
+
+
+def test_system_prompt_offers_dembrane_support_path():
+    prompt = SYSTEM_PROMPT.lower()
+    assert "getting help from the dembrane team" in prompt
+    assert "the dembrane team" in prompt

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -19,6 +19,7 @@ from dembrane.settings import get_settings
 from dembrane.chat_utils import generate_title
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.agentic_worker import process_agentic_run
+from dembrane.directus_async import async_directus
 from dembrane.agentic_runtime import (
     request_cancel,
     read_live_event,
@@ -55,6 +56,12 @@ class AgenticCreateRunSchema(BaseModel):
 class AgenticAppendMessageSchema(BaseModel):
     message: str = Field(..., min_length=1)
     language: str = Field(default="en", min_length=1)
+
+
+class AgenticSupportRequestSchema(BaseModel):
+    message: str = Field(..., min_length=1)
+    # A short note from the assistant about what the host was doing / needs.
+    page_context: Optional[str] = None
 
 
 def _run_task_key(run_id: str, turn_seq: int) -> tuple[str, int]:
@@ -803,6 +810,39 @@ async def list_project_conversations(
         conversation_id=conversation_id,
         transcript_query=transcript_query,
         directus_client=directus,
+    )
+
+
+@AgenticRouter.post("/projects/{project_id}/support-request")
+async def create_support_request(
+    project_id: str,
+    body: AgenticSupportRequestSchema,
+    auth: DependencyDirectusSession,
+) -> JSONResponse:
+    """Raise a support request to the dembrane team on the host's behalf.
+
+    Writes a support_request row (an outbox); a separate job forwards new rows
+    to the team. The assistant never contacts anyone directly."""
+    await _assert_project_access(project_id, auth)
+
+    project = await async_directus.get_item("project", project_id)
+    workspace_id = project.get("workspace_id") if isinstance(project, dict) else None
+
+    created = await async_directus.create_item(
+        "support_request",
+        {
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "directus_user_id": auth.user_id,
+            "message": body.message,
+            "page_context": body.page_context,
+            "status": "new",
+        },
+    )
+    support_request_id = created.get("id") if isinstance(created, dict) else None
+    return JSONResponse(
+        status_code=201,
+        content={"id": support_request_id, "status": "new"},
     )
 
 


### PR DESCRIPTION
Step 2 of the build-out. The assistant can pass a host's question to the dembrane team when it can't help directly — landing in a Directus `support_request` outbox that a separate job (your Sam cron) reads and forwards to Slack.

## What's added
- **`POST /agentic/projects/{project_id}/support-request`** — `_assert_project_access` gate; writes a `support_request` row: `workspace_id` (resolved from the project), `project_id`, `directus_user_id` (from auth), `message`, `page_context`, `status="new"`. Returns `{id, status}`.
- **`reachOutToDembrane(message, context)`** agent tool + `EchoClient.create_support_request`.
- **SYSTEM_PROMPT** "Getting help from the dembrane team" section: offer to reach out, say what will be sent first, send the host's own words, don't promise a timeline.

## Notes
- **Depends on #765** (`support_request` collection). Code runs without it applied; the write fails at runtime until pushed.
- **The assistant never contacts anyone directly** — it only writes an outbox row.
- **chat_id not captured yet.** Only `project_id` reaches the agent service (route `/copilotkit/{project_id}`), so linking the support row to the exact chat is a cross-service follow-up. For now the assistant folds relevant context into `message`/`context`.
- The tool name is deliberately kept **out of** the prompt text so the brand guardrail (`"Dembrane"` substring must not appear in SYSTEM_PROMPT) still holds; the model routes via the bound tool docstring.

## Verification
- Agent unit tests **15 passed** (2 new: sends for current project; prompt exposes the path).
- `ruff check` clean on the server + agent changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH