### PR TITLE
feat(server): DELETE /user-settings/account for in-app account deletion

### DIFF
--- a/echo/server/dembrane/api/user_settings.py
+++ b/echo/server/dembrane/api/user_settings.py
@@ -1,5 +1,6 @@
 from typing import Literal, Optional
 from logging import getLogger
+from datetime import datetime, timezone
 
 import requests
 from fastapi import APIRouter, UploadFile, HTTPException
@@ -585,4 +586,33 @@ async def update_legal_basis(
         logger.error(f"Failed to update legal basis: {e}")
         raise HTTPException(status_code=500, detail="Failed to update legal basis") from None
 
+    return {"status": "ok"}
+
+
+# ── Account Deletion ──
+
+
+@UserSettingsRouter.delete("/account")
+async def delete_account(auth: DependencyDirectusSession) -> dict:
+    """Request account deletion (App Store guideline 5.1.1(v)).
+
+    Suspends the account immediately, which blocks login and token refresh,
+    and marks it for permanent removal. Purge of suspended-for-deletion
+    accounts and their data happens out of band within 30 days.
+    """
+    requested = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    try:
+        await run_in_thread_pool(
+            directus.update_user,
+            auth.user_id,
+            {
+                "status": "suspended",
+                "description": f"deletion requested in-app on {requested}, purge within 30 days",
+            },
+        )
+    except Exception as e:
+        logger.error(f"Failed to suspend account {auth.user_id} for deletion: {e}")
+        raise HTTPException(status_code=500, detail="Failed to delete account") from None
+
+    logger.info(f"account {auth.user_id} suspended pending deletion, requested {requested}")
     return {"status": "ok"}


### PR DESCRIPTION
## Why

dembrane Go's App Store submission (v1.0 build 30) was rejected under guideline 5.1.1(v): account deletion must be completable in-app, and no deletion capability existed anywhere in echo. The app previously opened the website, which has no deletion flow either.

This endpoint is a **resubmission blocker**: it must be live in production (release tag) before the app goes back to review, because the reviewer will create a throwaway account, delete it, and try to sign back in.

## What

New authed `DELETE /api/user-settings/account`:

- Sets the Directus user's `status` to `suspended`, which blocks login and token refresh immediately.
- Stamps the user's `description` with the request date so ops can find suspended-for-deletion accounts.
- Permanent purge happens out of band within 30 days. The app's confirmation dialog states exactly that, so **the purge must actually happen** (currently manual ops; a scheduled task can follow).

The dembrane Go Settings screen calls this, then signs out locally (app-side change ships separately via TestFlight, commit c39d232a on `worktree-dembrane-go`).

## Security notes (auth-adjacent change)

- The endpoint can only act on the caller: the target id comes from the session token (`auth.user_id`), no request parameters at all.
- Idempotent; re-calling on an already-suspended account is a no-op update.
- Already-issued access tokens stay valid until their normal expiry (minutes); login and refresh are blocked from the first call. Bounded and acceptable for this flow.
- Response body is `{"status": "ok"}` only, no user data.

Per repo convention, worth a `/security-review` pass before merge since this touches account lifecycle.

## Test plan

- [ ] On echo-next after merge: register a throwaway account, call `DELETE /api/user-settings/account` with its Bearer token, confirm 200, then confirm `POST /auth/login` and token refresh both fail.
- [ ] Confirm the Directus user shows `suspended` with the deletion note in its description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)