### PR TITLE
Monitor funnel (b): instrument portal onboarding stages

### DIFF
--- a/echo/frontend/src/components/participant/MicrophoneTest.tsx
+++ b/echo/frontend/src/components/participant/MicrophoneTest.tsx
@@ -19,12 +19,14 @@ import { testId } from "@/lib/testUtils";
 interface MicrophoneTestProps {
 	onContinue: (deviceId: string) => void;
 	onMicTestSuccess: (success: boolean) => void;
+	onMicAccessDenied?: (denied: boolean) => void;
 	isInModal?: boolean;
 }
 
 const MicrophoneTest: React.FC<MicrophoneTestProps> = ({
 	onContinue,
 	onMicTestSuccess,
+	onMicAccessDenied,
 	isInModal = false,
 }) => {
 	const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
@@ -41,6 +43,11 @@ const MicrophoneTest: React.FC<MicrophoneTestProps> = ({
 	const [micAccessDenied, setMicAccessDenied] = useState(false);
 	const [isMicTestSuccessful, setIsMicTestSuccessful] = useState(false);
 	const isMicSuccessRef = useRef(false);
+
+	// Surface a blocked mic to the host funnel (best-effort; optional callback).
+	useEffect(() => {
+		if (micAccessDenied) onMicAccessDenied?.(true);
+	}, [micAccessDenied, onMicAccessDenied]);
 	const displayLevel = Math.min(Math.sqrt(level / 255) * 100, 100);
 
 	const streamRef = useRef<MediaStream | null>(null);

--- a/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
@@ -34,6 +34,7 @@ import {
 	type ParticipantPingTelemetry,
 	pingConversation,
 } from "@/lib/api";
+import { getVisitorId } from "@/lib/visitorId";
 import { testId } from "@/lib/testUtils";
 import { I18nLink } from "../common/i18nLink";
 import { ScrollToBottomButton } from "../common/ScrollToBottom";
@@ -251,6 +252,7 @@ export const ParticipantConversationAudio = () => {
 			if (cancelled) return;
 			void pingConversation(conversationId, {
 				project_id: projectId,
+				visitor_id: projectId ? getVisitorId(projectId) : undefined,
 				state: participantState,
 				mode: "voice",
 				network: readNetworkTelemetry(),

--- a/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
+++ b/echo/frontend/src/components/participant/ParticipantOnboardingCards.tsx
@@ -9,6 +9,7 @@ import { Button, Checkbox, Stack, Text, Title } from "@mantine/core";
 import { Logo } from "@/components/common/Logo";
 import { PARTICIPANT_BASE_URL } from "@/config";
 import { useLanguage } from "@/hooks/useLanguage";
+import { useVisitorBeacon } from "@/hooks/useVisitorBeacon";
 import { testId } from "@/lib/testUtils";
 import { cn } from "@/lib/utils";
 import { useOnboardingCards } from "./hooks/useOnboardingCards";
@@ -57,8 +58,35 @@ const ParticipantOnboardingCards = ({
 	);
 	const [animationDirection, setAnimationDirection] = useState("");
 	const [micTestSuccess, setMicTestSuccess] = useState(false);
+	const [micSkipped, setMicSkipped] = useState(false);
+	const [micBlocked, setMicBlocked] = useState(false);
 
 	const { language } = useLanguage();
+
+	// Tables/tags preselected via the QR URL (?tags= / ?tag_id_list=), resolved
+	// to labels so the funnel can show them and mark them as preselected.
+	const preselectedTags = useMemo(() => {
+		const raw = searchParams.get("tags") ?? searchParams.get("tag_id_list");
+		if (!raw) return [] as string[];
+		const wanted = raw
+			.split(",")
+			.map((value) => value.trim())
+			.filter(Boolean);
+		const projectTags = project.tags ?? [];
+		return wanted
+			.map((value) => {
+				const match = projectTags.find(
+					(tag) =>
+						typeof tag === "object" &&
+						tag !== null &&
+						(tag.id === value || tag.text === value),
+				);
+				return typeof match === "object" && match !== null
+					? (match.text ?? value)
+					: value;
+			})
+			.filter(Boolean);
+	}, [searchParams, project.tags]);
 
 	const InitiateFormComponent = useMemo(
 		() => () => <ParticipantInitiateForm project={project} />,
@@ -71,6 +99,7 @@ const ParticipantOnboardingCards = ({
 			<MicrophoneTest
 				onContinue={(_id: string) => {}}
 				onMicTestSuccess={setMicTestSuccess}
+				onMicAccessDenied={setMicBlocked}
 			/>
 		),
 		[setMicTestSuccess],
@@ -230,6 +259,27 @@ const ParticipantOnboardingCards = ({
 
 	const currentCard = allSlides[currentSlideIndex];
 
+	// The funnel stage this visitor is at, reported to the host monitor. Mic
+	// carries its outcome (ok / skipped / blocked) so a stuck participant is
+	// visible. Monotonic-ish: furthest milestone reached wins.
+	const funnelStage =
+		skipOnboarding === "1" || currentSlideIndex === allSlides.length - 1
+			? "profile"
+			: micBlocked
+				? "mic_blocked"
+				: micSkipped
+					? "mic_skipped"
+					: micTestSuccess
+						? "mic_ok"
+						: currentSlideIndex > 0
+							? "terms"
+							: "scanned";
+	useVisitorBeacon(project.id, {
+		stage: funnelStage,
+		tags: preselectedTags,
+		tagsPreselected: preselectedTags.length > 0,
+	});
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: needs to be inspected
 	useEffect(() => {
 		const timer = setTimeout(() => setAnimationDirection(""), 300);
@@ -305,7 +355,10 @@ const ParticipantOnboardingCards = ({
 						>
 							{currentCard?.type === "microphone" && (
 								<Button
-									onClick={nextSlide}
+									onClick={() => {
+										setMicSkipped(true);
+										nextSlide();
+									}}
 									variant="subtle"
 									color="primary"
 									size="md"

--- a/echo/frontend/src/hooks/useVisitorBeacon.ts
+++ b/echo/frontend/src/hooks/useVisitorBeacon.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+
+import { pingVisitor, type VisitorPingTelemetry } from "@/lib/api";
+import {
+	readBatteryTelemetry,
+	readDeviceLabel,
+	readNetworkTelemetry,
+} from "@/lib/deviceTelemetry";
+import { bumpScanCount, getVisitorId } from "@/lib/visitorId";
+
+type BeaconArgs = {
+	stage: string;
+	name?: string | null;
+	tags?: string[];
+	tagsPreselected?: boolean;
+	enabled?: boolean;
+};
+
+// Every 10s, matching the host funnel's expectation, plus an immediate beacon
+// whenever the stage (or reported name/tags) changes.
+const PING_INTERVAL_MS = 10000;
+
+/**
+ * Reports a portal visitor's funnel stage to the server while they onboard,
+ * before any conversation exists. Keyed by a device-persistent visitor id so a
+ * re-scan is recognised as the same dot.
+ */
+export const useVisitorBeacon = (
+	projectId: string | undefined,
+	{ stage, name, tags, tagsPreselected, enabled = true }: BeaconArgs,
+): void => {
+	const scanCountRef = useRef<number | null>(null);
+	const tagsKey = (tags ?? []).join("|");
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: tags is folded into tagsKey to keep a stable dep
+	useEffect(() => {
+		if (!enabled || !projectId) return;
+		const visitorId = getVisitorId(projectId);
+		if (scanCountRef.current === null) {
+			scanCountRef.current = bumpScanCount(projectId);
+		}
+		let cancelled = false;
+		const send = async () => {
+			const battery = await readBatteryTelemetry();
+			if (cancelled) return;
+			const telemetry: VisitorPingTelemetry = {
+				stage,
+				name: name?.trim() || undefined,
+				tags: tags && tags.length ? tags : undefined,
+				tags_preselected: tagsPreselected || undefined,
+				scan_count: scanCountRef.current ?? undefined,
+				device: readDeviceLabel(),
+				network: readNetworkTelemetry(),
+				battery,
+			};
+			void pingVisitor(projectId, visitorId, telemetry);
+		};
+		void send();
+		const interval = setInterval(() => void send(), PING_INTERVAL_MS);
+		return () => {
+			cancelled = true;
+			clearInterval(interval);
+		};
+	}, [enabled, projectId, stage, name, tagsKey, tagsPreselected]);
+};

--- a/echo/frontend/src/lib/api.ts
+++ b/echo/frontend/src/lib/api.ts
@@ -366,6 +366,8 @@ export type ParticipantPingTelemetry = {
 	state?: string;
 	mode?: "voice" | "text";
 	screen?: string;
+	/** The pre-conversation funnel dot this recording grew out of. */
+	visitor_id?: string;
 	network?: {
 		online?: boolean;
 		effective_type?: string;
@@ -373,6 +375,42 @@ export type ParticipantPingTelemetry = {
 		rtt?: number;
 	};
 	battery?: { level?: number; charging?: boolean };
+};
+
+export type VisitorPingTelemetry = {
+	stage?: string;
+	name?: string;
+	tags?: string[];
+	tags_preselected?: boolean;
+	scan_count?: number;
+	device?: string;
+	network?: {
+		online?: boolean;
+		effective_type?: string;
+		downlink?: number;
+		rtt?: number;
+	};
+	battery?: { level?: number; charging?: boolean };
+};
+
+/**
+ * Pre-conversation funnel beacon. Reports where a visitor is in onboarding
+ * (scanned / terms / mic / profile) before a conversation exists, keyed by a
+ * device-persistent visitor id. Best-effort; failures are swallowed.
+ */
+export const pingVisitor = async (
+	projectId: string,
+	visitorId: string,
+	telemetry?: VisitorPingTelemetry,
+): Promise<void> => {
+	try {
+		await apiNoAuth.post(
+			`/participant/projects/${projectId}/visitors/${visitorId}/ping`,
+			telemetry ?? undefined,
+		);
+	} catch {
+		// Non-critical; the next beacon re-establishes funnel presence.
+	}
 };
 
 /**

--- a/echo/frontend/src/lib/deviceTelemetry.ts
+++ b/echo/frontend/src/lib/deviceTelemetry.ts
@@ -1,0 +1,72 @@
+// Best-effort device telemetry for the host monitor. The Network Information
+// and Battery Status APIs are not on every browser (Safari/Firefox lack
+// Battery entirely), so each degrades to `undefined` and is simply omitted.
+
+export type NetworkTelemetry = {
+	online?: boolean;
+	effective_type?: string;
+	downlink?: number;
+	rtt?: number;
+};
+
+export type BatteryTelemetry = {
+	level?: number;
+	charging?: boolean;
+};
+
+export const readNetworkTelemetry = (): NetworkTelemetry | undefined => {
+	const nav = navigator as Navigator & {
+		connection?: { effectiveType?: string; downlink?: number; rtt?: number };
+	};
+	const conn = nav.connection;
+	const online =
+		typeof navigator.onLine === "boolean" ? navigator.onLine : undefined;
+	if (!conn && online === undefined) return undefined;
+	return {
+		online,
+		effective_type: conn?.effectiveType,
+		downlink: conn?.downlink,
+		rtt: conn?.rtt,
+	};
+};
+
+export const readBatteryTelemetry = async (): Promise<
+	BatteryTelemetry | undefined
+> => {
+	const nav = navigator as Navigator & {
+		getBattery?: () => Promise<{ level: number; charging: boolean }>;
+	};
+	if (typeof nav.getBattery !== "function") return undefined;
+	try {
+		const battery = await nav.getBattery();
+		return { level: battery.level, charging: battery.charging };
+	} catch {
+		return undefined;
+	}
+};
+
+// A short, human-readable device hint (browser + platform) for the host's
+// diagnostic drilldown — never a full fingerprint.
+export const readDeviceLabel = (): string | undefined => {
+	const ua = navigator.userAgent;
+	if (!ua) return undefined;
+	const browser = /edg/i.test(ua)
+		? "Edge"
+		: /chrome|crios/i.test(ua)
+			? "Chrome"
+			: /firefox|fxios/i.test(ua)
+				? "Firefox"
+				: /safari/i.test(ua)
+					? "Safari"
+					: "Browser";
+	const platform = /iphone|ipad|ipod/i.test(ua)
+		? "iOS"
+		: /android/i.test(ua)
+			? "Android"
+			: /mac/i.test(ua)
+				? "Mac"
+				: /win/i.test(ua)
+					? "Windows"
+					: "";
+	return platform ? `${browser} · ${platform}` : browser;
+};

--- a/echo/frontend/src/lib/visitorId.ts
+++ b/echo/frontend/src/lib/visitorId.ts
@@ -1,0 +1,44 @@
+// A client-minted, device-persistent id for a portal visitor, so the host
+// funnel can track someone from the moment they scan the QR — before any
+// conversation exists — and recognise a re-scan from the same device instead
+// of drawing a phantom new dot. It is an anonymous random UUID (no PII).
+
+const visitorKey = (projectId: string) => `dembrane:visitor:${projectId}`;
+const scanKey = (projectId: string) => `dembrane:visitor-scans:${projectId}`;
+
+const randomId = (): string => {
+	try {
+		if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+			return crypto.randomUUID();
+		}
+	} catch {
+		// fall through
+	}
+	return `v-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+};
+
+/** Stable visitor id for this device + project, minted once and reused. */
+export const getVisitorId = (projectId: string): string => {
+	try {
+		const existing = localStorage.getItem(visitorKey(projectId));
+		if (existing) return existing;
+		const fresh = randomId();
+		localStorage.setItem(visitorKey(projectId), fresh);
+		return fresh;
+	} catch {
+		// Private mode / storage disabled: fall back to an ephemeral id.
+		return randomId();
+	}
+};
+
+/** Increment and return how many times this device has started a portal
+ * session for the project — the "scanned twice" signal. */
+export const bumpScanCount = (projectId: string): number => {
+	try {
+		const next = (Number(localStorage.getItem(scanKey(projectId))) || 0) + 1;
+		localStorage.setItem(scanKey(projectId), String(next));
+		return next;
+	} catch {
+		return 1;
+	}
+};


### PR DESCRIPTION
Second of three. The portal now beacons each funnel stage, so the host can see people from the QR scan onward — not just once they're recording.

## What it does
- **`visitorId.ts`** — device-persistent `localStorage` visitor id + `scan_count` (re-scan detection). **`deviceTelemetry.ts`** — shared network/battery/device reads.
- **`useVisitorBeacon`** — pings `POST /participant/projects/{id}/visitors/{vid}/ping` every 10s + on stage change (best-effort network/battery/device).
- **Stages** reported from `ParticipantOnboardingCards`: `scanned → terms → mic_ok / mic_skipped / mic_blocked → profile`. Mic outcome is explicit — the Skip button sets `mic_skipped`, and `MicrophoneTest` now surfaces a blocked mic via a new `onMicAccessDenied` callback (your "show that they skipped / got stuck").
- **Preselected tags** from the QR URL (`?tags=`) are resolved to labels and flagged `tags_preselected`.
- The **recording-screen ping carries `visitor_id`** so a graduated dot dedupes against its live conversation.

## Scope
Frontend-only, additive: the funnel *data* flows now, but the monitor UI doesn't render it yet — that's PR (c). So this is inert on its own (as expected). tsc + biome clean; no new strings.

## Deferred to (c)
Reporting the **typed name at the profile stage** (needs lifting the initiate-form draft). Today pre-initiate dots are anonymous; the name appears once recording. I'll wire it with the funnel UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH