### PR TITLE
Docs: Monitor live mic-level meter (#803)

### DIFF
--- a/docs/_authoring/FACTS.md
+++ b/docs/_authoring/FACTS.md
@@ -270,8 +270,10 @@ Auth: `/login /register /check-your-email /verify-email /password-reset /request
   mic ok/skipped/blocked, terms, details). Per-conversation rows: state pills (Recording,
   Paused, Verifying, Exploring, Typing, Finishing, Finished, Waiting, Just started, Idle),
   `Transcribing N clips` chip, `catch up ~N min` backlog estimate, red `Error` badge,
-  `Audio stopped?` (stalled) and `Screen locked` (backgrounded) warnings, weak-network and
-  low-battery hints, live transcript snippet. Real-time over SSE
+  `Audio stopped?` (stalled) and `Screen locked` (backgrounded) warnings, a live mic-level
+  meter (5-bar, from the beacon's `audio_level` 0..1 RMS, shown on `receiving` rows;
+  all-quiet hints *check the mic isn't muted*), weak-network and low-battery hints, live
+  transcript snippet. Real-time over SSE
   (`GET /v2/bff/conversations/monitor/stream`, Redis-cached snapshot ≤1 Directus read/3s).
   Project home shows a *Live & recent* section embedding the same monitor.
 - *Library / analysis* `/.../library`, `/.../library/views/:viewId`,

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -55,9 +55,11 @@ it keeps growing as people speak.
   drop off before recording, while it's still fixable.
 - *Each live recording* - who's recording, paused, or finishing, with a live transcript
   snippet and a running duration.
-- *Is the audio coming in?* - a recording that was sending audio and stopped gets an
-  *Audio stopped?* warning (they may have lost connection); a locked phone or hidden tab shows
-  *Screen locked*, because recording pauses until they come back.
+- *Is the audio coming in?* - each live recording shows a small level meter, so you can see
+  audio is actually flowing; when it goes silent it nudges you to *check the mic isn't muted*.
+  A recording that was sending audio and then stopped gets an *Audio stopped?* warning (they
+  may have lost connection); a locked phone or hidden tab shows *Screen locked*, because
+  recording pauses until they come back.
 - *Transcription progress* - a *Transcribing* count per conversation, a rough *catch up*
   estimate when a backlog builds, and an *Error* badge when something needs attention.
 

--- a/docs/users/host/collecting-conversations.md
+++ b/docs/users/host/collecting-conversations.md
@@ -48,9 +48,10 @@ flow is in [the participant portal](../../features/portal-and-participant-experi
 *[dembrane next only](../../features/dembrane-next.md).* During a live session, open
 *Monitor* in the project sidebar. It shows every participant from the moment they scan the QR,
 moving through *Scanned → Setting up → Recording* - so you spot the person stuck at the mic
-check while they're still in the room. Each live recording shows its state, duration, and a
-live transcript snippet; if someone's audio stops coming in you get an *Audio stopped?*
-warning, and a locked phone shows as *Screen locked*. Transcription progress and errors show
+check while they're still in the room. Each live recording shows its state, duration, a level
+meter so you can see audio is actually arriving, and a live transcript snippet; if someone's
+audio stops coming in you get an *Audio stopped?* warning, and a locked phone shows as
+*Screen locked*. Transcription progress and errors show
 per conversation, with a rough *catch up* estimate when a backlog builds. The project home
 shows the same thing in brief under *Live & recent*.
 


### PR DESCRIPTION
Follow-up to #802 (which caught up docs for #778–#800). Documents the **live mic-level meter** added to the Monitor in #803.

The Monitor now shows a per-recording level meter (from the participant beacon's `audio_level`, 0..1 RMS) so the host can *see* audio is actually flowing — not just that chunks are landing — with a soft "check the mic isn't muted" nudge when it goes silent.

Updated, all grounded in the shipped labels:
- `docs/_authoring/FACTS.md` — Monitor per-conversation rows now list the mic-level meter
- `docs/features/recording.md` — "Is the audio coming in?" bullet
- `docs/users/host/collecting-conversations.md` — host retelling

Build: `folder2website` clean (84 pages, no broken links/anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)