### PR TITLE
Agent: docs site url resolved in code, forwarded per request (no gitops env)

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -204,6 +204,7 @@ def create_agent_graph(
     bearer_token: str,
     llm: Any | None = None,
     echo_client_factory: Callable[[str], EchoClient] | None = None,
+    docs_base_url: str = "",
 ):
     if not bearer_token:
         raise ValueError("bearer_token is required")
@@ -906,7 +907,7 @@ def create_agent_graph(
         readMemory,
         remember,
     ]
-    system_prompt = SYSTEM_PROMPT + knowledge.prompt_section()
+    system_prompt = SYSTEM_PROMPT + knowledge.prompt_section(docs_base_url=docs_base_url)
     configured_llm = llm or _build_llm()
     llm_with_tools = configured_llm.bind_tools(tools)
 

--- a/echo/agent/knowledge.py
+++ b/echo/agent/knowledge.py
@@ -36,13 +36,6 @@ def docs_root() -> Optional[Path]:
     return _first_existing(*candidates)
 
 
-def docs_base_url() -> str:
-    """Public docs site prefix for citations, per environment (DOCS_BASE_URL,
-    e.g. https://docs.echo-next.dembrane.com). Empty means the corpus is not
-    published anywhere this deployment should link to; cite bare paths."""
-    return os.environ.get("DOCS_BASE_URL", "").strip().rstrip("/")
-
-
 def skills_root() -> Optional[Path]:
     override = os.environ.get("KNOWLEDGE_SKILLS_DIR")
     if override:
@@ -146,12 +139,16 @@ def read_skill(path: str) -> str:
     return target.read_text(encoding="utf-8", errors="replace")
 
 
