### PR TITLE
Monitor: dedicated sidebar destination for the live monitor

### DIFF
--- a/echo/frontend/src/Router.tsx
+++ b/echo/frontend/src/Router.tsx
@@ -28,6 +28,7 @@ import { ParticipantPostConversation } from "./routes/participant/ParticipantPos
 import { ParticipantStartRoute } from "./routes/participant/ParticipantStart";
 import { ProjectConversationRoute } from "./routes/project/conversation/ProjectConversationRoute";
 import { ProjectHomeRoute } from "./routes/project/ProjectHomeRoute";
+import { ProjectMonitorRoute } from "./routes/project/ProjectMonitorRoute";
 // Tab-based routes - import directly for now to debug
 import {
 	ProjectAccessRoute,
@@ -172,6 +173,10 @@ const projectRouteChildren = [
 					{
 						element: <ProjectHomeRoute />,
 						path: "home",
+					},
+					{
+						element: <ProjectMonitorRoute />,
+						path: "monitor",
 					},
 					{
 						children: [

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
@@ -136,11 +136,38 @@ const MonitorRow = ({
 	);
 };
 
-export const LiveMonitorSection = ({ projectId }: { projectId: string }) => {
+export const LiveMonitorSection = ({
+	projectId,
+	standalone = false,
+}: {
+	projectId: string;
+	/** On the dedicated Monitor page, show an empty state instead of
+	 * collapsing to nothing when there is no recent activity. */
+	standalone?: boolean;
+}) => {
 	const { conversations, summary } = useConversationMonitor(projectId);
 
-	// Nothing recent to monitor — stay out of the way.
-	if (summary.total === 0) return null;
+	// Nothing recent to monitor. On the home page we stay out of the way; on the
+	// dedicated Monitor page we explain what the host is looking at.
+	if (summary.total === 0) {
+		if (!standalone) return null;
+		return (
+			<Card withBorder p="lg" radius="sm">
+				<Stack gap="xs" align="center">
+					<BroadcastIcon size={24} />
+					<Text size="sm" fw={500}>
+						<Trans>No recent activity</Trans>
+					</Text>
+					<Text size="xs" c="dimmed" ta="center" maw={420}>
+						<Trans>
+							Live recordings, transcription progress, and errors show up here
+							as participants start recording in the portal.
+						</Trans>
+					</Text>
+				</Stack>
+			</Card>
+		);
+	}
 
 	return (
 		<Stack gap="sm">

--- a/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
@@ -84,12 +84,10 @@ export const ProjectHomeView = () => {
 				label={<Trans>Portal editor</Trans>}
 				icon={PaintBrushIcon}
 			/>
-			<NavButton
+			<NavItem
+				to={`${base}/monitor`}
 				label={<Trans>Monitor</Trans>}
 				icon={BroadcastIcon}
-				onClick={() => undefined}
-				badge={<Trans>Planned</Trans>}
-				disabled
 			/>
 			<NavItem
 				to={`${base}/host-guide`}

--- a/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
+++ b/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
@@ -1,0 +1,29 @@
+import { Trans } from "@lingui/react/macro";
+import { Stack, Text, Title } from "@mantine/core";
+import { useParams } from "react-router";
+import { LiveMonitorSection } from "@/components/conversation/LiveMonitorSection";
+import { PageContainer } from "@/components/layout/PageContainer";
+
+export const ProjectMonitorRoute = () => {
+	const { projectId } = useParams<{ projectId: string }>();
+
+	return (
+		<PageContainer width="xl">
+			<Stack gap="xl">
+				<Stack gap={4}>
+					<Title order={2} fw={500} style={{ color: "#2d2d2c" }}>
+						<Trans>Monitor</Trans>
+					</Title>
+					<Text size="sm" c="dimmed" maw={560}>
+						<Trans>
+							Watch live recordings, transcription progress, and errors across
+							this project as they happen.
+						</Trans>
+					</Text>
+				</Stack>
+
+				{projectId && <LiveMonitorSection projectId={projectId} standalone />}
+			</Stack>
+		</PageContainer>
+	);
+};


### PR DESCRIPTION
## What
The live monitor was only reachable as a section on the project overview page, and the sidebar **Monitor** entry was a disabled *Planned* stub. This wires that entry to a real destination.

- New `/w/:workspaceId/projects/:projectId/monitor` route → `ProjectMonitorRoute` (full-page monitor with a title + empty state).
- `LiveMonitorSection` gains a `standalone` prop: on the dedicated page it shows an empty state ("No recent activity…") instead of collapsing to nothing. The home-page instance is unchanged (still collapses when idle to stay out of the way).
- Sidebar **Monitor** `NavButton` stub → active `NavItem` pointing at the new route.

## Notes
- Reuses the existing `useConversationMonitor` polling + `gather_project_monitor` backend, so the dedicated page and the home snapshot can't drift.
- New UI strings are English (source fallback); translation can follow.

## Verify on echo-next
Open a project → **Monitor** in the sidebar → full monitor renders; start a portal recording and confirm it shows live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH