### PR TITLE
Monitor: center funnel piles, hover tooltip, easier click

### DIFF
--- a/echo/frontend/src/components/conversation/FunnelCanvas.tsx
+++ b/echo/frontend/src/components/conversation/FunnelCanvas.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { t } from "@lingui/core/macro";
+import { useEffect, useRef, useState } from "react";
 
 import type {
 	FunnelVisitor,
@@ -114,17 +115,21 @@ export const FunnelCanvas = ({
 				);
 				const perRow = Math.max(1, Math.floor(innerW / spacing));
 				const x0 = col * colW + 12 + spacing / 2;
+				// Center the pile vertically instead of piling from the bottom.
+				const rows = Math.ceil(n / perRow);
+				const top = Math.max(spacing / 2, (h - rows * spacing) / 2);
+				const dotR = Math.max(2.5, Math.min(5, spacing * 0.4));
 				colNodes.forEach((node, i) => {
 					const id = node.data.id;
 					live.add(id);
 					const row = Math.floor(i / perRow);
 					const column = i % perRow;
 					const tx = x0 + column * spacing;
-					const ty = h - 8 - (row * spacing + spacing / 2);
+					const ty = top + row * spacing + spacing / 2;
 					const color = colorOf(node);
 					let p = particles.current.get(id);
 					if (!p) {
-						// Spawn from the left edge of the column and rise into place.
+						// Spawn from the left edge of the column and glide into place.
 						p = {
 							alpha: 0,
 							col,
@@ -133,11 +138,11 @@ export const FunnelCanvas = ({
 							id,
 							kind: node.kind,
 							pulse: node.kind === "conversation",
-							r: Math.max(1.5, Math.min(4, spacing * 0.34)),
+							r: dotR,
 							tx,
 							ty,
 							x: col * colW + 4,
-							y: h - 8,
+							y: h / 2,
 						};
 						particles.current.set(id, p);
 					}
@@ -146,7 +151,7 @@ export const FunnelCanvas = ({
 					p.pulse = node.kind === "conversation";
 					p.tx = tx;
 					p.ty = ty;
-					p.r = Math.max(1.5, Math.min(4, spacing * 0.34));
+					p.r = dotR;
 					p.dead = false;
 				});
 			});
@@ -203,39 +208,64 @@ export const FunnelCanvas = ({
 		};
 	}, [height]);
 
-	const nearest = (
-		event: React.MouseEvent<HTMLCanvasElement>,
-	): NodeDatum | null => {
-		const canvas = canvasRef.current;
-		if (!canvas) return null;
-		const rect = canvas.getBoundingClientRect();
-		const mx = event.clientX - rect.left;
-		const my = event.clientY - rect.top;
+	const [hover, setHover] = useState<{ label: string; x: number; y: number } | null>(
+		null,
+	);
+
+	const nearest = (mx: number, my: number): NodeDatum | null => {
 		let best: { id: string; d: number } | null = null;
 		for (const [id, p] of particles.current) {
 			if (p.dead) continue;
 			const d = (p.x - mx) ** 2 + (p.y - my) ** 2;
 			if (!best || d < best.d) best = { d, id };
 		}
-		if (!best || best.d > 14 * 14) return null;
+		// Generous radius so tiny dots are still easy to hit.
+		if (!best || best.d > 18 * 18) return null;
 		return nodesRef.current.find((n) => n.data.id === best?.id) ?? null;
 	};
 
+	const labelFor = (node: NodeDatum): string => {
+		if (node.kind === "conversation") {
+			return node.data.label?.trim() || t`Recording`;
+		}
+		return node.data.name?.trim() || t`Anonymous`;
+	};
+
+	const mouseXY = (event: React.MouseEvent<HTMLCanvasElement>) => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+	};
+
 	return (
-		<div ref={wrapRef} className="w-full">
+		<div ref={wrapRef} className="relative w-full">
 			<canvas
 				ref={canvasRef}
 				onClick={(event) => {
-					const node = nearest(event);
+					const { x, y } = mouseXY(event);
+					const node = nearest(x, y);
 					if (node) onSelect(node);
 				}}
-				onMouseMove={
-					onHover ? (event) => onHover(nearest(event)) : undefined
-				}
-				onMouseLeave={onHover ? () => onHover(null) : undefined}
-				className="w-full cursor-pointer"
-				style={{ height }}
+				onMouseMove={(event) => {
+					const { x, y } = mouseXY(event);
+					const node = nearest(x, y);
+					onHover?.(node);
+					setHover(node ? { label: labelFor(node), x, y } : null);
+				}}
+				onMouseLeave={() => {
+					onHover?.(null);
+					setHover(null);
+				}}
+				className="w-full"
+				style={{ cursor: hover ? "pointer" : "default", height }}
 			/>
+			{hover && (
+				<div
+					className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded bg-slate-800 px-2 py-1 text-xs text-white shadow"
+					style={{ left: hover.x, top: hover.y - 6 }}
+				>
+					{hover.label}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -1977,10 +1977,9 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9886,6 +9885,7 @@ msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -1784,10 +1784,9 @@ msgstr "Anonymisierte Unterhaltung"
 msgid "Anonymized conversation"
 msgstr "Anonymisierte Unterhaltung"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9662,6 +9661,7 @@ msgstr "Ein weiteres Gespräch aufnehmen"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -1977,10 +1977,9 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr "Anonymous"
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr "Anonymous"
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9886,6 +9885,7 @@ msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr "Recording"
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -1784,10 +1784,9 @@ msgstr "conversación anónima"
 msgid "Anonymized conversation"
 msgstr "Conversación anónima"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9668,6 +9667,7 @@ msgstr "Registrar otra conversación"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -1799,10 +1799,9 @@ msgstr "conversation anonymisée"
 msgid "Anonymized conversation"
 msgstr "Conversation anonymisée"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9683,6 +9682,7 @@ msgstr "Enregistrer une autre conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -1977,10 +1977,9 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9886,6 +9885,7 @@ msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -1554,10 +1554,9 @@ msgstr "anoniem gesprek"
 msgid "Anonymized conversation"
 msgstr "Anoniem gesprek"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #~ msgid "Anonymous host"
 #~ msgstr "Anonieme host"
@@ -9214,6 +9213,7 @@ msgstr "Neem nog een gesprek op"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -1977,10 +1977,9 @@ msgstr "anonymized conversation"
 msgid "Anonymized conversation"
 msgstr "Anonymized conversation"
 
-#: src/components/conversation/LiveFunnelSection.tsx:185
-#: src/components/conversation/LiveFunnelSection.tsx:202
-#~ msgid "Anonymous"
-#~ msgstr ""
+#: src/components/conversation/FunnelCanvas.tsx:231
+msgid "Anonymous"
+msgstr ""
 
 #: src/components/chat/PublishTemplateForm.tsx:157
 #: src/components/chat/CommunityTemplateCard.tsx:124
@@ -9886,6 +9885,7 @@ msgstr "Record another conversation"
 
 #: src/components/conversation/LiveMonitorSection.tsx:45
 #: src/components/conversation/LiveFunnelSection.tsx:286
+#: src/components/conversation/FunnelCanvas.tsx:229
 msgid "Recording"
 msgstr ""
 


### PR DESCRIPTION
Host feedback on the canvas funnel:
- **Center the piles vertically** (they were packed at the bottom edge).
- **Hover tooltip** — canvas dots now show a floating name/"Recording" label on hover, a pointer cursor only when over a dot, and the **click/hover hit radius is wider (14 → 18px)** with slightly larger dots, so they're easy to click.

tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH