### PR TITLE
Monitor: responsive funnel widths + working 'Open conversation' link

### DIFF
--- a/echo/frontend/src/components/conversation/FunnelCanvas.tsx
+++ b/echo/frontend/src/components/conversation/FunnelCanvas.tsx
@@ -54,11 +54,15 @@ const colorOf = (node: NodeDatum): string => {
 export const FunnelCanvas = ({
 	nodes,
 	height = 150,
+	weights = [1, 1, 1],
 	onSelect,
 	onHover,
 }: {
 	nodes: NodeDatum[];
 	height?: number;
+	/** Relative widths of the three columns, so empty stages shrink and the
+	 * busy ones grow (e.g. only-recording -> ~25/25/50). */
+	weights?: [number, number, number];
 	onSelect: (node: NodeDatum) => void;
 	onHover?: (node: NodeDatum | null) => void;
 }) => {
@@ -66,8 +70,10 @@ export const FunnelCanvas = ({
 	const wrapRef = useRef<HTMLDivElement | null>(null);
 	const particles = useRef<Map<string, Particle>>(new Map());
 	const nodesRef = useRef<NodeDatum[]>(nodes);
+	const weightsRef = useRef<[number, number, number]>(weights);
 	const sizeRef = useRef<{ w: number; h: number }>({ w: 0, h: height });
 	nodesRef.current = nodes;
+	weightsRef.current = weights;
 
 	// Reconcile particles from the latest nodes, then run one animation loop
 	// for the component's lifetime.
@@ -97,8 +103,16 @@ export const FunnelCanvas = ({
 
 		const layout = () => {
 			const { w, h } = sizeRef.current;
-			const colW = w / 3;
-			// Group current nodes by column and assign a bottom-packed slot.
+			// Weighted columns: empty stages shrink, busy ones grow.
+			const wts = weightsRef.current;
+			const wtTotal = wts[0] + wts[1] + wts[2] || 1;
+			const colX = [
+				0,
+				(wts[0] / wtTotal) * w,
+				((wts[0] + wts[1]) / wtTotal) * w,
+			];
+			const colWArr = wts.map((weight) => (weight / wtTotal) * w);
+			// Group current nodes by column and assign a slot.
 			const byCol: NodeDatum[][] = [[], [], []];
 			for (const node of nodesRef.current) byCol[columnOf(node)].push(node);
 			const live = new Set<string>();
@@ -106,6 +120,7 @@ export const FunnelCanvas = ({
 			byCol.forEach((colNodes, col) => {
 				const n = colNodes.length;
 				if (n === 0) return;
+				const colW = colWArr[col];
 				const innerW = colW - 24;
 				// Spacing that fits the pile into the column; clamped small so
 				// thousands still fit, larger when there are only a few.
@@ -114,7 +129,7 @@ export const FunnelCanvas = ({
 					Math.min(16, Math.sqrt((innerW * (h - 20)) / n)),
 				);
 				const perRow = Math.max(1, Math.floor(innerW / spacing));
-				const x0 = col * colW + 12 + spacing / 2;
+				const x0 = colX[col] + 12 + spacing / 2;
 				// Center the pile vertically instead of piling from the bottom.
 				const rows = Math.ceil(n / perRow);
 				const top = Math.max(spacing / 2, (h - rows * spacing) / 2);
@@ -141,7 +156,7 @@ export const FunnelCanvas = ({
 							r: dotR,
 							tx,
 							ty,
-							x: col * colW + 4,
+							x: colX[col] + 4,
 							y: h / 2,
 						};
 						particles.current.set(id, p);

--- a/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
@@ -198,21 +198,34 @@ const ConversationDrilldown = ({
 				)}
 			</Group>
 			{base && (
-				<Button
-					component={I18nLink}
+				<I18nLink
 					to={`${base}/conversations/${conversation.id}`}
-					variant="light"
-					size="xs"
+					className="no-underline"
 				>
-					<Trans>Open conversation</Trans>
-				</Button>
+					<Button variant="light" size="xs">
+						<Trans>Open conversation</Trans>
+					</Button>
+				</I18nLink>
 			)}
 		</Stack>
 	);
 };
 
-const StageLabel = ({ label, count }: { label: string; count: number }) => (
-	<Group gap="xs" align="center" className="flex-1 justify-center">
+const StageLabel = ({
+	label,
+	count,
+	weight,
+}: {
+	label: string;
+	count: number;
+	weight: number;
+}) => (
+	<Group
+		gap="xs"
+		align="center"
+		className="justify-center"
+		style={{ flexBasis: 0, flexGrow: weight }}
+	>
 		<Text size="xs" fw={600} tt="uppercase" c="dimmed">
 			{label}
 		</Text>
@@ -235,7 +248,7 @@ export const LiveFunnelSection = ({
 		workspaceId && projectId ? `/w/${workspaceId}/projects/${projectId}` : null;
 	const [selected, setSelected] = useState<Selection | null>(null);
 
-	const { nodes, counts } = useMemo(() => {
+	const { nodes, counts, weights } = useMemo(() => {
 		const recording = conversations.filter((c) => c.is_live);
 		const visitorNodes: NodeDatum[] = funnel.visitors.map((data) => ({
 			data,
@@ -246,13 +259,17 @@ export const LiveFunnelSection = ({
 			kind: "conversation",
 		}));
 		const scanned = funnel.visitors.filter((v) => v.stage === "scanned").length;
+		const setup = funnel.visitors.length - scanned;
 		return {
-			counts: {
-				recording: recording.length,
-				scanned,
-				setup: funnel.visitors.length - scanned,
-			},
+			counts: { recording: recording.length, scanned, setup },
 			nodes: [...visitorNodes, ...recordingNodes],
+			// Empty stages shrink; recording carries extra weight so an
+			// all-recording view reads ~25/25/50.
+			weights: [
+				Math.max(1, scanned),
+				Math.max(1, setup),
+				Math.max(2, recording.length),
+			] as [number, number, number],
 		};
 	}, [funnel.visitors, conversations]);
 
@@ -281,12 +298,25 @@ export const LiveFunnelSection = ({
 			) : (
 				<Box>
 					<Group gap={0} justify="space-between" mb={4}>
-						<StageLabel label={t`Scanned`} count={counts.scanned} />
-						<StageLabel label={t`Setting up`} count={counts.setup} />
-						<StageLabel label={t`Recording`} count={counts.recording} />
+						<StageLabel
+							label={t`Scanned`}
+							count={counts.scanned}
+							weight={weights[0]}
+						/>
+						<StageLabel
+							label={t`Setting up`}
+							count={counts.setup}
+							weight={weights[1]}
+						/>
+						<StageLabel
+							label={t`Recording`}
+							count={counts.recording}
+							weight={weights[2]}
+						/>
 					</Group>
 					<FunnelCanvas
 						nodes={nodes}
+						weights={weights}
 						onSelect={(node) =>
 							setSelected(
 								node.kind === "visitor"


### PR DESCRIPTION
- **Responsive columns** — empty stages shrink, busy ones grow. An all-recording view now reads ~25/25/50 instead of three equal thirds. Canvas + label row share the weights (`max(1,scanned) / max(1,setup) / max(2,recording)`).
- **Fixed the "Open conversation" link** — it was `<Button component={I18nLink}>`, which didn't render a real `<a href>` (nothing to click or copy). Now the Button is wrapped in `I18nLink` (the pattern used everywhere else), so it navigates and the link is copyable. The conversation's source is irrelevant.

tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD179xADi3u9u1AwkGVMyH