-def prompt_section() -> str:
+def prompt_section(docs_base_url: str = "") -> str:
     """The knowledge block appended to the system prompt: how to use the
-    docs corpus plus the skill catalog (frontmatter only, bodies lazy)."""
+    docs corpus plus the skill catalog (frontmatter only, bodies lazy).
+
+    docs_base_url is where this environment's corpus is published (the server
+    resolves it in code from its own env and forwards it per request); empty
+    means unpublished, so citations stay bare paths."""
     parts: list[str] = []
     if docs_root() is not None:
-        base = docs_base_url()
+        base = docs_base_url.strip().rstrip("/")
         if base:
             citation = (
                 "When you cite a doc, link to its published page: drop the .md "

--- a/echo/agent/main.py
+++ b/echo/agent/main.py
@@ -57,10 +57,19 @@ async def copilotkit_endpoint(request: Request, project_id: str, path: Optional[
     request.scope.setdefault("path_params", {})
     request.scope["path_params"]["path"] = path or ""
 
+    # Where this environment publishes the docs corpus. The server resolves it
+    # in code from its own env and forwards it here; absent means unpublished
+    # and the agent cites bare doc paths.
+    docs_base_url = request.headers.get("x-dembrane-docs-base-url", "")
+
     agent = LangGraphAgent(
         name="default",
         description="Echo Agentic Chat default agent",
-        graph=create_agent_graph(project_id=project_id, bearer_token=bearer_token),
+        graph=create_agent_graph(
+            project_id=project_id,
+            bearer_token=bearer_token,
+            docs_base_url=docs_base_url,
+        ),
     )
     # CopilotKit currently rejects LangGraphAgent only for literal list inputs.
     # Supplying a callable preserves expected runtime behavior in this SDK version.

--- a/echo/agent/tests/test_knowledge.py
+++ b/echo/agent/tests/test_knowledge.py
@@ -56,16 +56,14 @@ def test_skill_catalog_requires_full_frontmatter(knowledge_dirs):
     assert "Guide setup." in knowledge_dirs.prompt_section()
 
 
-def test_prompt_section_links_published_docs_when_base_url_set(knowledge_dirs, monkeypatch):
-    monkeypatch.setenv("DOCS_BASE_URL", "https://docs.echo-next.dembrane.com/")
-    section = knowledge_dirs.prompt_section()
+def test_prompt_section_links_published_docs_when_base_url_given(knowledge_dirs):
+    section = knowledge_dirs.prompt_section(docs_base_url="https://docs.echo-next.dembrane.com/")
     # Trailing slash is normalized; the .md -> .html mapping is spelled out.
     assert "https://docs.echo-next.dembrane.com/users/host/index.html" in section
     assert "Cite the doc path you used." not in section
 
 
-def test_prompt_section_cites_bare_paths_without_base_url(knowledge_dirs, monkeypatch):
-    monkeypatch.delenv("DOCS_BASE_URL", raising=False)
+def test_prompt_section_cites_bare_paths_without_base_url(knowledge_dirs):
     section = knowledge_dirs.prompt_section()
     assert "Cite the doc path you used." in section
 

--- a/echo/server/dembrane/agentic_client.py
+++ b/echo/server/dembrane/agentic_client.py
@@ -28,6 +28,21 @@ class AgenticUpstreamError(AgenticClientError):
 MessageHistoryEntry = dict[str, str]
 
 
+def docs_base_url_for_env() -> str:
+    """The published docs site for this environment, derived in code from the
+    per-env ADMIN_BASE_URL that is already configured (same idea as the
+    frontend's byEnv(): no dedicated env var to wire through gitops).
+
+    Only echo-next publishes the docs/ corpus today (GitHub Pages, dembrane/echo
+    main). docs.dembrane.com still serves the old echo-user-docs site with
+    different paths, so prod, testing, and local resolve to empty and the agent
+    cites bare doc paths instead of links."""
+    admin_host = httpx.URL(get_settings().urls.admin_base_url).host
+    if admin_host.endswith(".echo-next.dembrane.com"):
+        return "https://docs.echo-next.dembrane.com"
+    return ""
+
+
 def _build_payload_messages(
     *,
     user_message: str,
@@ -106,6 +121,9 @@ async def stream_agent_events(
         "Authorization": f"Bearer {bearer_token}",
         "Accept": "application/x-ndjson",
     }
+    docs_base_url = docs_base_url_for_env()
+    if docs_base_url:
+        headers["X-Dembrane-Docs-Base-Url"] = docs_base_url
 
     payload: dict[str, Any] = {
         "threadId": thread_id,

--- a/echo/server/tests/test_agentic_client.py
+++ b/echo/server/tests/test_agentic_client.py
@@ -9,6 +9,7 @@ from dembrane.agentic_client import (
     AgenticTimeoutError,
     AgenticUpstreamError,
     stream_agent_events,
+    docs_base_url_for_env,
 )
 
 
@@ -308,3 +309,53 @@ async def test_stream_agent_events_converts_transport_errors_to_upstream_error(m
     assert exc.value.status_code == 502
     assert exc.value.error_code == "AGENT_UPSTREAM_TRANSPORT"
     assert "incomplete chunked read" in exc.value.message.lower()
+
+
+def test_docs_base_url_for_env_maps_admin_host(monkeypatch) -> None:
+    class _Urls:
+        admin_base_url = "https://dashboard.echo-next.dembrane.com"
+
+    class _Settings:
+        urls = _Urls()
+
+    monkeypatch.setattr("dembrane.agentic_client.get_settings", lambda: _Settings())
+    assert docs_base_url_for_env() == "https://docs.echo-next.dembrane.com"
+
+    # Unpublished environments cite bare paths: no base url.
+    _Urls.admin_base_url = "https://dashboard.dembrane.com"
+    assert docs_base_url_for_env() == ""
+    _Urls.admin_base_url = "https://dashboard.echo-testing.dembrane.com"
+    assert docs_base_url_for_env() == ""
+    _Urls.admin_base_url = "http://localhost:3000"
+    assert docs_base_url_for_env() == ""
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_events_forwards_docs_base_url_header(monkeypatch) -> None:
+    capture: dict[str, Any] = {}
+    response = _FakeStreamResponse(status_code=200, chunks=[])
+
+    def _build_client(*, base_url: str, timeout: float) -> _FakeAsyncClient:
+        return _FakeAsyncClient(
+            base_url=base_url,
+            timeout=timeout,
+            capture=capture,
+            response=response,
+        )
+
+    monkeypatch.setattr("dembrane.agentic_client.httpx.AsyncClient", _build_client)
+    monkeypatch.setattr(
+        "dembrane.agentic_client.docs_base_url_for_env",
+        lambda: "https://docs.echo-next.dembrane.com",
+    )
+
+    async for _ in stream_agent_events(
+        project_id="project-1",
+        user_message="hello",
+        bearer_token="token-1",
+        agent_service_url="http://agent.test",
+        timeout_seconds=42,
+    ):
+        pass
+
+    assert capture["headers"]["X-Dembrane-Docs-Base-Url"] == "https://docs.echo-next.dembrane.com"


### PR DESCRIPTION
Replaces both the gitops-wired `DOCS_BASE_URL` (echo-gitops#33, closed) and the k8s-namespace-file idea with the pattern the frontend uses: resolve config per environment **in code**, from a signal that already exists.

## How

- **Server** (`agentic_client.py`): `docs_base_url_for_env()` derives the published docs site from the per-env `ADMIN_BASE_URL` that is already configured everywhere (dev: dashboard.echo-next.dembrane.com -> https://docs.echo-next.dembrane.com; prod/testing/local -> none, their corpus is not published). `stream_agent_events` sends it as an `X-Dembrane-Docs-Base-Url` header — the one place the server calls the agent.
- **Agent** (`main.py` -> `create_agent_graph` -> `knowledge.prompt_section(docs_base_url=...)`): the header value threads into the knowledge prompt, so doc citations become links to the published page (`users/host/index.md` -> `.../users/host/index.html`). No header = bare-path citations, exactly the old behavior.

No new env vars anywhere; nothing for gitops to carry. When prod docs migrate to this corpus, prod turns on by adding one line to the in-code mapping.

## Verified

- 59 agent tests pass.
- 8 server `test_agentic_client` tests pass in the devcontainer (2 new: env mapping + header forwarding). They fail on a bare host either way — pre-existing `.env` gap (DirectusSettings), not this change.
- ruff clean over `dembrane` + `tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)