### PR TITLE
Monitor funnel: dots-only lanes + hover-to-highlight the card below

### DIFF
--- a/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
@@ -37,19 +37,17 @@ import {
 	useConversationMonitor,
 } from "@/hooks/useConversationMonitor";
 
-const weakNetwork = (network: {
-	online?: boolean;
-	effective_type?: string;
-} | null): boolean => {
+const weakNetwork = (
+	network: { online?: boolean; effective_type?: string } | null,
+): boolean => {
 	if (!network) return false;
 	if (network.online === false) return true;
 	return network.effective_type === "2g" || network.effective_type === "slow-2g";
 };
 
-const lowBattery = (battery: {
-	level?: number;
-	charging?: boolean;
-} | null): boolean => {
+const lowBattery = (
+	battery: { level?: number; charging?: boolean } | null,
+): boolean => {
 	if (!battery || battery.charging) return false;
 	return typeof battery.level === "number" && battery.level <= 0.15;
 };
@@ -63,154 +61,76 @@ const relativeTime = (stamp: string | null): string => {
 	}
 };
 
-const micStageMeta = (
-	stage: FunnelStage,
-): { color: string; label: string } | null => {
-	if (stage === "mic_ok") return { color: "green", label: t`Mic OK` };
-	if (stage === "mic_skipped") return { color: "gray", label: t`Mic skipped` };
-	if (stage === "mic_blocked") return { color: "red", label: t`Mic blocked` };
+const micStageLabel = (stage: FunnelStage): string | null => {
+	if (stage === "mic_ok") return t`Mic OK`;
+	if (stage === "mic_skipped") return t`Mic skipped`;
+	if (stage === "mic_blocked") return t`Mic blocked`;
 	return null;
 };
 
-// ── selection for the same-screen drilldown ──────────────────────────
+const visitorDotColor = (stage: FunnelStage): string => {
+	if (stage === "mic_blocked") return "var(--mantine-color-red-6)";
+	if (stage === "mic_ok") return "var(--mantine-color-green-6)";
+	if (stage === "profile") return "var(--mantine-color-primary-6)";
+	return "var(--mantine-color-gray-5)";
+};
+
 type Selection =
 	| { kind: "visitor"; visitor: FunnelVisitor }
 	| { kind: "conversation"; conversation: MonitorConversation };
 
-const VisitorDot = ({
-	visitor,
+// A small clickable dot; the atom of every lane. Hovering a recording dot
+// highlights its detailed card in the list below.
+const Dot = ({
+	color,
+	label,
+	pulse,
+	warn,
+	icon,
 	onOpen,
+	onHoverStart,
+	onHoverEnd,
 }: {
-	visitor: FunnelVisitor;
+	color: string;
+	label: string;
+	pulse?: boolean;
+	warn?: boolean;
+	icon?: React.ReactNode;
 	onOpen: () => void;
-}) => {
-	const mic = micStageMeta(visitor.stage);
-	const warn = weakNetwork(visitor.network) || lowBattery(visitor.battery);
-	const color =
-		visitor.stage === "mic_blocked"
-			? "var(--mantine-color-red-6)"
-			: visitor.stage === "mic_ok"
-				? "var(--mantine-color-green-6)"
-				: "var(--mantine-color-gray-5)";
-	return (
-		<Tooltip
-			label={mic?.label ?? (visitor.name?.trim() || t`Anonymous`)}
-			openDelay={200}
-			withArrow
+	onHoverStart?: () => void;
+	onHoverEnd?: () => void;
+}) => (
+	<Tooltip label={label} openDelay={150} withArrow>
+		<button
+			type="button"
+			onClick={onOpen}
+			onMouseEnter={onHoverStart}
+			onMouseLeave={onHoverEnd}
+			onFocus={onHoverStart}
+			onBlur={onHoverEnd}
+			aria-label={label}
+			className="relative flex h-7 w-7 items-center justify-center rounded-full transition-transform hover:scale-110"
+			style={{ backgroundColor: color }}
 		>
-			<button
-				type="button"
-				onClick={onOpen}
-				aria-label={visitor.name?.trim() || t`Visitor`}
-				className="relative flex h-7 w-7 items-center justify-center rounded-full transition-transform hover:scale-110"
-				style={{ backgroundColor: color, opacity: 0.9 }}
-			>
-				{visitor.stage === "mic_ok" && (
-					<CheckIcon size={12} color="white" weight="bold" />
-				)}
-				{visitor.stage === "mic_blocked" && (
-					<WarningCircleIcon size={13} color="white" weight="bold" />
-				)}
-				{warn && (
-					<span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-orange-400" />
-				)}
-			</button>
-		</Tooltip>
-	);
-};
-
-const VisitorMiniCard = ({
-	visitor,
-	onOpen,
-}: {
-	visitor: FunnelVisitor;
-	onOpen: () => void;
-}) => (
-	<Card
-		withBorder
-		p="xs"
-		radius="md"
-		className="cursor-pointer transition-colors hover:!border-primary-400"
-		onClick={onOpen}
-	>
-		<Group gap={6} justify="space-between" wrap="nowrap">
-			<Text size="sm" fw={500} truncate>
-				{visitor.name?.trim() || t`Anonymous`}
-			</Text>
-			{visitor.scan_count > 1 && (
-				<Badge size="xs" color="gray" variant="light">
-					<Trans>×{visitor.scan_count}</Trans>
-				</Badge>
+			{pulse && (
+				<span
+					className="absolute inset-0 rounded-full animate-ping"
+					style={{ backgroundColor: color, opacity: 0.5 }}
+				/>
 			)}
-		</Group>
-		{visitor.tags.length > 0 && (
-			<Group gap={4} mt={4} wrap="wrap">
-				{visitor.tags.slice(0, 3).map((tag) => (
-					<Badge
-						key={tag}
-						size="xs"
-						variant="light"
-						color={visitor.tags_preselected ? "primary" : "gray"}
-					>
-						{tag}
-					</Badge>
-				))}
-			</Group>
-		)}
-	</Card>
-);
-
-const RecordingCard = ({
-	conversation,
-	onOpen,
-}: {
-	conversation: MonitorConversation;
-	onOpen: () => void;
-}) => (
-	<Card
-		withBorder
-		p="xs"
-		radius="md"
-		className="cursor-pointer transition-colors hover:!border-primary-400"
-		onClick={onOpen}
-	>
-		<Group gap={6} justify="space-between" wrap="nowrap">
-			<Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
-				<span className="inline-block h-2 w-2 shrink-0 rounded-full bg-red-500 animate-pulse" />
-				<Text size="sm" fw={500} truncate>
-					{conversation.label?.trim() || t`Anonymous`}
-				</Text>
-			</Group>
-			{conversation.has_error && (
-				<WarningCircleIcon size={15} className="shrink-0 text-red-500" />
+			{icon}
+			{warn && (
+				<span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-orange-400" />
 			)}
-		</Group>
-		<Group gap={4} mt={4} wrap="wrap">
-			{conversation.state === "paused" && (
-				<Badge size="xs" color="yellow" variant="light">
-					<Trans>Paused</Trans>
-				</Badge>
-			)}
-			{conversation.state === "verifying" && (
-				<Badge size="xs" color="blue" variant="light">
-					<Trans>Verifying</Trans>
-				</Badge>
-			)}
-			{conversation.transcription_status === "transcribing" && (
-				<Badge size="xs" color="blue" variant="light">
-					<Trans>Transcribing</Trans>
-				</Badge>
-			)}
-		</Group>
-	</Card>
+		</button>
+	</Tooltip>
 );
 
 type Lane = {
 	key: string;
 	label: string;
-	dots?: FunnelVisitor[];
-	cards?: FunnelVisitor[];
-	recordings?: MonitorConversation[];
+	visitors: FunnelVisitor[];
+	recordings: MonitorConversation[];
 	count: number;
 };
 
@@ -218,14 +138,16 @@ const FunnelLane = ({
 	lane,
 	onOpenVisitor,
 	onOpenConversation,
+	onHoverConversation,
 }: {
 	lane: Lane;
 	onOpenVisitor: (visitor: FunnelVisitor) => void;
 	onOpenConversation: (conversation: MonitorConversation) => void;
+	onHoverConversation: (id: string | null) => void;
 }) => {
 	const [opened, { toggle }] = useDisclosure(true);
 	return (
-		<Stack gap="xs" className="min-w-[190px] flex-1">
+		<Stack gap="xs" className="min-w-[150px] flex-1">
 			<Group
 				gap="xs"
 				align="center"
@@ -250,38 +172,42 @@ const FunnelLane = ({
 				</Badge>
 			</Group>
 			<Collapse in={opened}>
-				<Stack gap="xs">
-					{lane.dots && lane.dots.length > 0 && (
-						<Group gap={6} wrap="wrap">
-							{lane.dots.map((visitor) => (
-								<VisitorDot
-									key={visitor.id}
-									visitor={visitor}
-									onOpen={() => onOpenVisitor(visitor)}
-								/>
-							))}
-						</Group>
-					)}
-					{lane.cards?.map((visitor) => (
-						<VisitorMiniCard
-							key={visitor.id}
-							visitor={visitor}
-							onOpen={() => onOpenVisitor(visitor)}
-						/>
-					))}
-					{lane.recordings?.map((conversation) => (
-						<RecordingCard
-							key={conversation.id}
-							conversation={conversation}
-							onOpen={() => onOpenConversation(conversation)}
-						/>
-					))}
-					{lane.count === 0 && (
-						<Text size="xs" c="dimmed" className="pl-1">
-							<Trans>Nobody here yet</Trans>
-						</Text>
-					)}
-				</Stack>
+				{lane.count === 0 ? (
+					<Text size="xs" c="dimmed" className="pl-1">
+						<Trans>Nobody here yet</Trans>
+					</Text>
+				) : (
+					<Group gap={8} wrap="wrap">
+						{lane.visitors.map((visitor) => (
+							<Dot
+								key={visitor.id}
+								color={visitorDotColor(visitor.stage)}
+								label={micStageLabel(visitor.stage) ?? visitor.name?.trim() ?? t`Anonymous`}
+								warn={weakNetwork(visitor.network) || lowBattery(visitor.battery)}
+								icon={
+									visitor.stage === "mic_ok" ? (
+										<CheckIcon size={12} color="white" weight="bold" />
+									) : visitor.stage === "mic_blocked" ? (
+										<WarningCircleIcon size={13} color="white" weight="bold" />
+									) : undefined
+								}
+								onOpen={() => onOpenVisitor(visitor)}
+							/>
+						))}
+						{lane.recordings.map((conversation) => (
+							<Dot
+								key={conversation.id}
+								color="var(--mantine-color-red-6)"
+								pulse
+								label={conversation.label?.trim() || t`Anonymous`}
+								warn={weakNetwork(conversation.network) || lowBattery(conversation.battery)}
+								onOpen={() => onOpenConversation(conversation)}
+								onHoverStart={() => onHoverConversation(conversation.id)}
+								onHoverEnd={() => onHoverConversation(null)}
+							/>
+						))}
+					</Group>
+				)}
 			</Collapse>
 		</Stack>
 	);
@@ -408,39 +334,43 @@ const ConversationDrilldown = ({
 	);
 };
 
-export const LiveFunnelSection = ({ projectId }: { projectId: string }) => {
+export const LiveFunnelSection = ({
+	projectId,
+	onHoverConversation,
+}: {
+	projectId: string;
+	/** Notifies the parent which recording is hovered, so the detailed card
+	 * below can highlight. */
+	onHoverConversation?: (id: string | null) => void;
+}) => {
 	const { funnel, conversations } = useConversationMonitor(projectId);
 	const { workspaceId } = useParams<{ workspaceId: string }>();
 	const base =
-		workspaceId && projectId
-			? `/w/${workspaceId}/projects/${projectId}`
-			: null;
+		workspaceId && projectId ? `/w/${workspaceId}/projects/${projectId}` : null;
 	const [selected, setSelected] = useState<Selection | null>(null);
 
 	const lanes = useMemo<Lane[]>(() => {
 		const byStage = (stages: FunnelStage[]) =>
 			funnel.visitors.filter((v) => stages.includes(v.stage));
 		const recording = conversations.filter((c) => c.is_live);
-		const scanned = byStage(["scanned"]);
-		const terms = byStage(["terms"]);
-		const mic = byStage(["mic_ok", "mic_skipped", "mic_blocked"]);
-		const profile = byStage(["profile"]);
+		const make = (
+			key: string,
+			label: string,
+			visitors: FunnelVisitor[],
+			recordings: MonitorConversation[] = [],
+		): Lane => ({
+			key,
+			label,
+			visitors,
+			recordings,
+			count: visitors.length + recordings.length,
+		});
 		return [
-			{ key: "scanned", label: t`Scanned`, dots: scanned, count: scanned.length },
-			{ key: "terms", label: t`Terms`, dots: terms, count: terms.length },
-			{ key: "mic", label: t`Mic check`, dots: mic, count: mic.length },
-			{
-				key: "profile",
-				label: t`Profile`,
-				cards: profile,
-				count: profile.length,
-			},
-			{
-				key: "recording",
-				label: t`Recording`,
-				recordings: recording,
-				count: recording.length,
-			},
+			make("scanned", t`Scanned`, byStage(["scanned"])),
+			make("terms", t`Terms`, byStage(["terms"])),
+			make("mic", t`Mic check`, byStage(["mic_ok", "mic_skipped", "mic_blocked"])),
+			make("profile", t`Profile`, byStage(["profile"])),
+			make("recording", t`Recording`, [], recording),
 		];
 	}, [funnel.visitors, conversations]);
 
@@ -467,7 +397,7 @@ export const LiveFunnelSection = ({ projectId }: { projectId: string }) => {
 					</Text>
 				</Card>
 			) : (
-				<Box className="flex gap-4 overflow-x-auto pb-2">
+				<Box className="flex flex-wrap gap-x-6 gap-y-4">
 					{lanes.map((lane) => (
 						<FunnelLane
 							key={lane.key}
@@ -478,6 +408,7 @@ export const LiveFunnelSection = ({ projectId }: { projectId: string }) => {
 							onOpenConversation={(conversation) =>
 								setSelected({ kind: "conversation", conversation })
 							}
+							onHoverConversation={(id) => onHoverConversation?.(id)}
 						/>
 					))}
 				</Box>

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
@@ -194,9 +194,11 @@ const TranscriptionBadge = ({
 const MonitorRow = ({
 	conversation,
 	to,
+	highlighted,
 }: {
 	conversation: MonitorConversation;
 	to: string | null;
+	highlighted?: boolean;
 }) => {
 	const label = conversation.label?.trim() || t`Anonymous participant`;
 	const weakNetwork = isWeakNetwork(conversation);
@@ -207,11 +209,7 @@ const MonitorRow = ({
 			withBorder
 			p="sm"
 			radius="md"
-			className={
-				to
-					? "transition-colors hover:!border-primary-400 cursor-pointer"
-					: undefined
-			}
+			className={`transition-colors ${to ? "hover:!border-primary-400 cursor-pointer" : ""} ${highlighted ? "!border-primary-500 ring-2 ring-primary-200" : ""}`}
 		>
 			<Stack gap={8}>
 				<Group justify="space-between" align="center" wrap="nowrap">
@@ -329,9 +327,11 @@ const groupByTag = (conversations: MonitorConversation[]): TagGroup[] => {
 const TagGroupSection = ({
 	group,
 	base,
+	highlightedConversationId,
 }: {
 	group: TagGroup;
 	base: string | null;
+	highlightedConversationId?: string | null;
 }) => {
 	const [opened, { toggle }] = useDisclosure(true);
 	const [expanded, setExpanded] = useState(false);
@@ -376,6 +376,7 @@ const TagGroupSection = ({
 							key={conversation.id}
 							conversation={conversation}
 							to={base ? `${base}/conversations/${conversation.id}` : null}
+							highlighted={conversation.id === highlightedConversationId}
 						/>
 					))}
 					{overflow > 0 && (
@@ -397,11 +398,14 @@ const TagGroupSection = ({
 export const LiveMonitorSection = ({
 	projectId,
 	standalone = false,
+	highlightedConversationId,
 }: {
 	projectId: string;
 	/** On the dedicated Monitor page, show an empty state instead of
 	 * collapsing to nothing when there is no recent activity. */
 	standalone?: boolean;
+	/** Row to highlight (hovered from the funnel above). */
+	highlightedConversationId?: string | null;
 }) => {
 	const { workspaceId } = useParams<{ workspaceId: string }>();
 	const { conversations, summary } = useConversationMonitor(projectId);
@@ -468,7 +472,12 @@ export const LiveMonitorSection = ({
 
 			<Stack gap="lg">
 				{groups.map((group) => (
-					<TagGroupSection key={group.key} group={group} base={base} />
+					<TagGroupSection
+						key={group.key}
+						group={group}
+						base={base}
+						highlightedConversationId={highlightedConversationId}
+					/>
 				))}
 			</Stack>
 		</Stack>

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -489,7 +489,7 @@ msgstr "{0, plural, one {# conversation} other {# conversations}}"
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -544,12 +544,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# tag} other {# tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr "{sent} invites sent"
 msgid "{sentCount} invites sent."
 msgstr "{sentCount} invites sent."
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -1023,10 +1023,9 @@ msgstr "+{hiddenCount} conversations"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #: src/routes/participant/ParticipantConversation.tsx:574
 #: src/routes/participant/ParticipantConversation.tsx:649
@@ -1974,9 +1973,8 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1985,7 +1983,7 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Anonymous host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
@@ -1993,7 +1991,7 @@ msgstr ""
 #~ msgid "Anonymous Participant"
 #~ msgstr "Anonymous Participant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3351,7 +3349,7 @@ msgid "conversation"
 msgstr "conversation"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr "Conversation"
 
@@ -3574,7 +3572,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr "Could not load the rollup. Check auth and backend logs."
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4813,7 +4811,7 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6539,7 +6537,7 @@ msgstr "Jump to"
 msgid "Just a moment"
 msgstr "Just a moment"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6631,7 +6629,7 @@ msgid "Language"
 msgstr "Language"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6657,7 +6655,7 @@ msgid "Last saved {0}"
 msgstr "Last saved {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6823,11 +6821,11 @@ msgstr "Live audio level:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live audio level:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6835,7 +6833,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -7022,8 +7020,8 @@ msgstr "Longest first"
 msgid "Longest First"
 msgstr "Longest First"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -7212,19 +7210,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Messages from {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -7256,7 +7254,7 @@ msgstr "Mode"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr "Monitor"
@@ -7885,7 +7883,7 @@ msgstr "No projects match."
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -8035,7 +8033,7 @@ msgstr "No workspaces match \"{search}\"."
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr "No workspaces yet. Create your first one to get started."
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8359,7 +8357,7 @@ msgstr "Open all"
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr "Open conversation"
 
@@ -8749,7 +8747,7 @@ msgstr "Participant Emails"
 msgid "Participant Features"
 msgstr "Participant Features"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr "Participant name"
 
@@ -8840,7 +8838,6 @@ msgid "Pause reading"
 msgstr "Pause reading"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9491,7 +9488,7 @@ msgstr "Processing <0>{totalCount, plural, one {# conversation} other {# convers
 msgid "Processing your retranscription request..."
 msgstr "Processing your retranscription request..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9868,7 +9865,7 @@ msgid "Record another conversation"
 msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10589,7 +10586,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10642,7 +10639,7 @@ msgstr "Save template"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr "Saved"
 
@@ -10662,12 +10659,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scan the QR code or copy the secret into your app."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11315,7 +11312,7 @@ msgstr "Show"
 msgid "Show {hidden} more"
 msgstr "Show {hidden} more"
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -12008,7 +12005,7 @@ msgid "Templates"
 msgstr "Templates"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12779,8 +12776,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -13132,7 +13129,7 @@ msgstr "Unsaved changes"
 msgid "Unsubscribe"
 msgstr "Unsubscribe"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13598,7 +13595,6 @@ msgid "Verify Topics"
 msgstr "Verify Topics"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13674,10 +13670,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13719,7 +13715,7 @@ msgstr "Waiting for conversations to finish before generating a report."
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13884,8 +13880,8 @@ msgstr "We've added organisations so you can organize projects and share them wi
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -14082,7 +14078,7 @@ msgstr "When finishing the conversation, participants who haven't verified yet w
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -313,7 +313,7 @@ msgstr ""
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -368,12 +368,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# Tag} other {# Tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -753,11 +753,11 @@ msgstr ""
 msgid "{sentCount} invites sent."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -836,10 +836,9 @@ msgstr "+{hiddenCount} Unterhaltungen"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #~ msgid "<0>Wait </0>{0}:{1}"
 #~ msgstr "<0>Warte </0>{0}:{1}"
@@ -1781,9 +1780,8 @@ msgstr "Anonymisierte Unterhaltung"
 msgid "Anonymized conversation"
 msgstr "Anonymisierte Unterhaltung"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1792,11 +1790,11 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Anonymer Host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3128,7 +3126,7 @@ msgid "conversation"
 msgstr "Gespräch"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr ""
 
@@ -3351,7 +3349,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4579,7 +4577,7 @@ msgstr "Von dem Teilnehmer auf dem Portal eingetragen"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6259,7 +6257,7 @@ msgstr ""
 msgid "Just a moment"
 msgstr "Einen Moment bitte"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6350,7 +6348,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6376,7 +6374,7 @@ msgid "Last saved {0}"
 msgstr "Zuletzt gespeichert am {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6550,11 +6548,11 @@ msgstr "Live Audiopegel:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live Audiopegel:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6562,7 +6560,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Live Vorschau"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -6748,8 +6746,8 @@ msgstr ""
 msgid "Longest First"
 msgstr "Längste zuerst"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -6938,19 +6936,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Nachrichten von {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -6981,7 +6979,7 @@ msgstr "Modus"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr ""
@@ -7603,7 +7601,7 @@ msgstr ""
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "Keine Zitate verfügbar. Generieren Sie Zitate für dieses Gespräch, indem Sie <0><1>die Projektbibliothek</1></0> besuchen."
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -7749,7 +7747,7 @@ msgstr ""
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8070,7 +8068,7 @@ msgstr ""
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr ""
 
@@ -8454,7 +8452,7 @@ msgstr "Teilnehmer-E-Mails"
 msgid "Participant Features"
 msgstr "Teilnehmer-Funktionen"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8652,7 +8650,6 @@ msgid "Pause reading"
 msgstr "Vorlesen pausieren"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9285,7 +9282,7 @@ msgstr "<0>{totalCount, plural, one {# Unterhaltung} other {# Unterhaltungen}}</
 msgid "Processing your retranscription request..."
 msgstr "Ihre Hertranskription anfragen werden verarbeitet..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9644,7 +9641,7 @@ msgid "Record another conversation"
 msgstr "Ein weiteres Gespräch aufnehmen"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10352,7 +10349,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10405,7 +10402,7 @@ msgstr "Vorlage speichern"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr ""
 
@@ -10425,12 +10422,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scannen Sie den QR-Code oder kopieren Sie das Geheimnis in Ihre App."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11073,7 +11070,7 @@ msgstr "Anzeigen"
 msgid "Show {hidden} more"
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -11752,7 +11749,7 @@ msgid "Templates"
 msgstr "Vorlagen"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12492,8 +12489,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -12836,7 +12833,7 @@ msgstr "Ungespeicherte Änderungen"
 msgid "Unsubscribe"
 msgstr "Abmelden"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13293,7 +13290,6 @@ msgid "Verify Topics"
 msgstr "Verify Themen"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13367,10 +13363,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13408,7 +13404,7 @@ msgstr "Warten auf den Abschluss der Gespräche, bevor ein Bericht erstellt wird
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13568,8 +13564,8 @@ msgstr ""
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -13764,7 +13760,7 @@ msgstr "Wenn das Gespräch abgeschlossen wird, werden Teilnehmer, die noch nicht
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -489,7 +489,7 @@ msgstr "{0, plural, one {# conversation} other {# conversations}}"
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr "{0, plural, one {# live} other {# live}}"
 
@@ -544,12 +544,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# tag} other {# tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr "{0, plural, one {# transcribing} other {# transcribing}}"
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr "{0, plural, one {# with errors} other {# with errors}}"
 
@@ -939,11 +939,11 @@ msgstr "{sent} invites sent"
 msgid "{sentCount} invites sent."
 msgstr "{sentCount} invites sent."
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr "{tag} (preselected)"
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr "{totalActive, plural, one {# active} other {# active}}"
 
@@ -1023,10 +1023,9 @@ msgstr "+{hiddenCount} conversations"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr "×{0}"
+#~ msgid "×{0}"
+#~ msgstr "×{0}"
 
 #: src/routes/participant/ParticipantConversation.tsx:574
 #: src/routes/participant/ParticipantConversation.tsx:649
@@ -1974,9 +1973,8 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr "Anonymous"
 
@@ -1985,7 +1983,7 @@ msgstr "Anonymous"
 #~ msgid "Anonymous host"
 #~ msgstr "Anonymous host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr "Anonymous participant"
 
@@ -1993,7 +1991,7 @@ msgstr "Anonymous participant"
 #~ msgid "Anonymous Participant"
 #~ msgstr "Anonymous Participant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr "Anonymous visitor"
 
@@ -3351,7 +3349,7 @@ msgid "conversation"
 msgstr "conversation"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr "Conversation"
 
@@ -3574,7 +3572,7 @@ msgstr "Could not load payments. Check auth and backend logs."
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr "Could not load the rollup. Check auth and backend logs."
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -4813,7 +4811,7 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6539,7 +6537,7 @@ msgstr "Jump to"
 msgid "Just a moment"
 msgstr "Just a moment"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr "just now"
 
@@ -6631,7 +6629,7 @@ msgid "Language"
 msgstr "Language"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr "Last activity {0}"
 
@@ -6657,7 +6655,7 @@ msgid "Last saved {0}"
 msgstr "Last saved {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr "Last seen {0}"
 
@@ -6823,11 +6821,11 @@ msgstr "Live audio level:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live audio level:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr "Live monitoring"
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr "Live participant flow"
 
@@ -6835,7 +6833,7 @@ msgstr "Live participant flow"
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 
@@ -7022,8 +7020,8 @@ msgstr "Longest first"
 msgid "Longest First"
 msgstr "Longest First"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr "Low battery"
 
@@ -7212,19 +7210,19 @@ msgstr "Message limit reached"
 msgid "Messages from {0} - {1}%"
 msgstr "Messages from {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr "Mic blocked"
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr "Mic check"
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr "Mic OK"
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr "Mic skipped"
 
@@ -7256,7 +7254,7 @@ msgstr "Mode"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr "Monitor"
@@ -7885,7 +7883,7 @@ msgstr "No projects match."
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr "No recent activity"
 
@@ -8035,7 +8033,7 @@ msgstr "No workspaces match \"{search}\"."
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr "No workspaces yet. Create your first one to get started."
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr "Nobody here yet"
 
@@ -8359,7 +8357,7 @@ msgstr "Open all"
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr "Open conversation"
 
@@ -8749,7 +8747,7 @@ msgstr "Participant Emails"
 msgid "Participant Features"
 msgstr "Participant Features"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr "Participant name"
 
@@ -8840,7 +8838,6 @@ msgid "Pause reading"
 msgstr "Pause reading"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr "Paused"
 
@@ -9491,7 +9488,7 @@ msgstr "Processing <0>{totalCount, plural, one {# conversation} other {# convers
 msgid "Processing your retranscription request..."
 msgstr "Processing your retranscription request..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr "Profile"
 
@@ -9868,7 +9865,7 @@ msgid "Record another conversation"
 msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr "Recording"
 
@@ -10589,7 +10586,7 @@ msgstr "Sales invoice issued."
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10642,7 +10639,7 @@ msgstr "Save template"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr "Saved"
 
@@ -10662,12 +10659,12 @@ msgstr "Scan or click the QR code to open the feedback portal"
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scan the QR code or copy the secret into your app."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr "Scanned"
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr "Scanned {0} times"
 
@@ -11315,7 +11312,7 @@ msgstr "Show"
 msgid "Show {hidden} more"
 msgstr "Show {hidden} more"
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr "Show {overflow} more"
 
@@ -12008,7 +12005,7 @@ msgid "Templates"
 msgstr "Templates"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr "Terms"
 
@@ -12779,8 +12776,8 @@ msgid "Transcribed"
 msgstr "Transcribed"
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr "Transcribing"
+#~ msgid "Transcribing"
+#~ msgstr "Transcribing"
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -13132,7 +13129,7 @@ msgstr "Unsaved changes"
 msgid "Unsubscribe"
 msgstr "Unsubscribe"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr "Untagged"
 
@@ -13598,7 +13595,6 @@ msgid "Verify Topics"
 msgstr "Verify Topics"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr "Verifying"
 
@@ -13674,10 +13670,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr "Visible to everyone in this workspace. Leave off to keep it personal."
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr "Visitor"
+#~ msgid "Visitor"
+#~ msgstr "Visitor"
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr "Visitor details"
 
@@ -13719,7 +13715,7 @@ msgstr "Waiting for conversations to finish before generating a report."
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr "Watch live recordings, transcription progress, and errors across this project as they happen."
 
@@ -13884,8 +13880,8 @@ msgstr "We've added organisations so you can organize projects and share them wi
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr "Weak network"
 
@@ -14082,7 +14078,7 @@ msgstr "When finishing the conversation, participants who haven't verified yet w
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr "When participants scan the QR code, they'll appear here and move across the stages in real time."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -313,7 +313,7 @@ msgstr ""
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -368,12 +368,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# etiqueta} other {# etiquetas}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -753,11 +753,11 @@ msgstr ""
 msgid "{sentCount} invites sent."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -836,10 +836,9 @@ msgstr "+{hiddenCount} conversaciones"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #~ msgid "<0>Wait </0>{0}:{1}"
 #~ msgstr "<0>Espera </0>{0}:{1}"
@@ -1781,9 +1780,8 @@ msgstr "conversación anónima"
 msgid "Anonymized conversation"
 msgstr "Conversación anónima"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1792,11 +1790,11 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Host anónimo"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3131,7 +3129,7 @@ msgid "conversation"
 msgstr "conversación"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr ""
 
@@ -3354,7 +3352,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4582,7 +4580,7 @@ msgstr "Ingresado por el participante en el portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6262,7 +6260,7 @@ msgstr ""
 msgid "Just a moment"
 msgstr "Un momento"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6353,7 +6351,7 @@ msgid "Language"
 msgstr "Idioma"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6379,7 +6377,7 @@ msgid "Last saved {0}"
 msgstr "Última vez guardado el {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6553,11 +6551,11 @@ msgstr "Nivel de audio en vivo"
 #~ msgid "Live audio level:"
 #~ msgstr "Nivel de audio en vivo:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6565,7 +6563,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Vista Previa en Vivo"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -6751,8 +6749,8 @@ msgstr ""
 msgid "Longest First"
 msgstr "Más largo primero"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -6941,19 +6939,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Mensajes de {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -6984,7 +6982,7 @@ msgstr "Modo"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr ""
@@ -7606,7 +7604,7 @@ msgstr ""
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "No hay citas disponibles. Genera citas para esta conversación visitando<0><1> la biblioteca del proyecto.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -7752,7 +7750,7 @@ msgstr ""
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8073,7 +8071,7 @@ msgstr ""
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr ""
 
@@ -8457,7 +8455,7 @@ msgstr "Correos electrónicos del participante"
 msgid "Participant Features"
 msgstr "Funciones para participantes"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8655,7 +8653,6 @@ msgid "Pause reading"
 msgstr "Pausar lectura"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9291,7 +9288,7 @@ msgstr "Procesando <0>{totalCount, plural, one {# conversación} other {# conver
 msgid "Processing your retranscription request..."
 msgstr "Procesando tu solicitud de retranscripción..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9650,7 +9647,7 @@ msgid "Record another conversation"
 msgstr "Registrar otra conversación"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10358,7 +10355,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10411,7 +10408,7 @@ msgstr "Guardar plantilla"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr ""
 
@@ -10431,12 +10428,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Escanea el código QR o copia el secreto en tu aplicación."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11079,7 +11076,7 @@ msgstr "Mostrar"
 msgid "Show {hidden} more"
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -11758,7 +11755,7 @@ msgid "Templates"
 msgstr "Plantillas"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12495,8 +12492,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -12840,7 +12837,7 @@ msgstr "Cambios sin guardar"
 msgid "Unsubscribe"
 msgstr "Desuscribirse"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13297,7 +13294,6 @@ msgid "Verify Topics"
 msgstr "Temas de verificación"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13371,10 +13367,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13412,7 +13408,7 @@ msgstr "Esperando a que terminen las conversaciones antes de generar un informe.
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Advertencia: Has añadido {0} términos clave. Solo los primeros {ASSEMBLYAI_MAX_HOTWORDS} serán utilizados por el motor de transcripción."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13572,8 +13568,8 @@ msgstr ""
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -13768,7 +13764,7 @@ msgstr "Cuando finalices la conversación, los participantes que no han verifica
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -328,7 +328,7 @@ msgstr ""
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -383,12 +383,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# étiquette} other {# étiquettes}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -768,11 +768,11 @@ msgstr ""
 msgid "{sentCount} invites sent."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -851,10 +851,9 @@ msgstr "+{hiddenCount} conversations"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #~ msgid "<0>Wait </0>{0}:{1}"
 #~ msgstr "<0>Attendre </0>{0}:{1}"
@@ -1796,9 +1795,8 @@ msgstr "conversation anonymisée"
 msgid "Anonymized conversation"
 msgstr "Conversation anonymisée"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1807,11 +1805,11 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Hôte anonyme"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3146,7 +3144,7 @@ msgid "conversation"
 msgstr "conversation"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr ""
 
@@ -3369,7 +3367,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4597,7 +4595,7 @@ msgstr "Entré par le participant sur le portail"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6277,7 +6275,7 @@ msgstr ""
 msgid "Just a moment"
 msgstr "Un instant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6368,7 +6366,7 @@ msgid "Language"
 msgstr "Langue"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6394,7 +6392,7 @@ msgid "Last saved {0}"
 msgstr "Dernièrement enregistré le {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6568,11 +6566,11 @@ msgstr "Niveau audio en direct:"
 #~ msgid "Live audio level:"
 #~ msgstr "Niveau audio en direct:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6580,7 +6578,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Vue en direct"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -6766,8 +6764,8 @@ msgstr ""
 msgid "Longest First"
 msgstr "Plus long en premier"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -6956,19 +6954,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Messages de {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -6999,7 +6997,7 @@ msgstr "Mode"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr ""
@@ -7621,7 +7619,7 @@ msgstr ""
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "Aucune citation disponible. Générez des citations pour cette conversation en visitant<0><1> la bibliothèque du projet.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -7767,7 +7765,7 @@ msgstr ""
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8088,7 +8086,7 @@ msgstr ""
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr ""
 
@@ -8472,7 +8470,7 @@ msgstr "Emails du participant"
 msgid "Participant Features"
 msgstr "Fonctionnalités participant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8670,7 +8668,6 @@ msgid "Pause reading"
 msgstr "Mettre en pause la lecture"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9306,7 +9303,7 @@ msgstr "Traitement de <0>{totalCount, plural, one {# conversation} other {# conv
 msgid "Processing your retranscription request..."
 msgstr "Traitement de votre demande de retranscription..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9665,7 +9662,7 @@ msgid "Record another conversation"
 msgstr "Enregistrer une autre conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10373,7 +10370,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10426,7 +10423,7 @@ msgstr "Enregistrer le modèle"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr ""
 
@@ -10446,12 +10443,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scannez le code QR ou copiez le secret dans votre application."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11094,7 +11091,7 @@ msgstr "Afficher"
 msgid "Show {hidden} more"
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -11773,7 +11770,7 @@ msgid "Templates"
 msgstr "Modèles"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12510,8 +12507,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -12855,7 +12852,7 @@ msgstr "Modifications non enregistrées"
 msgid "Unsubscribe"
 msgstr "Se désabonner"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13312,7 +13309,6 @@ msgid "Verify Topics"
 msgstr "Sujets de vérification"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13386,10 +13382,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13427,7 +13423,7 @@ msgstr "En attente de la fin des conversations avant de générer un rapport."
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13591,8 +13587,8 @@ msgstr ""
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -13787,7 +13783,7 @@ msgstr "Lorsque vous terminez la conversation, les participants qui n'ont pas en
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -489,7 +489,7 @@ msgstr ""
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -544,12 +544,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# tag} other {# tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "{sentCount} invites sent."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -1023,10 +1023,9 @@ msgstr "+{hiddenCount} conversations"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #: src/routes/participant/ParticipantConversation.tsx:574
 #: src/routes/participant/ParticipantConversation.tsx:649
@@ -1974,9 +1973,8 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1985,7 +1983,7 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Anonymous host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
@@ -1993,7 +1991,7 @@ msgstr ""
 #~ msgid "Anonymous Participant"
 #~ msgstr "Anonymous Participant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3351,7 +3349,7 @@ msgid "conversation"
 msgstr "conversation"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr ""
 
@@ -3574,7 +3572,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4813,7 +4811,7 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6539,7 +6537,7 @@ msgstr ""
 msgid "Just a moment"
 msgstr "Just a moment"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6631,7 +6629,7 @@ msgid "Language"
 msgstr "Language"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6657,7 +6655,7 @@ msgid "Last saved {0}"
 msgstr "Last saved {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6823,11 +6821,11 @@ msgstr "Live audio level:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live audio level:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6835,7 +6833,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -7022,8 +7020,8 @@ msgstr ""
 msgid "Longest First"
 msgstr "Longest First"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -7212,19 +7210,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Messages from {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -7256,7 +7254,7 @@ msgstr "Mode"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr ""
@@ -7885,7 +7883,7 @@ msgstr ""
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -8035,7 +8033,7 @@ msgstr ""
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8359,7 +8357,7 @@ msgstr ""
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr ""
 
@@ -8749,7 +8747,7 @@ msgstr "Participant Emails"
 msgid "Participant Features"
 msgstr "Participant Features"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8840,7 +8838,6 @@ msgid "Pause reading"
 msgstr "Pause reading"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9491,7 +9488,7 @@ msgstr "Processing <0>{totalCount, plural, one {# conversation} other {# convers
 msgid "Processing your retranscription request..."
 msgstr "Processing your retranscription request..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9868,7 +9865,7 @@ msgid "Record another conversation"
 msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10589,7 +10586,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10642,7 +10639,7 @@ msgstr "Save template"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr ""
 
@@ -10662,12 +10659,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scan the QR code or copy the secret into your app."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11315,7 +11312,7 @@ msgstr "Show"
 msgid "Show {hidden} more"
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -12008,7 +12005,7 @@ msgid "Templates"
 msgstr "Templates"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12779,8 +12776,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -13132,7 +13129,7 @@ msgstr "Unsaved changes"
 msgid "Unsubscribe"
 msgstr "Unsubscribe"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13598,7 +13595,6 @@ msgid "Verify Topics"
 msgstr "Verify Topics"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13674,10 +13670,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13719,7 +13715,7 @@ msgstr "Waiting for conversations to finish before generating a report."
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13884,8 +13880,8 @@ msgstr ""
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -14082,7 +14078,7 @@ msgstr "When finishing the conversation, participants who haven't verified yet w
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -150,7 +150,7 @@ msgstr "{0, plural, one {# gesprek} other {# gesprekken}}"
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr "{0, plural, one {# live} other {# live}}"
 
@@ -202,12 +202,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# tag} other {# tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr "{0, plural, one {# met fouten} other {# met fouten}}"
 
@@ -567,11 +567,11 @@ msgstr "{sent} uitnodigingen verstuurd"
 msgid "{sentCount} invites sent."
 msgstr "{sentCount} uitnodigingen verstuurd."
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -651,10 +651,9 @@ msgstr "+{hiddenCount} gesprekken"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #~ msgid "<0>Wait </0>{0}:{1}"
 #~ msgstr "<0>Wacht </0>{0}:{1}"
@@ -1551,23 +1550,22 @@ msgstr "anoniem gesprek"
 msgid "Anonymized conversation"
 msgstr "Anoniem gesprek"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
 #~ msgid "Anonymous host"
 #~ msgstr "Anonieme host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr "Anonieme deelnemer"
 
 #~ msgid "Anonymous Participant"
 #~ msgstr "Anonieme deelnemer"
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -2868,7 +2866,7 @@ msgid "conversation"
 msgstr "gesprek"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr "Gesprek"
 
@@ -3087,7 +3085,7 @@ msgstr "Betalingen konden niet worden geladen. Controleer de authenticatie en de
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr "De rollup kon niet worden geladen. Controleer de authenticatie en de backend-logs."
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4284,7 +4282,7 @@ msgstr "Ingevoerd door de deelnemer op het portaal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -5889,7 +5887,7 @@ msgstr "Ga naar"
 msgid "Just a moment"
 msgstr "Gewoon een momentje"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -5978,7 +5976,7 @@ msgid "Language"
 msgstr "Taal"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr "Laatste activiteit {0}"
 
@@ -6002,7 +6000,7 @@ msgid "Last saved {0}"
 msgstr "Laatst opgeslagen {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6175,11 +6173,11 @@ msgstr "Live audio niveau:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live audio level:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr "Live monitoring"
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6187,7 +6185,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Live Voorbeeld"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -6365,8 +6363,8 @@ msgstr "Langste eerst"
 msgid "Longest First"
 msgstr "Langste eerst"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -6546,19 +6544,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Berichten van {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -6587,7 +6585,7 @@ msgstr "Modus"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr "Mollie is niet ingesteld in deze omgeving, dus er worden geen live transacties getoond. De Dashboard-link verwijst nog steeds naar de juiste Mollie-omgeving."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr "Monitoren"
@@ -7178,7 +7176,7 @@ msgstr "Geen projecten gevonden."
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "Geen quotes beschikbaar. Genereer quotes voor dit gesprek door naar <0><1>de projectbibliotheek.</1></0> te gaan."
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -7319,7 +7317,7 @@ msgstr "Geen werkruimtes komen overeen met \"{search}\"."
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -7618,7 +7616,7 @@ msgstr "Alles openen"
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr "Gesprek openen"
 
@@ -7983,7 +7981,7 @@ msgstr "Deelnemer e-mails"
 msgid "Participant Features"
 msgstr "Deelnemer features"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8257,7 +8255,6 @@ msgid "Pause reading"
 msgstr "Pauzeer het voorlezen"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -8846,7 +8843,7 @@ msgstr "<0>{totalCount, plural, one {# gesprek} other {# gesprekken}}</0> verwer
 msgid "Processing your retranscription request..."
 msgstr "Hertranscriptieaanvraag wordt verwerkt..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9196,7 +9193,7 @@ msgid "Record another conversation"
 msgstr "Neem nog een gesprek op"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -9868,7 +9865,7 @@ msgstr "Verkoopfactuur uitgegeven."
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -9919,7 +9916,7 @@ msgstr "Template opslaan"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr "Opgeslagen"
 
@@ -9938,12 +9935,12 @@ msgstr "Scan of klik op de QR-code om het feedbackportaal te openen"
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scan de QR-code of kopieer het geheim naar je app."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -10565,7 +10562,7 @@ msgstr "Toon"
 msgid "Show {hidden} more"
 msgstr "Toon {hidden} meer"
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -11194,7 +11191,7 @@ msgid "Templates"
 msgstr "Sjablonen"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr "Voorwaarden"
 
@@ -11931,8 +11928,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -12273,7 +12270,7 @@ msgstr "Niet-opgeslagen wijzigingen"
 msgid "Unsubscribe"
 msgstr "Afmelden"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -12710,7 +12707,6 @@ msgid "Verify Topics"
 msgstr "Onderwerpen verifiëren"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -12779,10 +12775,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr "Zichtbaar voor iedereen in deze werkruimte. Laat uit om het persoonlijk te houden."
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -12815,7 +12811,7 @@ msgstr "Wachten tot gesprekken zijn afgerond voordat een rapport wordt gegeneree
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Waarschuwing: je hebt {0} sleutelwoorden toegevoegd. Alleen de eerste {ASSEMBLYAI_MAX_HOTWORDS} worden door de transcriptie-engine gebruikt."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -12964,8 +12960,8 @@ msgstr "We hebben organisaties toegevoegd zodat je projecten kunt ordenen en del
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr "We hebben een verificatielink naar <0>{0}</0> gestuurd. Open de e-mail en klik op de link om verder te gaan."
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -13153,7 +13149,7 @@ msgstr "Wanneer je het gesprek afmaakt, worden deelnemers die nog niet hebben ge
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -489,7 +489,7 @@ msgstr ""
 #. placeholder {0}: group.liveCount
 #. placeholder {0}: summary.live
 #: src/components/conversation/LiveMonitorSection.tsx:368
-#: src/components/conversation/LiveMonitorSection.tsx:446
+#: src/components/conversation/LiveMonitorSection.tsx:450
 msgid "{0, plural, one {# live} other {# live}}"
 msgstr ""
 
@@ -544,12 +544,12 @@ msgid "{0, plural, one {# tag} other {# tags}}"
 msgstr "{0, plural, one {# tag} other {# tags}}"
 
 #. placeholder {0}: summary.transcribing
-#: src/components/conversation/LiveMonitorSection.tsx:450
+#: src/components/conversation/LiveMonitorSection.tsx:454
 msgid "{0, plural, one {# transcribing} other {# transcribing}}"
 msgstr ""
 
 #. placeholder {0}: summary.with_errors
-#: src/components/conversation/LiveMonitorSection.tsx:459
+#: src/components/conversation/LiveMonitorSection.tsx:463
 msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "{sentCount} invites sent."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:314
+#: src/components/conversation/LiveFunnelSection.tsx:240
 msgid "{tag} (preselected)"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:456
+#: src/components/conversation/LiveFunnelSection.tsx:386
 msgid "{totalActive, plural, one {# active} other {# active}}"
 msgstr ""
 
@@ -1023,10 +1023,9 @@ msgstr "+{hiddenCount} conversations"
 #~ msgid "+5s"
 #~ msgstr "+5s"
 
-#. placeholder {0}: visitor.scan_count
 #: src/components/conversation/LiveFunnelSection.tsx:142
-msgid "×{0}"
-msgstr ""
+#~ msgid "×{0}"
+#~ msgstr ""
 
 #: src/routes/participant/ParticipantConversation.tsx:574
 #: src/routes/participant/ParticipantConversation.tsx:649
@@ -1974,9 +1973,8 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:97
-#: src/components/conversation/LiveFunnelSection.tsx:138
-#: src/components/conversation/LiveFunnelSection.tsx:181
+#: src/components/conversation/LiveFunnelSection.tsx:185
+#: src/components/conversation/LiveFunnelSection.tsx:202
 msgid "Anonymous"
 msgstr ""
 
@@ -1985,7 +1983,7 @@ msgstr ""
 #~ msgid "Anonymous host"
 #~ msgstr "Anonymous host"
 
-#: src/components/conversation/LiveMonitorSection.tsx:201
+#: src/components/conversation/LiveMonitorSection.tsx:203
 msgid "Anonymous participant"
 msgstr ""
 
@@ -1993,7 +1991,7 @@ msgstr ""
 #~ msgid "Anonymous Participant"
 #~ msgstr "Anonymous Participant"
 
-#: src/components/conversation/LiveFunnelSection.tsx:294
+#: src/components/conversation/LiveFunnelSection.tsx:220
 msgid "Anonymous visitor"
 msgstr ""
 
@@ -3351,7 +3349,7 @@ msgid "conversation"
 msgstr "conversation"
 
 #: src/features/sidebar/hooks/useSearchHits.ts:224
-#: src/components/conversation/LiveFunnelSection.tsx:491
+#: src/components/conversation/LiveFunnelSection.tsx:422
 msgid "Conversation"
 msgstr ""
 
@@ -3574,7 +3572,7 @@ msgstr ""
 msgid "Could not load the rollup. Check auth and backend logs."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:364
+#: src/components/conversation/LiveFunnelSection.tsx:290
 msgid "Could not save"
 msgstr ""
 
@@ -4813,7 +4811,7 @@ msgstr "Entered by the participant on the portal"
 
 #: src/components/dropzone/UploadConversationDropzone.tsx:734
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
-#: src/components/conversation/LiveMonitorSection.tsx:248
+#: src/components/conversation/LiveMonitorSection.tsx:246
 #: src/components/chat/AgenticChatPanel.tsx:271
 #: src/components/chat/AgenticChatPanel.tsx:1042
 msgid "Error"
@@ -6539,7 +6537,7 @@ msgstr ""
 msgid "Just a moment"
 msgstr "Just a moment"
 
-#: src/components/conversation/LiveFunnelSection.tsx:58
+#: src/components/conversation/LiveFunnelSection.tsx:56
 msgid "just now"
 msgstr ""
 
@@ -6631,7 +6629,7 @@ msgid "Language"
 msgstr "Language"
 
 #. placeholder {0}: lastActivityLabel(conversation)
-#: src/components/conversation/LiveMonitorSection.tsx:260
+#: src/components/conversation/LiveMonitorSection.tsx:258
 msgid "Last activity {0}"
 msgstr ""
 
@@ -6657,7 +6655,7 @@ msgid "Last saved {0}"
 msgstr "Last saved {0}"
 
 #. placeholder {0}: relativeTime(visitor.last_seen_at)
-#: src/components/conversation/LiveFunnelSection.tsx:303
+#: src/components/conversation/LiveFunnelSection.tsx:229
 msgid "Last seen {0}"
 msgstr ""
 
@@ -6823,11 +6821,11 @@ msgstr "Live audio level:"
 #~ msgid "Live audio level:"
 #~ msgstr "Live audio level:"
 
-#: src/components/conversation/LiveMonitorSection.tsx:441
+#: src/components/conversation/LiveMonitorSection.tsx:445
 msgid "Live monitoring"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:453
+#: src/components/conversation/LiveFunnelSection.tsx:383
 msgid "Live participant flow"
 msgstr ""
 
@@ -6835,7 +6833,7 @@ msgstr ""
 msgid "Live Preview"
 msgstr "Live Preview"
 
-#: src/components/conversation/LiveMonitorSection.tsx:425
+#: src/components/conversation/LiveMonitorSection.tsx:429
 msgid "Live recordings, transcription progress, and errors show up here as participants start recording in the portal."
 msgstr ""
 
@@ -7022,8 +7020,8 @@ msgstr ""
 msgid "Longest First"
 msgstr "Longest First"
 
-#: src/components/conversation/LiveMonitorSection.tsx:236
-#: src/components/conversation/LiveFunnelSection.tsx:337
+#: src/components/conversation/LiveMonitorSection.tsx:234
+#: src/components/conversation/LiveFunnelSection.tsx:263
 msgid "Low battery"
 msgstr ""
 
@@ -7212,19 +7210,19 @@ msgstr ""
 msgid "Messages from {0} - {1}%"
 msgstr "Messages from {0} - {1}%"
 
-#: src/components/conversation/LiveFunnelSection.tsx:71
+#: src/components/conversation/LiveFunnelSection.tsx:67
 msgid "Mic blocked"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:431
+#: src/components/conversation/LiveFunnelSection.tsx:371
 msgid "Mic check"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:69
+#: src/components/conversation/LiveFunnelSection.tsx:65
 msgid "Mic OK"
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:70
+#: src/components/conversation/LiveFunnelSection.tsx:66
 msgid "Mic skipped"
 msgstr ""
 
@@ -7256,7 +7254,7 @@ msgstr "Mode"
 msgid "Mollie is not configured in this environment, so no live transactions are shown. The dashboard link still points to the right Mollie environment."
 msgstr ""
 
-#: src/routes/project/ProjectMonitorRoute.tsx:16
+#: src/routes/project/ProjectMonitorRoute.tsx:21
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:89
 msgid "Monitor"
 msgstr ""
@@ -7885,7 +7883,7 @@ msgstr ""
 #~ msgid "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 #~ msgstr "No quotes available. Generate quotes for this conversation by visiting<0><1> the project library.</1></0>"
 
-#: src/components/conversation/LiveMonitorSection.tsx:422
+#: src/components/conversation/LiveMonitorSection.tsx:426
 msgid "No recent activity"
 msgstr ""
 
@@ -8035,7 +8033,7 @@ msgstr ""
 #~ msgid "No workspaces yet. Create your first one to get started."
 #~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:281
+#: src/components/conversation/LiveFunnelSection.tsx:177
 msgid "Nobody here yet"
 msgstr ""
 
@@ -8359,7 +8357,7 @@ msgstr ""
 
 #: src/components/conversation/ProjectConversationsPanel.tsx:378
 #: src/components/conversation/ProjectConversationsPanel.tsx:382
-#: src/components/conversation/LiveFunnelSection.tsx:404
+#: src/components/conversation/LiveFunnelSection.tsx:330
 msgid "Open conversation"
 msgstr ""
 
@@ -8749,7 +8747,7 @@ msgstr "Participant Emails"
 msgid "Participant Features"
 msgstr "Participant Features"
 
-#: src/components/conversation/LiveFunnelSection.tsx:372
+#: src/components/conversation/LiveFunnelSection.tsx:298
 msgid "Participant name"
 msgstr ""
 
@@ -8840,7 +8838,6 @@ msgid "Pause reading"
 msgstr "Pause reading"
 
 #: src/components/conversation/LiveMonitorSection.tsx:47
-#: src/components/conversation/LiveFunnelSection.tsx:191
 msgid "Paused"
 msgstr ""
 
@@ -9491,7 +9488,7 @@ msgstr "Processing <0>{totalCount, plural, one {# conversation} other {# convers
 msgid "Processing your retranscription request..."
 msgstr "Processing your retranscription request..."
 
-#: src/components/conversation/LiveFunnelSection.tsx:434
+#: src/components/conversation/LiveFunnelSection.tsx:372
 msgid "Profile"
 msgstr ""
 
@@ -9868,7 +9865,7 @@ msgid "Record another conversation"
 msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
-#: src/components/conversation/LiveFunnelSection.tsx:440
+#: src/components/conversation/LiveFunnelSection.tsx:373
 msgid "Recording"
 msgstr ""
 
@@ -10589,7 +10586,7 @@ msgstr ""
 #: src/components/settings/ChangePasswordCard.tsx:101
 #: src/components/settings/AccountSettingsCard.tsx:195
 #: src/components/project/CustomTopicModal.tsx:260
-#: src/components/conversation/LiveFunnelSection.tsx:381
+#: src/components/conversation/LiveFunnelSection.tsx:307
 #: src/components/common/InputModal.tsx:85
 #: src/components/chat/ChatAccordion.tsx:161
 msgid "Save"
@@ -10642,7 +10639,7 @@ msgstr "Save template"
 #: src/routes/organisation/OrganisationRoute.tsx:1084
 #: src/routes/admin/AdminSettingsRoute.tsx:458
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:109
-#: src/components/conversation/LiveFunnelSection.tsx:363
+#: src/components/conversation/LiveFunnelSection.tsx:289
 msgid "Saved"
 msgstr ""
 
@@ -10662,12 +10659,12 @@ msgstr ""
 msgid "Scan the QR code or copy the secret into your app."
 msgstr "Scan the QR code or copy the secret into your app."
 
-#: src/components/conversation/LiveFunnelSection.tsx:429
+#: src/components/conversation/LiveFunnelSection.tsx:369
 msgid "Scanned"
 msgstr ""
 
 #. placeholder {0}: visitor.scan_count
-#: src/components/conversation/LiveFunnelSection.tsx:298
+#: src/components/conversation/LiveFunnelSection.tsx:224
 msgid "Scanned {0} times"
 msgstr ""
 
@@ -11315,7 +11312,7 @@ msgstr "Show"
 msgid "Show {hidden} more"
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:388
+#: src/components/conversation/LiveMonitorSection.tsx:389
 msgid "Show {overflow} more"
 msgstr ""
 
@@ -12008,7 +12005,7 @@ msgid "Templates"
 msgstr "Templates"
 
 #: src/components/layout/Footer.tsx:9
-#: src/components/conversation/LiveFunnelSection.tsx:430
+#: src/components/conversation/LiveFunnelSection.tsx:370
 msgid "Terms"
 msgstr ""
 
@@ -12779,8 +12776,8 @@ msgid "Transcribed"
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:201
-msgid "Transcribing"
-msgstr ""
+#~ msgid "Transcribing"
+#~ msgstr ""
 
 #: src/components/conversation/ConversationChunkAudioTranscript.tsx:80
 msgid "Transcribing..."
@@ -13132,7 +13129,7 @@ msgstr "Unsaved changes"
 msgid "Unsubscribe"
 msgstr "Unsubscribe"
 
-#: src/components/conversation/LiveMonitorSection.tsx:309
+#: src/components/conversation/LiveMonitorSection.tsx:307
 msgid "Untagged"
 msgstr ""
 
@@ -13598,7 +13595,6 @@ msgid "Verify Topics"
 msgstr "Verify Topics"
 
 #: src/components/conversation/LiveMonitorSection.tsx:49
-#: src/components/conversation/LiveFunnelSection.tsx:196
 msgid "Verifying"
 msgstr ""
 
@@ -13674,10 +13670,10 @@ msgid "Visible to everyone in this workspace. Leave off to keep it personal."
 msgstr ""
 
 #: src/components/conversation/LiveFunnelSection.tsx:104
-msgid "Visitor"
-msgstr ""
+#~ msgid "Visitor"
+#~ msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:492
+#: src/components/conversation/LiveFunnelSection.tsx:423
 msgid "Visitor details"
 msgstr ""
 
@@ -13719,7 +13715,7 @@ msgstr "Waiting for conversations to finish before generating a report."
 #~ msgid "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 #~ msgstr "Warning: You have added {0} key terms. Only the first {ASSEMBLYAI_MAX_HOTWORDS} will be used by the transcription engine."
 
-#: src/routes/project/ProjectMonitorRoute.tsx:19
+#: src/routes/project/ProjectMonitorRoute.tsx:24
 msgid "Watch live recordings, transcription progress, and errors across this project as they happen."
 msgstr ""
 
@@ -13884,8 +13880,8 @@ msgstr ""
 msgid "We've sent a verification link to <0>{0}</0>. Open the email and click the link to continue."
 msgstr ""
 
-#: src/components/conversation/LiveMonitorSection.tsx:231
-#: src/components/conversation/LiveFunnelSection.tsx:329
+#: src/components/conversation/LiveMonitorSection.tsx:229
+#: src/components/conversation/LiveFunnelSection.tsx:255
 msgid "Weak network"
 msgstr ""
 
@@ -14082,7 +14078,7 @@ msgstr "When finishing the conversation, participants who haven't verified yet w
 msgid "When on, dembrane support staff can join this workspace to help you. Their access ends automatically after 24 hours."
 msgstr ""
 
-#: src/components/conversation/LiveFunnelSection.tsx:463
+#: src/components/conversation/LiveFunnelSection.tsx:393
 msgid "When participants scan the QR code, they'll appear here and move across the stages in real time."
 msgstr ""
 

--- a/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
+++ b/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import { Divider, Stack, Text, Title } from "@mantine/core";
+import { useState } from "react";
 import { useParams } from "react-router";
 import { LiveFunnelSection } from "@/components/conversation/LiveFunnelSection";
 import { LiveMonitorSection } from "@/components/conversation/LiveMonitorSection";
@@ -7,6 +8,10 @@ import { PageContainer } from "@/components/layout/PageContainer";
 
 export const ProjectMonitorRoute = () => {
 	const { projectId } = useParams<{ projectId: string }>();
+	// Hovering a recording dot in the funnel highlights its detailed card below.
+	const [hoveredConversationId, setHoveredConversationId] = useState<
+		string | null
+	>(null);
 
 	return (
 		<PageContainer width="xl">
@@ -23,11 +28,22 @@ export const ProjectMonitorRoute = () => {
 					</Text>
 				</Stack>
 
-				{projectId && <LiveFunnelSection projectId={projectId} />}
+				{projectId && (
+					<LiveFunnelSection
+						projectId={projectId}
+						onHoverConversation={setHoveredConversationId}
+					/>
+				)}
 
 				<Divider />
 
-				{projectId && <LiveMonitorSection projectId={projectId} standalone />}
+				{projectId && (
+					<LiveMonitorSection
+						projectId={projectId}
+						standalone
+						highlightedConversationId={hoveredConversationId}
+					/>
+				)}
 			</Stack>
 		</PageContainer>
 	);


### PR DESCRIPTION
Host feedback on the funnel (screenshot): each recording was duplicated (a funnel card *and* the detailed card below), and the wide cards forced an ugly horizontal scrollbar.

## Fix
- **Every lane is just dots now** — the funnel is a compact overview, no mini-cards. Lanes **wrap** instead of scrolling horizontally (scrollbar gone).
- **Hover a Recording dot → its detailed card below highlights** (shared hover state lifted to the Monitor route). Dots still open the same-screen drilldown on click; visitor dots keep their tooltip.
- The detailed cards below are the single source of per-conversation detail — no duplication.

tsc + biome clean; no new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH