### PR TITLE
Docs site on docs.echo-next.dembrane.com + agent doc links

### DIFF
--- a/.github/workflows/dev-deploy-docs.yml
+++ b/.github/workflows/dev-deploy-docs.yml
@@ -1,0 +1,55 @@
+# Publishes the user documentation site (docs/) to GitHub Pages at
+# https://docs.echo-next.dembrane.com on every push to main.
+#
+# Built with the separately-tracked folder2website tool, same pattern as
+# dembrane/sam. One Pages site per repo: this serves the echo-next docs;
+# production docs (docs.dembrane.com) still deploy from echo-user-docs/.
+name: dev-deploy-docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/dev-deploy-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: dev-deploy-docs
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # folder2website reads git history for page metadata
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build docs site
+        run: bunx github:spashii/folder2website#main docs --out _docs-site --base-url https://docs.echo-next.dembrane.com
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _docs-site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/echo/agent/knowledge.py
+++ b/echo/agent/knowledge.py
@@ -36,6 +36,13 @@ def docs_root() -> Optional[Path]:
     return _first_existing(*candidates)
 
 
+def docs_base_url() -> str:
+    """Public docs site prefix for citations, per environment (DOCS_BASE_URL,
+    e.g. https://docs.echo-next.dembrane.com). Empty means the corpus is not
+    published anywhere this deployment should link to; cite bare paths."""
+    return os.environ.get("DOCS_BASE_URL", "").strip().rstrip("/")
+
+
 def skills_root() -> Optional[Path]:
     override = os.environ.get("KNOWLEDGE_SKILLS_DIR")
     if override:
@@ -144,11 +151,20 @@ def prompt_section() -> str:
     docs corpus plus the skill catalog (frontmatter only, bodies lazy)."""
     parts: list[str] = []
     if docs_root() is not None:
+        base = docs_base_url()
+        if base:
+            citation = (
+                "When you cite a doc, link to its published page: drop the .md "
+                f"suffix, append .html, and prefix {base}/ (so users/host/index.md "
+                f"becomes {base}/users/host/index.html). Use a markdown link with "
+                "a readable title, never the bare path."
+            )
+        else:
+            citation = "Cite the doc path you used."
         parts.append(
             "You have a read-only product documentation corpus. Use grepDocs to "
             "search it and readDoc to read pages before answering questions about "
-            "how dembrane works, and cite the doc path you used. Prefer docs over "
-            "guessing."
+            "how dembrane works. Prefer docs over guessing. " + citation
         )
     catalog = skill_catalog()
     if catalog:

--- a/echo/agent/tests/test_knowledge.py
+++ b/echo/agent/tests/test_knowledge.py
@@ -56,6 +56,20 @@ def test_skill_catalog_requires_full_frontmatter(knowledge_dirs):
     assert "Guide setup." in knowledge_dirs.prompt_section()
 
 
+def test_prompt_section_links_published_docs_when_base_url_set(knowledge_dirs, monkeypatch):
+    monkeypatch.setenv("DOCS_BASE_URL", "https://docs.echo-next.dembrane.com/")
+    section = knowledge_dirs.prompt_section()
+    # Trailing slash is normalized; the .md -> .html mapping is spelled out.
+    assert "https://docs.echo-next.dembrane.com/users/host/index.html" in section
+    assert "Cite the doc path you used." not in section
+
+
+def test_prompt_section_cites_bare_paths_without_base_url(knowledge_dirs, monkeypatch):
+    monkeypatch.delenv("DOCS_BASE_URL", raising=False)
+    section = knowledge_dirs.prompt_section()
+    assert "Cite the doc path you used." in section
+
+
 def test_missing_corpus_degrades_gracefully(tmp_path, monkeypatch):
     monkeypatch.setenv("KNOWLEDGE_DOCS_DIR", str(tmp_path / "nope"))
     monkeypatch.setenv("KNOWLEDGE_SKILLS_DIR", str(tmp_path / "nope"))


### PR DESCRIPTION
## What

Two pieces of the chat spec:

1. **Publish the user docs from main** (`.github/workflows/dev-deploy-docs.yml`): every push to main that touches `docs/` builds the folder2website site and deploys it to GitHub Pages at **docs.echo-next.dembrane.com**. Same pattern as the dembrane/sam pages workflow (`bunx github:spashii/folder2website#main`).
2. **Env-prefixed doc links in chat** (`echo/agent/knowledge.py`): with `DOCS_BASE_URL` set, the agent cites docs as links to the published page (`users/host/index.md` -> `https://docs.echo-next.dembrane.com/users/host/index.html`) instead of bare corpus paths. Unset (local dev, prod) keeps path citations, since docs.dembrane.com is still the old Nextra site.

The gitops side (`agent.env.DOCS_BASE_URL` in `values-echo-next.yaml`) ships separately in echo-gitops.

## Notes

- One Pages site per repo: this serves echo-next only. Production docs still deploy from `echo-user-docs/` to docs.dembrane.com, untouched.
- Pages custom domain + Cloudflare CNAME (`docs.echo-next` -> `dembrane.github.io`) are configured outside this PR.

## Verified

- 59 agent tests pass (2 new for the prompt-section link instruction).
- Local `bunx folder2website` build of `docs/`: 82 pages, assets and nl-NL twins render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)