### PR TITLE
docs(go): mark dembrane Go as beta - not yet on the App Store

### DIFF
--- a/docs/_authoring/FACTS.md
+++ b/docs/_authoring/FACTS.md
@@ -321,6 +321,12 @@ No account required. Public/participant API in §10.4.
 
 ## 9. dembrane Go (iOS) - native SwiftUI app (`dembrane-go/`)
 
+*Distribution: BETA.* NOT on the App Store yet - distributed via TestFlight to invited
+testers only. Beta sign-up: email sameer@dembrane.com. Docs must not imply general
+availability; user-facing mentions carry a "beta" qualifier and the canonical pages
+(`features/mobile-app-dembrane-go.md`, `users/host/using-dembrane-go-mobile.md`) carry the
+contact callout. Drop all of this at App Store launch.
+
 Production env, email/password + 2FA login, register. Local-first chunked recording
 (30 s chunks, survives crash/kill, background capture, Live Activity / Dynamic Island,
 waveform, mic selector), audio-file import. Conversations list/detail (transcript, summary,

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -39,7 +39,7 @@ Getting spoken (or written) input into dembrane.
 - *[The participant portal](./portal-and-participant-experience.md)* - the no-account
   experience people use to record for you.
 - *[The portal editor](./portal-editor.md)* - how you shape that experience.
-- *[dembrane Go (mobile)](./mobile-app-dembrane-go.md)* - the native iOS recorder.
+- *[dembrane Go (mobile)](./mobile-app-dembrane-go.md)* - the native iOS recorder, currently in beta.
 
 ## Making sense of it
 

--- a/docs/features/mobile-app-dembrane-go.md
+++ b/docs/features/mobile-app-dembrane-go.md
@@ -1,6 +1,6 @@
 ---
 title: dembrane Go (the mobile app)
-description: The native iOS recorder for facilitators - local-first chunked recording, background capture, conversations, chat, and portal settings on the go.
+description: The native iOS recorder for facilitators - local-first chunked recording, background capture, conversations, chat, and portal settings on the go. Currently in beta, not yet on the App Store.
 audience: host
 ---
 
@@ -10,6 +10,11 @@ dembrane Go is the native iOS app for the person in the room - walking a venue, 
 tables, recording conversation after conversation on a phone. It records *locally first*, keeps
 going in the background, and uploads to the same project you'd see on the
 [dashboard](./projects.md). On background-recording resilience it's actually *ahead* of the web.
+
+> [!IMPORTANT]
+> dembrane Go is in *beta* - it isn't on the App Store yet. We're inviting a small group of
+> testers through TestFlight while we finish it. Want to be one of them? Email
+> [sameer@dembrane.com](mailto:sameer@dembrane.com) and we'll get you set up.
 
 You sign in with your email and password (two-factor supported), into the same workspaces and
 projects as the web. What you can do still follows your

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -27,9 +27,9 @@ through onboarding, consent, a mic check, and recording.
 
 You can also record yourself. From the dashboard you get the same recorder participants use,
 with the same pause, resume and stop controls - useful when you're the one in the room.
-[dembrane Go](./mobile-app-dembrane-go.md), the native iOS app, is the most robust option when
-connectivity is shaky: it records to the device first and uploads when it can, so a dead spot
-never costs you the conversation.
+[dembrane Go](./mobile-app-dembrane-go.md), the native iOS app (currently in beta), is the
+most robust option when connectivity is shaky: it records to the device first and uploads
+when it can, so a dead spot never costs you the conversation.
 
 ## The mic check
 
@@ -90,5 +90,5 @@ asked for them* in the [portal editor](./portal-editor.md), and transcripts can 
 - [Transcription](./transcription.md) - what happens to the audio once it's uploaded.
 - [The participant portal](./portal-and-participant-experience.md) - the no-account recording
   experience, end to end.
-- [dembrane Go (mobile)](./mobile-app-dembrane-go.md) - the native iOS recorder.
+- [dembrane Go (mobile)](./mobile-app-dembrane-go.md) - the native iOS recorder (beta).
 - [Tiers & billing](./tiers-and-billing.md) - recording hours and what's metered.

--- a/docs/users/host/collecting-conversations.md
+++ b/docs/users/host/collecting-conversations.md
@@ -21,7 +21,7 @@ doesn't use recording time.
 | *Portal: QR or direct link* | The people themselves, on their own phones | Many people at once; self-service; in person or remote |
 | *Record yourself (browser)* | You, on a laptop | You're holding the conversation or interviewing |
 | *Upload text* | No one - you already have it | Migrating data, or audio captured elsewhere |
-| *dembrane Go (iOS)* | You, on your phone | Mobile, walking, or flaky-laptop situations |
+| *dembrane Go (iOS, beta)* | You, on your phone | Mobile, walking, or flaky-laptop situations |
 
 ## The portal: QR or direct link
 
@@ -99,6 +99,9 @@ away from a desk: local-first recording in 30-second chunks that survives a cras
 being killed, background recording, a Live Activity in the Dynamic Island, and a microphone
 selector. Sign in with your dembrane account, pick the project, and record - conversations
 sync to the same project and transcribe like browser recordings.
+
+dembrane Go is in *beta* - it isn't on the App Store yet. Email
+[sameer@dembrane.com](mailto:sameer@dembrane.com) to join the TestFlight beta.
 
 > [!IMPORTANT]
 > dembrane Go is a *recording* companion. Analysis, reports, the library, and project

--- a/docs/users/host/getting-started.md
+++ b/docs/users/host/getting-started.md
@@ -68,7 +68,7 @@ ready-to-print sheet with instructions and the code on it.
 People open the portal, do a quick mic test, and talk - the portal handles pausing,
 resuming, and uploading in the background. You can mix in other ways too: record yourself in
 the browser if you're holding the conversation, upload transcripts you already have, or
-record on your phone with [dembrane Go](./using-dembrane-go-mobile.md). See
+record on your phone with [dembrane Go](./using-dembrane-go-mobile.md) (currently in beta). See
 [collecting conversations](./collecting-conversations.md) for which to use when.
 
 ## 6. Read what comes back

--- a/docs/users/host/index.md
+++ b/docs/users/host/index.md
@@ -23,7 +23,7 @@ Almost everything you do falls into three movements.
 [set up its portal](./portal-editor.md), and share a QR code or link so people can record.
 There are [several ways to collect](./collecting-conversations.md) - the portal, recording
 yourself, uploading text you already have, or recording on your phone with
-[dembrane Go](./using-dembrane-go-mobile.md).
+[dembrane Go](./using-dembrane-go-mobile.md) (currently in beta).
 
 *Understand.* Audio [transcribes automatically](../../features/transcription.md) and gets a
 summary. [Read and organise](./transcripts-and-conversations.md) what comes in, then
@@ -44,7 +44,7 @@ reading - the judgement stays yours.
 - [Collecting conversations](./collecting-conversations.md) - every way to gather input.
 - [Setting up the portal](./portal-editor.md) - configuring the page participants see.
 - [Transcripts & conversations](./transcripts-and-conversations.md) - reading and tidying what you've collected.
-- [Using dembrane Go on mobile](./using-dembrane-go-mobile.md) - recording from your phone.
+- [Using dembrane Go on mobile](./using-dembrane-go-mobile.md) - recording from your phone (beta).
 - [Getting help](./getting-help.md) - every way to reach the dembrane team when you're stuck.
 
 ## Related

--- a/docs/users/host/using-dembrane-go-mobile.md
+++ b/docs/users/host/using-dembrane-go-mobile.md
@@ -1,6 +1,6 @@
 ---
 title: Using dembrane Go on mobile
-description: A host's guide to the dembrane Go iOS app - when to record on mobile versus the web, what syncs, and what stays web-only.
+description: A host's guide to the dembrane Go iOS app - when to record on mobile versus the web, what syncs, and what stays web-only. Currently in beta, not yet on the App Store.
 audience: host
 ---
 
@@ -11,6 +11,11 @@ with your dembrane account, pick a project, and record - it captures locally and
 then syncs into the same [projects](./creating-a-project.md) you use on the web, on the same
 transcription back end. A recording made on your phone is indistinguishable from a browser
 one once it lands.
+
+> [!IMPORTANT]
+> dembrane Go is in *beta* - it isn't on the App Store yet. To record on your phone today,
+> email [sameer@dembrane.com](mailto:sameer@dembrane.com) and we'll invite you to the
+> TestFlight beta.
 
 For the role-neutral reference, see
 [dembrane Go (the mobile app)](../../features/mobile-app-dembrane-go.md).


### PR DESCRIPTION
## What

The docs currently read as if dembrane Go is generally available, but it hasn't shipped to the App Store yet. This gives it the same treatment as dembrane next: an explicit availability status, and a way in for people who want to try it.

- The two canonical Go pages (`features/mobile-app-dembrane-go.md`, `users/host/using-dembrane-go-mobile.md`) open with an `[!IMPORTANT]` callout: dembrane Go is in beta, not on the App Store, TestFlight invites via sameer@dembrane.com. Frontmatter descriptions (previews/SEO) say the same.
- Every passing mention gets a light "beta" qualifier: feature catalogue, recording page, collecting-conversations (table row + section, with the contact email), host overview, and getting-started.
- `_authoring/FACTS.md` §9 records the distribution status as a fact, so future doc authors (and the code-to-docs skill) don't regress it. It also notes to drop all beta tags at App Store launch — grep the docs for "beta" when that day comes.

## Notes

- Deliberately untouched: `map.md` (bare link list, same as dembrane-next), account-and-security + developer-internal mentions (they describe behaviour/code, not availability).
- No Dutch twins exist for the Go pages yet, so this is English-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)