### PR TITLE
Monitor funnel (a): backend visitor-session layer

### DIFF
--- a/echo/server/dembrane/api/participant.py
+++ b/echo/server/dembrane/api/participant.py
@@ -18,6 +18,10 @@ from dembrane.monitor_stream import (
     register_active_conversation,
 )
 from dembrane.service.project import ProjectNotFoundException
+from dembrane.visitor_session import (
+    VALID_VISITOR_STAGES,
+    mark_visitor_seen,
+)
 from dembrane.service.conversation import (
     ConversationServiceException,
     ConversationNotFoundException,
@@ -408,6 +412,9 @@ class ConversationPingRequest(BaseModel):
     state: Optional[str] = None
     mode: Optional[str] = None  # "voice" | "text"
     screen: Optional[str] = None
+    # The pre-conversation funnel dot this recording grew out of. Lets the
+    # monitor dedupe a visitor that has graduated into a live conversation.
+    visitor_id: Optional[str] = None
     network: Optional[ConversationNetworkTelemetry] = None
     battery: Optional[ConversationBatteryTelemetry] = None
 
@@ -423,6 +430,8 @@ def _build_ping_telemetry(body: Optional[ConversationPingRequest]) -> dict:
         telemetry["mode"] = body.mode
     if body.screen:
         telemetry["screen"] = body.screen.strip()[:40]
+    if body.visitor_id:
+        telemetry["visitor_id"] = body.visitor_id.strip()[:64]
     if body.network is not None:
         network = body.network.model_dump(exclude_none=True)
         if isinstance(network.get("effective_type"), str):
@@ -464,6 +473,75 @@ async def ping_conversation(
             body.project_id, conversation_id, score=time()
         )
         await publish_monitor_dirty(body.project_id)
+    return {"ok": True}
+
+
+class VisitorPingRequest(BaseModel):
+    """Pre-conversation funnel beacon: where a participant is during onboarding,
+    before a conversation exists. All optional and best-effort."""
+
+    stage: Optional[str] = None
+    name: Optional[str] = None
+    tags: Optional[List[str]] = None
+    tags_preselected: Optional[bool] = None
+    scan_count: Optional[int] = None
+    device: Optional[str] = None
+    network: Optional[ConversationNetworkTelemetry] = None
+    battery: Optional[ConversationBatteryTelemetry] = None
+
+
+def _build_visitor_telemetry(body: Optional[VisitorPingRequest]) -> dict:
+    if body is None:
+        return {}
+    telemetry: dict = {}
+    if body.stage and body.stage in VALID_VISITOR_STAGES:
+        telemetry["stage"] = body.stage
+    if body.name:
+        telemetry["name"] = body.name.strip()[:120]
+    if isinstance(body.tags, list) and body.tags:
+        telemetry["tags"] = [str(t).strip()[:80] for t in body.tags[:20] if str(t).strip()]
+    if body.tags_preselected is not None:
+        telemetry["tags_preselected"] = bool(body.tags_preselected)
+    if isinstance(body.scan_count, int):
+        telemetry["scan_count"] = max(1, min(body.scan_count, 999))
+    if body.device:
+        telemetry["device"] = body.device.strip()[:60]
+    if body.network is not None:
+        network = body.network.model_dump(exclude_none=True)
+        if isinstance(network.get("effective_type"), str):
+            network["effective_type"] = network["effective_type"][:12]
+        if network:
+            telemetry["network"] = network
+    if body.battery is not None:
+        battery = body.battery.model_dump(exclude_none=True)
+        if battery:
+            telemetry["battery"] = battery
+    return telemetry
+
+
+@ParticipantRouter.post(
+    "/projects/{project_id}/visitors/{visitor_id}/ping", response_model=dict
+)
+async def ping_visitor(
+    project_id: str,
+    visitor_id: str,
+    body: Optional[VisitorPingRequest] = None,
+) -> dict:
+    """Pre-conversation funnel beacon (public), keyed by a client-minted
+    visitor_id. Cheap: stamps a short-lived Redis key + per-project index and
+    nudges open monitor streams. Swallows Redis errors so onboarding is never
+    disrupted."""
+    try:
+        await mark_visitor_seen(
+            project_id,
+            visitor_id,
+            telemetry=_build_visitor_telemetry(body) or None,
+            score=time(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Visitor ping failed for %s/%s: %s", project_id, visitor_id, exc)
+        return {"ok": False}
+    await publish_monitor_dirty(project_id)
     return {"ok": True}
 
 

--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -46,6 +46,11 @@ from dembrane.monitor_stream import (
     get_active_conversation_ids,
 )
 from dembrane.search_filters import merge_search_filter
+from dembrane.visitor_session import (
+    VALID_VISITOR_STAGES,
+    get_visitors_many,
+    get_active_visitor_ids,
+)
 from dembrane.api.v2.bff._access import (
     filter_exclude_deleted,
     resolve_project_access,
@@ -912,6 +917,49 @@ def _build_monitor_payload(
     }
 
 
+_FUNNEL_STAGES = ("scanned", "terms", "mic_ok", "mic_skipped", "mic_blocked", "profile")
+
+
+def _build_funnel(
+    visitors: dict[str, dict], graduated: set[str]
+) -> dict:
+    """Shape pre-conversation visitor sessions into the host funnel.
+
+    `visitors` maps visitor_id -> telemetry (with a `seen` datetime). `graduated`
+    is the set of visitor_ids that already have a live conversation, so a dot
+    that became a recording isn't double-counted in the funnel.
+    """
+    entries: list[dict] = []
+    counts = {stage: 0 for stage in _FUNNEL_STAGES}
+    for visitor_id, tele in visitors.items():
+        if visitor_id in graduated:
+            continue
+        stage = tele.get("stage")
+        if stage not in VALID_VISITOR_STAGES:
+            stage = "scanned"
+        seen = tele.get("seen")
+        entries.append(
+            {
+                "id": visitor_id,
+                "stage": stage,
+                "name": (tele.get("name") or "").strip() or None,
+                "tags": tele.get("tags") or [],
+                "tags_preselected": bool(tele.get("tags_preselected")),
+                "scan_count": int(tele.get("scan_count") or 1),
+                "device": tele.get("device"),
+                "network": tele.get("network"),
+                "battery": tele.get("battery"),
+                "last_seen_at": seen.isoformat() if isinstance(seen, datetime) else None,
+                "_sort": seen.isoformat() if isinstance(seen, datetime) else "",
+            }
+        )
+        counts[stage] += 1
+    entries.sort(key=lambda e: e["_sort"], reverse=True)
+    for entry in entries:
+        entry.pop("_sort", None)
+    return {"visitors": entries, "summary": {**counts, "total": len(entries)}}
+
+
 async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
     """Assemble the live-monitor payload for a project (no access gate).
 
@@ -1092,7 +1140,7 @@ async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Monitor liveness ping read failed: %s", exc)
 
-    return _build_monitor_payload(
+    payload = _build_monitor_payload(
         recent_chunks,
         chunk_counts,
         transcribed_counts,
@@ -1102,6 +1150,27 @@ async def gather_project_monitor(project_id: str, window_seconds: int) -> dict:
         tag_map,
         extra_conversations,
     )
+
+    # Pre-conversation funnel: visitors still onboarding (scan -> terms -> mic
+    # -> profile), deduped against those that already graduated into a live
+    # conversation (their recording ping carries the visitor_id).
+    graduated: set[str] = {
+        str(tele["visitor_id"])
+        for tele in telemetry.values()
+        if tele.get("visitor_id")
+    }
+    visitors: dict[str, dict] = {}
+    try:
+        visitor_ids = await get_active_visitor_ids(
+            project_id,
+            min_score=(now - timedelta(seconds=MONITOR_LOOKBACK_SECONDS)).timestamp(),
+        )
+        if visitor_ids:
+            visitors = await get_visitors_many(project_id, visitor_ids)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Monitor funnel read failed: %s", exc)
+    payload["funnel"] = _build_funnel(visitors, graduated)
+    return payload
 
 
 # The monitor snapshot is cached in Redis so Directus is hit at most ~once per

--- a/echo/server/dembrane/visitor_session.py
+++ b/echo/server/dembrane/visitor_session.py
@@ -1,0 +1,146 @@
+"""Pre-conversation visitor sessions for the host funnel.
+
+The host "funnel" monitor needs to see participants BEFORE a conversation row
+exists: from the moment they land on the portal (QR scan), through consent,
+mic check, and name entry. None of that has a conversation_id yet, so the
+portal mints a client-side ``visitor_id`` (persisted in localStorage) and
+beacons its funnel stage here, keyed by ``(project_id, visitor_id)``.
+
+Storage mirrors conversation liveness: a short-TTL JSON key per visitor plus a
+per-project sorted-set index so the monitor can enumerate who is currently in
+the funnel. All of it is best-effort — a Redis hiccup must never break the
+participant's onboarding.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+from datetime import datetime, timezone
+
+from dembrane.redis_async import get_redis_client
+
+# Visitors ping ~every 10s while onboarding. Keep the key alive across a few
+# missed pings; once they leave the page it expires and the dot drops off.
+VISITOR_TTL_SECONDS = 45
+
+_VISITOR_KEY_PREFIX = "visitor:"
+_VISITOR_INDEX_PREFIX = "monitor:visitors:"
+_VISITOR_INDEX_TTL_SECONDS = 2100
+
+# Funnel stages the portal reports. Mic carries its outcome so the host can see
+# a skip or a block, not just "advanced".
+VALID_VISITOR_STAGES = frozenset(
+    {
+        "scanned",  # landed on the portal (QR)
+        "terms",  # accepted / advanced past consent
+        "mic_ok",  # mic check passed
+        "mic_skipped",  # mic check skipped
+        "mic_blocked",  # mic permission denied / blocked
+        "profile",  # on the name/details step
+    }
+)
+
+_TELEMETRY_FIELDS = (
+    "stage",
+    "name",
+    "tags",
+    "tags_preselected",
+    "scan_count",
+    "network",
+    "battery",
+    "device",
+)
+
+
+def _key(project_id: str, visitor_id: str) -> str:
+    return f"{_VISITOR_KEY_PREFIX}{project_id}:{visitor_id}"
+
+
+def _index_key(project_id: str) -> str:
+    return f"{_VISITOR_INDEX_PREFIX}{project_id}"
+
+
+def _now_iso(now: Optional[datetime] = None) -> str:
+    return (now or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+
+
+def _parse_dt(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+async def mark_visitor_seen(
+    project_id: str,
+    visitor_id: str,
+    *,
+    now: Optional[datetime] = None,
+    telemetry: Optional[dict[str, Any]] = None,
+    score: Optional[float] = None,
+) -> None:
+    """Record a visitor funnel ping (best-effort). ``telemetry`` is caller-sanitised."""
+    if not project_id or not visitor_id:
+        return
+    payload: dict[str, Any] = {"seen": _now_iso(now), "id": visitor_id}
+    if telemetry:
+        for field in _TELEMETRY_FIELDS:
+            value = telemetry.get(field)
+            if value is not None:
+                payload[field] = value
+    client = await get_redis_client()
+    stamp = score if score is not None else (now or datetime.now(timezone.utc)).timestamp()
+    await client.set(_key(project_id, visitor_id), json.dumps(payload), ex=VISITOR_TTL_SECONDS)
+    await client.zadd(_index_key(project_id), {visitor_id: stamp})
+    await client.expire(_index_key(project_id), _VISITOR_INDEX_TTL_SECONDS)
+
+
+async def get_active_visitor_ids(project_id: str, *, min_score: float) -> list[str]:
+    """Return visitor ids pinged since ``min_score`` (epoch seconds); prunes older."""
+    try:
+        client = await get_redis_client()
+        key = _index_key(project_id)
+        await client.zremrangebyscore(key, "-inf", f"({min_score}")
+        members = await client.zrangebyscore(key, min_score, "+inf")
+    except Exception:  # noqa: BLE001
+        return []
+    return [
+        m.decode("utf-8") if isinstance(m, (bytes, bytearray)) else str(m)
+        for m in members
+    ]
+
+
+async def get_visitors_many(
+    project_id: str, visitor_ids: list[str]
+) -> dict[str, dict[str, Any]]:
+    """Return {visitor_id: telemetry} for ids with a live session key."""
+    if not visitor_ids:
+        return {}
+    client = await get_redis_client()
+    values = await client.mget([_key(project_id, vid) for vid in visitor_ids])
+    out: dict[str, dict[str, Any]] = {}
+    for visitor_id, raw in zip(visitor_ids, values, strict=False):
+        if raw is None:
+            continue
+        text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        seen = _parse_dt(parsed.get("seen"))
+        if seen is None:
+            continue
+        parsed["seen"] = seen
+        out[visitor_id] = parsed
+    return out

--- a/echo/server/tests/api/test_conversation_monitor.py
+++ b/echo/server/tests/api/test_conversation_monitor.py
@@ -369,6 +369,44 @@ def test_monitor_transcript_snippet_truncated() -> None:
     assert len(payload["conversations"][0]["latest_transcript"]) == MONITOR_TRANSCRIPT_SNIPPET_MAX_LEN
 
 
+def test_build_funnel_groups_stages_and_dedupes_graduated() -> None:
+    from datetime import datetime, timezone
+
+    from dembrane.api.v2.bff.conversations import _build_funnel
+
+    now = datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+    visitors = {
+        "v-scan": {"seen": now, "stage": "scanned", "scan_count": 2},
+        "v-mic-skip": {"seen": now, "stage": "mic_skipped"},
+        "v-profile": {
+            "seen": now,
+            "stage": "profile",
+            "name": "Ada",
+            "tags": ["Table 3"],
+            "tags_preselected": True,
+        },
+        # already graduated into a live conversation -> excluded
+        "v-live": {"seen": now, "stage": "profile"},
+        # unknown stage -> defaults to scanned
+        "v-weird": {"seen": now, "stage": "banana"},
+    }
+    funnel = _build_funnel(visitors, graduated={"v-live"})
+    by_id = {v["id"]: v for v in funnel["visitors"]}
+
+    assert "v-live" not in by_id  # graduated dot is not double-counted
+    assert by_id["v-scan"]["scan_count"] == 2
+    assert by_id["v-mic-skip"]["stage"] == "mic_skipped"
+    assert by_id["v-profile"]["name"] == "Ada"
+    assert by_id["v-profile"]["tags"] == ["Table 3"]
+    assert by_id["v-profile"]["tags_preselected"] is True
+    assert by_id["v-weird"]["stage"] == "scanned"
+
+    assert funnel["summary"]["scanned"] == 2  # v-scan + v-weird
+    assert funnel["summary"]["mic_skipped"] == 1
+    assert funnel["summary"]["profile"] == 1
+    assert funnel["summary"]["total"] == 4
+
+
 # ── endpoint wiring: access gate + two-query aggregation ──────────────
 
 
@@ -431,6 +469,16 @@ async def _build_client(
         return []
 
     monkeypatch.setattr(conv_bff, "get_active_conversation_ids", _fake_active)
+
+    # Funnel (visitor) reads also hit Redis; stub to empty.
+    async def _fake_active_visitors(project_id: str, *, min_score: float) -> list:  # noqa: ARG001
+        return []
+
+    async def _fake_visitors_many(project_id: str, visitor_ids: list) -> dict:  # noqa: ARG001
+        return {}
+
+    monkeypatch.setattr(conv_bff, "get_active_visitor_ids", _fake_active_visitors)
+    monkeypatch.setattr(conv_bff, "get_visitors_many", _fake_visitors_many)
 
     # The snapshot cache also uses Redis; stub a always-miss client so the
     # endpoint recomputes (and the Directus query assertions still hold).

--- a/echo/server/tests/api/test_participant_ping.py
+++ b/echo/server/tests/api/test_participant_ping.py
@@ -96,3 +96,58 @@ def test_ping_conversation_swallows_redis_errors(monkeypatch) -> None:
     result = _run(participant.ping_conversation("conv-1"))
 
     assert result == {"ok": False}
+
+
+def test_ping_visitor_sanitises_and_publishes(monkeypatch) -> None:
+    import dembrane.api.participant as participant
+
+    marked: list[tuple[str, str, object]] = []
+    published: list[str] = []
+
+    async def _fake_mark(project_id, visitor_id, *, telemetry=None, score=None):  # noqa: ANN001, ARG001
+        marked.append((project_id, visitor_id, telemetry))
+
+    async def _fake_publish(project_id: str) -> None:
+        published.append(project_id)
+
+    monkeypatch.setattr(participant, "mark_visitor_seen", _fake_mark)
+    monkeypatch.setattr(participant, "publish_monitor_dirty", _fake_publish)
+
+    body = participant.VisitorPingRequest(
+        stage="mic_skipped",
+        name="Ada",
+        tags=["Table 3", "  "],
+        tags_preselected=True,
+        scan_count=2,
+    )
+    result = _run(participant.ping_visitor("proj-1", "vis-1", body))
+
+    assert result == {"ok": True}
+    project_id, visitor_id, telemetry = marked[0]
+    assert (project_id, visitor_id) == ("proj-1", "vis-1")
+    assert telemetry["stage"] == "mic_skipped"
+    assert telemetry["name"] == "Ada"
+    assert telemetry["tags"] == ["Table 3"]  # blank tag dropped
+    assert telemetry["tags_preselected"] is True
+    assert telemetry["scan_count"] == 2
+    assert published == ["proj-1"]
+
+
+def test_ping_visitor_drops_unknown_stage(monkeypatch) -> None:
+    import dembrane.api.participant as participant
+
+    marked: list[object] = []
+
+    async def _fake_mark(project_id, visitor_id, *, telemetry=None, score=None):  # noqa: ANN001, ARG001
+        marked.append(telemetry)
+
+    async def _fake_publish(project_id: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(participant, "mark_visitor_seen", _fake_mark)
+    monkeypatch.setattr(participant, "publish_monitor_dirty", _fake_publish)
+
+    body = participant.VisitorPingRequest(stage="banana")
+    _run(participant.ping_visitor("proj-1", "vis-1", body))
+    # Unknown stage dropped -> empty telemetry -> None passed to mark.
+    assert marked == [None]

--- a/echo/server/tests/test_visitor_session.py
+++ b/echo/server/tests/test_visitor_session.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+from datetime import datetime, timezone
+
+import pytest
+
+import dembrane.visitor_session as vs
+
+
+class _FakeRedis:
+    """Async Redis stand-in supporting the string + sorted-set ops the
+    visitor session uses (set/mget/zadd/expire/zrangebyscore/zremrangebyscore)."""
+
+    def __init__(self) -> None:
+        self.kv: dict[str, bytes] = {}
+        self.zsets: dict[str, dict[str, float]] = {}
+
+    async def set(self, key: str, value: str, ex: Optional[int] = None) -> None:  # noqa: ARG002
+        self.kv[key] = value.encode("utf-8")
+
+    async def mget(self, keys: list[str]) -> list[Optional[bytes]]:
+        return [self.kv.get(k) for k in keys]
+
+    async def zadd(self, key: str, mapping: dict[str, float]) -> None:
+        self.zsets.setdefault(key, {}).update(mapping)
+
+    async def expire(self, key: str, ttl: int) -> None:  # noqa: ARG002
+        return None
+
+    async def zremrangebyscore(self, key: str, _min, mx) -> None:
+        # Only used as ("-inf", f"({cutoff}") => drop members strictly below cutoff.
+        z = self.zsets.get(key, {})
+        cutoff = float(str(mx).lstrip("("))
+        for member in [m for m, s in z.items() if s < cutoff]:
+            del z[member]
+
+    async def zrangebyscore(self, key: str, mn, _max) -> list[str]:
+        z = self.zsets.get(key, {})
+        lo = float(mn)
+        return sorted((m for m, s in z.items() if s >= lo), key=lambda m: z[m])
+
+
+@pytest.fixture
+def fake_redis(monkeypatch) -> _FakeRedis:
+    client = _FakeRedis()
+
+    async def _get_client():
+        return client
+
+    monkeypatch.setattr(vs, "get_redis_client", _get_client)
+    return client
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_mark_and_read_visitor(fake_redis: _FakeRedis) -> None:
+    now = datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+    _run(
+        vs.mark_visitor_seen(
+            "proj-1",
+            "vis-1",
+            now=now,
+            score=now.timestamp(),
+            telemetry={
+                "stage": "mic_skipped",
+                "name": "Ada",
+                "tags": ["Table 3"],
+                "tags_preselected": True,
+                "scan_count": 2,
+            },
+        )
+    )
+    result = _run(vs.get_visitors_many("proj-1", ["vis-1", "missing"]))
+    assert set(result.keys()) == {"vis-1"}
+    entry = result["vis-1"]
+    assert entry["seen"] == now
+    assert entry["stage"] == "mic_skipped"
+    assert entry["name"] == "Ada"
+    assert entry["tags"] == ["Table 3"]
+    assert entry["scan_count"] == 2
+
+
+def test_active_index_filters_and_prunes(fake_redis: _FakeRedis) -> None:
+    now = datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
+    fresh = now.timestamp()
+    stale = fresh - 10_000
+    _run(vs.mark_visitor_seen("proj-1", "fresh", now=now, score=fresh))
+    _run(vs.mark_visitor_seen("proj-1", "stale", now=now, score=stale))
+
+    ids = _run(vs.get_active_visitor_ids("proj-1", min_score=fresh - 60))
+    assert ids == ["fresh"]
+    # The stale member was pruned from the index on read.
+    assert "stale" not in fake_redis.zsets["monitor:visitors:proj-1"]
+
+
+def test_get_active_visitor_ids_handles_redis_down(monkeypatch) -> None:
+    async def _boom():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(vs, "get_redis_client", _boom)
+    assert _run(vs.get_active_visitor_ids("p", min_score=0)) == []


### PR DESCRIPTION
First of three PRs for the **participant funnel** — the host view that tracks people walking through onboarding (QR scan → terms → mic check → profile → recording), not just once they're recording.

## Why this layer exists
Everything today keys on `conversation_id`, which doesn't exist until *initiate* (the last onboarding step). So stages 1–4 are invisible. This adds a **pre-conversation visitor session**, so the funnel can see people from the moment they land.

## What's in this PR (backend only — additive, no UI yet)
- **`visitor_session.py`** — a client-minted `visitor_id` (localStorage) beacons its stage to `POST /participant/projects/{id}/visitors/{visitor_id}/ping`. Stored as a short-TTL Redis JSON key + per-project sorted-set index, mirroring conversation liveness.
- **Stages carry outcome** — `mic_ok` / `mic_skipped` / `mic_blocked` (your "show that they skipped"), plus `tags_preselected` (your "show preselected as preselected") and `scan_count` (re-scan detection from the localStorage id).
- **`gather_project_monitor`** now returns a **`funnel`** section: visitors grouped by stage + per-stage counts, **deduped** against visitors that graduated into a live conversation (the recording ping carries `visitor_id`).
- Reuses the existing SSE stream, pub/sub nudge, and snapshot cache unchanged — so the Directus-load valve still holds.

## Tests
Visitor store round-trip + active-index prune + redis-down fallback, funnel grouping/dedup/skip-stage, and the visitor ping endpoint sanitising untrusted input + publishing. 34 tests pass; ruff + mypy clean.

## Next
(b) portal stage instrumentation (mint visitor_id, ping each stage), (c) the swimlane funnel UI with same-screen drilldown + host inline-edit (reuses existing `PATCH conversation` / `replace_conversation_tags`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH