### PR TITLE
Monitor: show just-initiated sessions instantly + duration over chunk count

### DIFF
--- a/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
@@ -124,6 +124,30 @@ const isLowBattery = (conversation: MonitorConversation): boolean => {
 	return typeof battery.level === "number" && battery.level <= 0.15;
 };
 
+const formatClock = (totalSeconds: number): string => {
+	const s = Math.max(0, Math.floor(totalSeconds));
+	const hours = Math.floor(s / 3600);
+	const minutes = Math.floor((s % 3600) / 60);
+	const seconds = s % 60;
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return hours > 0
+		? `${hours}:${pad(minutes)}:${pad(seconds)}`
+		: `${minutes}:${pad(seconds)}`;
+};
+
+// Recorded length when we have it (set on finish), otherwise elapsed since the
+// session started. It can be a little behind for a live session; that's fine.
+const durationLabel = (conversation: MonitorConversation): string | null => {
+	if (typeof conversation.duration === "number" && conversation.duration > 0) {
+		return formatClock(conversation.duration);
+	}
+	if (conversation.created_at) {
+		const start = new Date(conversation.created_at).getTime();
+		if (!Number.isNaN(start)) return formatClock((Date.now() - start) / 1000);
+	}
+	return null;
+};
+
 const lastActivityLabel = (conversation: MonitorConversation): string => {
 	const stamp = conversation.last_seen_at ?? conversation.last_chunk_at;
 	if (!stamp) return t`No activity yet`;
@@ -222,13 +246,11 @@ const MonitorRow = ({
 					<Text size="xs" c="dimmed">
 						<Trans>Last activity {lastActivityLabel(conversation)}</Trans>
 					</Text>
-					<Text size="xs" c="dimmed">
-						<Plural
-							value={conversation.chunk_count}
-							one="# recording"
-							other="# recordings"
-						/>
-					</Text>
+					{durationLabel(conversation) && (
+						<Text size="xs" c="dimmed">
+							{durationLabel(conversation)}
+						</Text>
+					)}
 				</Group>
 
 				{conversation.has_error && conversation.error_message && (

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
@@ -20,7 +20,9 @@ import {
 } from "@phosphor-icons/react";
 import { formatDistanceToNow } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router";
 
+import { I18nLink } from "@/components/common/i18nLink";
 import {
 	type MonitorConversation,
 	type ParticipantState,
@@ -191,15 +193,26 @@ const TranscriptionBadge = ({
 
 const MonitorRow = ({
 	conversation,
+	to,
 }: {
 	conversation: MonitorConversation;
+	to: string | null;
 }) => {
 	const label = conversation.label?.trim() || t`Anonymous participant`;
 	const weakNetwork = isWeakNetwork(conversation);
 	const lowBattery = isLowBattery(conversation);
 
-	return (
-		<Card withBorder p="sm" radius="md">
+	const card = (
+		<Card
+			withBorder
+			p="sm"
+			radius="md"
+			className={
+				to
+					? "transition-colors hover:!border-primary-400 cursor-pointer"
+					: undefined
+			}
+		>
 			<Stack gap={8}>
 				<Group justify="space-between" align="center" wrap="nowrap">
 					<Group gap="xs" align="center" style={{ minWidth: 0 }}>
@@ -263,6 +276,13 @@ const MonitorRow = ({
 			</Stack>
 		</Card>
 	);
+
+	if (!to) return card;
+	return (
+		<I18nLink to={to} className="block no-underline">
+			{card}
+		</I18nLink>
+	);
 };
 
 const UNTAGGED = "__untagged__";
@@ -306,7 +326,13 @@ const groupByTag = (conversations: MonitorConversation[]): TagGroup[] => {
 		});
 };
 
-const TagGroupSection = ({ group }: { group: TagGroup }) => {
+const TagGroupSection = ({
+	group,
+	base,
+}: {
+	group: TagGroup;
+	base: string | null;
+}) => {
 	const [opened, { toggle }] = useDisclosure(true);
 	const [expanded, setExpanded] = useState(false);
 	const visible = expanded
@@ -346,7 +372,11 @@ const TagGroupSection = ({ group }: { group: TagGroup }) => {
 			<Collapse in={opened}>
 				<Stack gap="xs">
 					{visible.map((conversation) => (
-						<MonitorRow key={conversation.id} conversation={conversation} />
+						<MonitorRow
+							key={conversation.id}
+							conversation={conversation}
+							to={base ? `${base}/conversations/${conversation.id}` : null}
+						/>
 					))}
 					{overflow > 0 && (
 						<Text
@@ -373,8 +403,14 @@ export const LiveMonitorSection = ({
 	 * collapsing to nothing when there is no recent activity. */
 	standalone?: boolean;
 }) => {
+	const { workspaceId } = useParams<{ workspaceId: string }>();
 	const { conversations, summary } = useConversationMonitor(projectId);
 	const groups = useMemo(() => groupByTag(conversations), [conversations]);
+	// Rows link to the conversation detail page when we know the workspace.
+	const base =
+		workspaceId && projectId
+			? `/w/${workspaceId}/projects/${projectId}`
+			: null;
 
 	if (summary.total === 0) {
 		if (!standalone) return null;
@@ -432,7 +468,7 @@ export const LiveMonitorSection = ({
 
 			<Stack gap="lg">
 				{groups.map((group) => (
-					<TagGroupSection key={group.key} group={group} />
+					<TagGroupSection key={group.key} group={group} base={base} />
 				))}
 			</Stack>
 		</Stack>

--- a/echo/frontend/src/hooks/useConversationMonitor.ts
+++ b/echo/frontend/src/hooks/useConversationMonitor.ts
@@ -46,6 +46,8 @@ export type MonitorConversation = {
 	tags: string[];
 	language: string | null;
 	latest_transcript: string | null;
+	created_at: string | null;
+	duration: number | null;
 	network: MonitorNetwork | null;
 	battery: MonitorBattery | null;
 	last_chunk_at: string | null;

--- a/echo/server/dembrane/api/participant.py
+++ b/echo/server/dembrane/api/participant.py
@@ -13,7 +13,10 @@ from dembrane.service import project_service, conversation_service
 from dembrane.directus import directus
 from dembrane.settings import get_settings
 from dembrane.async_helpers import run_in_thread_pool
-from dembrane.monitor_stream import publish_monitor_dirty
+from dembrane.monitor_stream import (
+    publish_monitor_dirty,
+    register_active_conversation,
+)
 from dembrane.service.project import ProjectNotFoundException
 from dembrane.service.conversation import (
     ConversationServiceException,
@@ -454,6 +457,12 @@ async def ping_conversation(
         logger.warning("Liveness ping failed for %s: %s", conversation_id, exc)
         return {"ok": False}
     if body is not None and body.project_id:
+        # Index the conversation as active so the monitor can show it the
+        # instant it is initiated, before any audio chunk exists, then nudge
+        # open streams to recompute.
+        await register_active_conversation(
+            body.project_id, conversation_id, score=time()
+        )
         await publish_monitor_dirty(body.project_id)
     return {"ok": True}
 

--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -41,7 +41,10 @@ from fastapi.responses import StreamingResponse
 from dembrane.redis_async import get_redis_client
 from dembrane.tier_capacity import is_conversation_locked
 from dembrane.directus_async import async_directus
-from dembrane.monitor_stream import channel_for_project
+from dembrane.monitor_stream import (
+    channel_for_project,
+    get_active_conversation_ids,
+)
 from dembrane.search_filters import merge_search_filter
 from dembrane.api.v2.bff._access import (
     filter_exclude_deleted,
@@ -709,8 +712,13 @@ def _build_monitor_payload(
     live_window_seconds: int,
     telemetry: Optional[dict[str, dict]] = None,
     tag_map: Optional[dict[str, list[str]]] = None,
+    extra_conversations: Optional[list[dict]] = None,
 ) -> dict:
     """Aggregate recent chunks into a per-conversation monitor view.
+
+    `extra_conversations` seeds sessions that are pinging but have no audio
+    chunk yet (just-initiated / waiting), so they appear instantly. Each is a
+    dict with id, participant_name, is_finished, created_at, duration.
 
     `recent_chunks` MUST be newest-first (sorted by -timestamp). Each row
     carries conversation_id (dict with id + participant_name, or a bare id
@@ -732,16 +740,41 @@ def _build_monitor_payload(
     order: list[str] = []
     by_conv: dict[str, dict] = {}
 
+    # Seed chunk-less, currently-pinging sessions first so a just-initiated
+    # conversation shows up before its first audio chunk exists.
+    for extra in extra_conversations or []:
+        conv_id = extra.get("id")
+        if not conv_id or conv_id in by_conv:
+            continue
+        by_conv[conv_id] = {
+            "id": conv_id,
+            "label": (extra.get("participant_name") or "").strip() or None,
+            "is_finished": bool(extra.get("is_finished")),
+            "last_chunk_at": None,
+            "last_chunk_dt": None,
+            "has_error": False,
+            "error_message": None,
+            "latest_transcript": None,
+            "language": None,
+            "created_at": extra.get("created_at"),
+            "duration": extra.get("duration"),
+        }
+        order.append(conv_id)
+
     for chunk in recent_chunks:
         conv = chunk.get("conversation_id")
         if isinstance(conv, dict):
             conv_id = conv.get("id")
             participant_name = conv.get("participant_name")
             is_finished = bool(conv.get("is_finished"))
+            created_at = conv.get("created_at")
+            duration = conv.get("duration")
         else:
             conv_id = conv
             participant_name = None
             is_finished = False
+            created_at = None
+            duration = None
         if not conv_id:
             continue
 
@@ -757,6 +790,8 @@ def _build_monitor_payload(
                 "error_message": None,
                 "latest_transcript": None,
                 "language": None,
+                "created_at": created_at,
+                "duration": duration,
             }
             by_conv[conv_id] = entry
             order.append(conv_id)
@@ -839,6 +874,8 @@ def _build_monitor_payload(
                 "tags": tag_map.get(conv_id, []),
                 "language": entry["language"],
                 "latest_transcript": entry["latest_transcript"],
+                "created_at": entry["created_at"],
+                "duration": entry["duration"],
                 "network": tele.get("network"),
                 "battery": tele.get("battery"),
                 "last_chunk_at": entry["last_chunk_at"],
@@ -899,6 +936,8 @@ async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
                     "conversation_id.id",
                     "conversation_id.participant_name",
                     "conversation_id.is_finished",
+                    "conversation_id.created_at",
+                    "conversation_id.duration",
                     "timestamp",
                     "error",
                     "transcript",
@@ -921,6 +960,52 @@ async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
         if conv_id and conv_id not in seen:
             seen.add(conv_id)
             conv_ids.append(conv_id)
+
+    # Sessions that are pinging but have no chunk yet (just-initiated /
+    # waiting) live in the Redis active index, not in the chunk read. Union
+    # them in so the monitor shows a conversation the instant it starts.
+    ping_only_ids: list[str] = []
+    try:
+        active_ids = await get_active_conversation_ids(
+            project_id, min_score=(now - timedelta(seconds=MONITOR_LOOKBACK_SECONDS)).timestamp()
+        )
+        ping_only_ids = [cid for cid in active_ids if cid and cid not in seen]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Monitor active-index read failed: %s", exc)
+
+    # Fetch metadata for the chunk-less sessions so they render with a name,
+    # tags, and duration. Bounded by the active-index size.
+    extra_conversations: list[dict] = []
+    if ping_only_ids:
+        try:
+            extra_rows = await async_directus.get_items(
+                "conversation",
+                {
+                    "query": {
+                        "filter": {
+                            "id": {"_in": ping_only_ids},
+                            "deleted_at": {"_null": True},
+                        },
+                        "fields": [
+                            "id",
+                            "participant_name",
+                            "is_finished",
+                            "created_at",
+                            "duration",
+                        ],
+                        "limit": len(ping_only_ids),
+                    }
+                },
+            )
+            if isinstance(extra_rows, list):
+                extra_conversations = extra_rows
+                for row in extra_rows:
+                    cid = row.get("id")
+                    if cid and cid not in seen:
+                        seen.add(cid)
+                        conv_ids.append(cid)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Monitor ping-only metadata read failed: %s", exc)
 
     chunk_counts: dict[str, int] = {}
     transcribed_counts: dict[str, int] = {}
@@ -1015,6 +1100,7 @@ async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
         window_seconds,
         telemetry,
         tag_map,
+        extra_conversations,
     )
 
 

--- a/echo/server/dembrane/monitor_stream.py
+++ b/echo/server/dembrane/monitor_stream.py
@@ -19,10 +19,63 @@ from dembrane.redis_async import get_redis_client
 logger = logging.getLogger("monitor_stream")
 
 _CHANNEL_PREFIX = "monitor:project:"
+# Per-project sorted set of recently-active conversation ids, scored by the
+# epoch of their last ping. This is how a just-initiated conversation (which
+# is pinging but has no audio chunk yet) becomes visible in the monitor
+# instantly, instead of only appearing once its first chunk lands.
+_ACTIVE_PREFIX = "monitor:active:"
+# Keep the index a little longer than the monitor lookback so a brief gap
+# doesn't drop a session; stale members are pruned on read anyway.
+_ACTIVE_TTL_SECONDS = 2100
 
 
 def channel_for_project(project_id: str) -> str:
     return f"{_CHANNEL_PREFIX}{project_id}"
+
+
+def _active_key(project_id: str) -> str:
+    return f"{_ACTIVE_PREFIX}{project_id}"
+
+
+async def register_active_conversation(
+    project_id: str, conversation_id: str, *, score: float
+) -> None:
+    """Record that a conversation is active (pinged) in its project's index.
+
+    `score` is epoch seconds of the ping. Best-effort. Refreshes the key TTL so
+    the index self-cleans once a project goes quiet.
+    """
+    if not project_id or not conversation_id:
+        return
+    try:
+        client = await get_redis_client()
+        key = _active_key(project_id)
+        await client.zadd(key, {conversation_id: score})
+        await client.expire(key, _ACTIVE_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("monitor active-index add failed for %s: %s", project_id, exc)
+
+
+async def get_active_conversation_ids(
+    project_id: str, *, min_score: float
+) -> list[str]:
+    """Return conversation ids pinged since `min_score` (epoch seconds).
+
+    Prunes members older than the cutoff on the way, so the index stays small.
+    Best-effort: returns [] if Redis is unavailable.
+    """
+    try:
+        client = await get_redis_client()
+        key = _active_key(project_id)
+        await client.zremrangebyscore(key, "-inf", f"({min_score}")
+        members = await client.zrangebyscore(key, min_score, "+inf")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("monitor active-index read failed for %s: %s", project_id, exc)
+        return []
+    return [
+        m.decode("utf-8") if isinstance(m, (bytes, bytearray)) else str(m)
+        for m in members
+    ]
 
 
 async def publish_monitor_dirty(project_id: str) -> None:

--- a/echo/server/tests/api/test_conversation_monitor.py
+++ b/echo/server/tests/api/test_conversation_monitor.py
@@ -307,6 +307,51 @@ def test_monitor_surfaces_metadata_and_telemetry() -> None:
     assert entry["battery"] == {"level": 0.2, "charging": False}
 
 
+def test_monitor_seeds_initiated_conversation_without_chunks() -> None:
+    # A just-initiated session pings but has no chunk yet. It must still appear,
+    # seeded from extra_conversations + its telemetry state.
+    now = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
+    extras = [
+        {
+            "id": "c-new",
+            "participant_name": "Ada",
+            "is_finished": False,
+            "created_at": _iso(now - timedelta(seconds=8)),
+            "duration": None,
+        }
+    ]
+    telemetry = {"c-new": {"seen": now - timedelta(seconds=2), "state": "waiting"}}
+    payload = _build_monitor_payload([], {}, {}, now, 45, telemetry, None, extras)
+    entry = payload["conversations"][0]
+    assert entry["id"] == "c-new"
+    assert entry["label"] == "Ada"
+    assert entry["state"] == "waiting"
+    assert entry["is_live"] is True  # a fresh ping keeps it live even with no chunk
+    assert entry["chunk_count"] == 0
+    assert payload["summary"]["live"] == 1
+
+
+def test_monitor_carries_created_at_and_duration() -> None:
+    now = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
+    created = _iso(now - timedelta(minutes=3))
+    recent_chunks = [
+        {
+            "conversation_id": {
+                "id": "c1",
+                "participant_name": "Ada",
+                "created_at": created,
+                "duration": 182,
+            },
+            "timestamp": _iso(now - timedelta(seconds=5)),
+            "error": None,
+        },
+    ]
+    payload = _build_monitor_payload(recent_chunks, {"c1": 2}, {"c1": 2}, now, 45)
+    entry = payload["conversations"][0]
+    assert entry["created_at"] == created
+    assert entry["duration"] == 182
+
+
 def test_monitor_transcript_snippet_truncated() -> None:
     from dembrane.api.v2.bff.conversations import MONITOR_TRANSCRIPT_SNIPPET_MAX_LEN
 
@@ -380,6 +425,12 @@ async def _build_client(
         return {}
 
     monkeypatch.setattr(conv_bff, "get_telemetry_many", _fake_telemetry)
+
+    # Active-index read hits Redis; stub to empty so gather stays chunk-only.
+    async def _fake_active(project_id: str, *, min_score: float) -> list:  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(conv_bff, "get_active_conversation_ids", _fake_active)
 
     # The snapshot cache also uses Redis; stub a always-miss client so the
     # endpoint recomputes (and the Directus query assertions still hold).

--- a/echo/server/tests/api/test_participant_ping.py
+++ b/echo/server/tests/api/test_participant_ping.py
@@ -35,8 +35,16 @@ def test_ping_conversation_persists_and_publishes_telemetry(monkeypatch) -> None
     async def _fake_publish(project_id: str) -> None:
         published.append(project_id)
 
+    registered: list[tuple[str, str]] = []
+
+    async def _fake_register(
+        project_id: str, conversation_id: str, *, score: float
+    ) -> None:  # noqa: ARG001
+        registered.append((project_id, conversation_id))
+
     monkeypatch.setattr(participant, "mark_conversation_seen", _fake_mark)
     monkeypatch.setattr(participant, "publish_monitor_dirty", _fake_publish)
+    monkeypatch.setattr(participant, "register_active_conversation", _fake_register)
 
     body = participant.ConversationPingRequest(
         project_id="proj-9",
@@ -56,6 +64,7 @@ def test_ping_conversation_persists_and_publishes_telemetry(monkeypatch) -> None
     assert telemetry["network"] == {"effective_type": "3g", "online": True}
     assert telemetry["battery"] == {"level": 0.4, "charging": False}
     assert published == ["proj-9"]
+    assert registered == [("proj-9", "conv-1")]
 
 
 def test_ping_conversation_drops_unknown_state(monkeypatch) -> None:


### PR DESCRIPTION
Follow-up to #779 from host testing.

## Initiated sessions were invisible until the first chunk
The monitor built its conversation list **only from audio chunks**, so a just-initiated session (participant on the screen, pinging `waiting`, no audio yet) never appeared until its first chunk landed. Telemetry was only read for conversations already discovered via chunks.

**Fix:** the ping already carries `project_id`, so it now also registers the conversation in a per-project **Redis active index** (sorted set scored by ping time, self-pruning + TTL). `gather_project_monitor` unions that index with the chunk-derived set and fetches metadata (name, tags, duration) for the chunk-less sessions. Combined with the existing pub/sub nudge, a session shows up in **~1s of the participant reaching the recording screen** — as `waiting` / `just started`, before any audio.

This is the **server-side event-index** equivalent of the `useDembraneEvents` subscription idea — we react to the ping we already receive, no Directus websocket needed. (Pre-initiate "scanned the QR" presence isn't shown because no conversation exists yet; the session appears the moment it's initiated.)

## "N recordings" → duration
The row showed the raw chunk count ("2 recordings"), which is the wrong metric. Replaced with a **duration**: `conversation.duration` when set (on finish), otherwise elapsed since start. It can lag for a live session — that's acceptable.

## Tests
Chunk-less seeding, `created_at`/`duration` passthrough, and the ping registering the active conversation. 28 monitor/ping/liveness tests pass; ruff + mypy + tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH