### PR TITLE
Monitor: add breadcrumb leaf for the monitor page

### DIFF
--- a/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
+++ b/echo/frontend/src/features/sidebar/breadcrumbs/AppBreadcrumbs.tsx
@@ -48,6 +48,7 @@ const PROJECT_SECTION_LABELS: Record<string, string> = {
 	"host-guide": "Host guide",
 	integrations: "Integrations",
 	library: "Explore",
+	monitor: "Monitor",
 	overview: "Settings",
 	portal: "Portal editor",
 	"portal-editor": "Portal editor",


### PR DESCRIPTION
Follow-up to #776. The new `/monitor` route landed without a `PROJECT_SECTION_LABELS` entry, so it was the only project tab missing its trailing breadcrumb crumb. Adds `monitor: "Monitor"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH