### PR TITLE
SMART loop: run-lifecycle + worker-loop fixes (verified reproductions)

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -157,8 +157,10 @@ such as a wall, pulse, dashboard, or page that keeps itself fresh. Always say th
 expiry plainly. Do not volunteer exact cadence or interval minutes unless the
 host asks for that detail; say it keeps itself fresh or updates on the next
 refresh. The host applies the proposal, and you can list canvases or pause,
-resume, and stop their loops by chat. Be honest that updates are periodic, not
-instant second-by-second changes.
+resume, and stop their loops by chat. For pause/resume/stop requests, first
+resolve the referenced canvas with listCanvases when the host uses a name or
+shorthand such as "the wall"; then confirm the action by canvas name. Be honest
+that updates are periodic, not instant second-by-second changes.
 
 ## Project setup
 When the first message signals setup, or when readGoal shows this project has no
@@ -1001,31 +1003,66 @@ def create_agent_graph(
             await client.close()
         return {"canvases": canvases}
 
-    async def _canvas_loop_action(canvas_id: str, action: str) -> dict[str, Any]:
-        normalized_canvas_id = canvas_id.strip()
-        if not normalized_canvas_id:
+    async def _resolve_canvas_id(reference: str) -> tuple[str, str | None]:
+        normalized_reference = reference.strip()
+        if not normalized_reference:
             raise ValueError("canvas_id is required.")
         client = _create_echo_client()
         try:
-            loop = await client.update_canvas_loop(project_id, normalized_canvas_id, action)
+            canvases = await client.list_canvases(project_id)
         finally:
             await client.close()
-        return {"canvas_id": normalized_canvas_id, "loop": loop}
+        if not canvases:
+            return normalized_reference, None
+
+        for canvas in canvases:
+            canvas_id = str(canvas.get("id") or "")
+            if canvas_id == normalized_reference:
+                return canvas_id, canvas.get("name")
+
+        reference_lower = normalized_reference.lower()
+        named = [
+            canvas
+            for canvas in canvases
+            if str(canvas.get("name") or "").strip().lower() == reference_lower
+        ]
+        if not named:
+            named = [
+                canvas
+                for canvas in canvases
+                if reference_lower in str(canvas.get("name") or "").strip().lower()
+            ]
+        if len(named) == 1:
+            canvas = named[0]
+            return str(canvas["id"]), canvas.get("name")
+        if len(named) > 1:
+            names = ", ".join(str(canvas.get("name") or canvas.get("id")) for canvas in named)
+            raise ValueError(f"Multiple canvases match {normalized_reference!r}: {names}.")
+        raise ValueError(f"No canvas matches {normalized_reference!r}. Use listCanvases first.")
+
+    async def _canvas_loop_action(canvas_id: str, action: str) -> dict[str, Any]:
+        resolved_canvas_id, resolved_name = await _resolve_canvas_id(canvas_id)
+        client = _create_echo_client()
+        try:
+            loop = await client.update_canvas_loop(project_id, resolved_canvas_id, action)
+        finally:
+            await client.close()
+        return {"canvas_id": resolved_canvas_id, "canvas_name": resolved_name, "loop": loop}
 
     @tool
     async def pauseCanvasLoop(canvas_id: str) -> dict[str, Any]:
-        """Pause a canvas loop. Use this when the host asks to pause updates."""
+        """Pause a canvas loop. canvas_id may be an id or unique canvas name/reference."""
         return await _canvas_loop_action(canvas_id, "pause")
 
     @tool
     async def resumeCanvasLoop(canvas_id: str) -> dict[str, Any]:
-        """Resume a paused canvas loop if it has not ended."""
+        """Resume a paused canvas loop if it has not ended. canvas_id may be an id or unique canvas name/reference."""
         return await _canvas_loop_action(canvas_id, "resume")
 
     @tool
     async def stopCanvasLoop(canvas_id: str) -> dict[str, Any]:
         """Stop a canvas loop permanently. Confirm with the host first because
-        stopping is terminal."""
+        stopping is terminal. canvas_id may be an id or unique canvas name/reference."""
         return await _canvas_loop_action(canvas_id, "stop")
 
     @tool

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -1235,10 +1235,54 @@ async def test_canvas_loop_tools_call_expected_actions():
     assert pause["canvas_id"] == "canvas-1"
     assert resume["loop"]["status"] == "paused"
     assert stop["loop"]["status"] == "paused"
-    assert [instance.canvas_loop_calls[0]["action"] for instance in factory.instances] == [
+    update_calls = [
+        instance.canvas_loop_calls[0]["action"]
+        for instance in factory.instances
+        if instance.canvas_loop_calls
+    ]
+    assert update_calls == [
         "pause",
         "resume",
         "stop",
+    ]
+    assert all(instance.closed for instance in factory.instances)
+
+
+@pytest.mark.asyncio
+async def test_canvas_loop_tool_resolves_unique_name_reference():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        canvases_payload=[
+            {
+                "id": "canvas-1",
+                "name": "Live Emerging Themes Wall",
+                "loop": {"status": "active"},
+            },
+        ],
+        canvas_loop_response={
+            "status": "paused",
+            "expires_at": "later",
+            "cadence_minutes": 5,
+        },
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    pause = await tools["pauseCanvasLoop"].ainvoke({"canvas_id": "wall"})
+
+    assert pause["canvas_id"] == "canvas-1"
+    assert pause["canvas_name"] == "Live Emerging Themes Wall"
+    assert factory.instances[0].list_canvases_calls == ["project-1"]
+    assert factory.instances[1].canvas_loop_calls == [
+        {"project_id": "project-1", "canvas_id": "canvas-1", "action": "pause"}
     ]
     assert all(instance.closed for instance in factory.instances)
 

--- a/echo/docs/plans/smart-loop-briefs/wave6d-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave6d-REPORT.md
@@ -1,0 +1,48 @@
+# Wave 6d report - echo-next post-deploy verification
+
+Run date: 2026-07-08 Europe/Amsterdam. Target: `https://dashboard.echo-next.dembrane.com`, admin account. Evidence is in `wave6d-shots/`; primary machine-readable evidence is `wave6d-shots/wave6d-evidence.json`.
+
+## Verdicts
+
+0. FRESHNESS GATE: PASS.
+   - API health source of truth was `https://api.echo-next.dembrane.com/api/health`: `200 {"status":"ok"}`.
+   - Project overview rendered the new Methodology section. Evidence project `8a4120bf-47e0-4acb-a4fa-ce22fa016cca` showed current methodology `dembrane (default)` and framing `Figure out what this project is for, then shape reports and canvases around that goal.` Screenshot: `02-freshness-methodology.png`.
+
+1. BEAT 1 RETEST: FAIL.
+   - Fresh project: `Wave 6d Verify 1783467296852`, project id `01b0125f-691a-4827-a60a-c3c70ce64296`, setup chat `bd520af5-50b5-432b-9286-9b8e6b720075`.
+   - The seeded setup run did attach stream, but it also made unexpected stop calls without a user Stop click. Captured network for run `f37a72af-6a5b-404b-a766-dd7d706958dd`:
+     - `POST /agentic/runs/f37a72af-6a5b-404b-a766-dd7d706958dd/stream?after_seq=0`
+     - `POST /agentic/runs/f37a72af-6a5b-404b-a766-dd7d706958dd/stream?after_seq=1`
+     - `POST /agentic/runs/f37a72af-6a5b-404b-a766-dd7d706958dd/stop` -> `200`
+     - later another `POST /agentic/runs/f37a72af-6a5b-404b-a766-dd7d706958dd/stop` -> `200`
+   - Run API for the same run reported `latest_error_code: AGENT_CANCELLED`, `latest_error: Run cancelled by user`, no `latest_output`, and only four events.
+   - The interview did not reach a goal proposal. After three Marieke answers, the composer did not return to an actionable send state before timeout. Screenshots: `05-setup-chat-seeded.png`, `06-setup-seeded-after-idle.png`, `07-marieke-answer-1.png`, `07-marieke-answer-2.png`, `07-marieke-answer-3.png`.
+   - Because no goal proposal card appeared, the Apply path and project settings `interview` attribution could not be verified end-to-end.
+
+2. BEAT 5 RETEST: FAIL / PARTIAL.
+   - Retested on the existing Wave 6a project with canvas `5` (`Live Emerging Themes Wall`) because the fresh setup chat was stuck.
+   - Chat turns for `Pause the wall.`, `Resume the wall.`, and `What's in my library?` all returned the composer to idle; it did not remain stuck on `Working on your answer...`.
+   - The library answer mentioned the canvas/list as expected.
+   - The loop status check after `Pause the wall.` did not show `Paused`; `pauseCanvasHasPaused` was false in evidence. Resume ended with an active-looking `Stays up to date` state.
+   - The continuation pass did not capture `/stream` network entries for these Beat 5 turns, so the required network evidence for Beat 5 is incomplete. Screenshots: `25-beat2-chat-pause.png`, `26-beat2-canvas-paused.png`, `27-beat2-chat-resume.png`, `28-beat2-canvas-resumed.png`, `29-beat2-library-answer.png`.
+
+3. METHODOLOGY SMOKE: PARTIAL.
+   - Project overview selector rendered `dembrane (default)` and framing. Screenshot: `30-methodology-project-select.png`.
+   - Workspace General tab rendered the Methodologies card and the dembrane row as built-in/read-only with no Edit button. Screenshot: `31-methodology-visible-readonly.png`.
+   - I could not complete the create/edit/select-patch portion under Playwright. The modal opened in probes, but repeated scripted create attempts lost access to the Framing field or modal focus before save. Treat the create/edit workflow as not verified in this pass, not as a confirmed product failure.
+
+4. GENERATION QUALITY: FAIL / INCONCLUSIVE.
+   - I refreshed canvas `5` on project `ed606b2f-8d84-45b5-9e6a-efb51e9cb7b6`, which has real uploaded material from Wave 6a. Screenshots: `34-quality-before-refresh.png`, `35-quality-refresh-clicked.png`, `36-quality-after-refresh.png`.
+   - No new generation id appeared within the polling window after the refresh click. The latest stored generation in the API response remained `12aa8e7e-d8d9-4f3c-bd5e-cbf873890e9c`, status `error`, `tick_kind: scheduled`, with empty `content_html`.
+   - Because no new successful stored generation was produced, I could not validate the new stored-generation rules against post-fix output. The empty/error latest generation has no HTML comments, no `canvas-shell` restyle, no cadence copy, and no assistant footer, but that is not meaningful quality evidence because there is no generated HTML.
+
+## Artifacts
+
+- Evidence JSON: `echo/docs/plans/smart-loop-briefs/wave6d-shots/wave6d-evidence.json`
+- Screenshots: `echo/docs/plans/smart-loop-briefs/wave6d-shots/`
+
+## Notes
+
+- No code changes were made.
+- No git write commands were run.
+- The strongest regression evidence is Beat 1: the seeded setup run still issued `/stop` calls and ended as `AGENT_CANCELLED`, matching the original failure class.

--- a/echo/docs/plans/smart-loop-briefs/wave6d-verify.md
+++ b/echo/docs/plans/smart-loop-briefs/wave6d-verify.md
@@ -1,0 +1,30 @@
+# Brief: Wave 6d - post-deploy verification on echo-next
+
+The hardening merged (#808). Verify the fixes on https://dashboard.echo-next.dembrane.com
+(admin@dembrane.com / dembrane2024, Playwright, real everything). Read
+wave6a-REPORT.md (the failures) and wave6c-REPORT.md (the fixes + their "Remaining QA"
+section - that section is your checklist).
+
+0. FRESHNESS GATE first: confirm the new frontend is live - project settings must show
+   the Methodology section (shipped in this merge). If absent, wait and retry (Vercel +
+   Argo lag); do not test stale code. Also confirm api health 200.
+1. BEAT 1 RETEST (was FAIL): create a fresh project -> land in setup chat -> watch the
+   NETWORK: the seeded run must attach POST /runs/{id}/stream and there must be NO
+   /runs/{id}/stop call. Let the live interview run; answer briefly as Marieke; a goal
+   proposal card should appear -> Apply -> project settings shows the goal with
+   'interview' attribution (set-by line).
+2. BEAT 5 RETEST (was FAIL): in a chat with a canvas (create one if needed via a quick
+   proposeCanvas flow), send 'Pause the wall.' -> the run must attach /stream and
+   complete; loop status becomes paused; 'Resume the wall.' works; 'What's in my
+   library?' answers with the canvas list. Composer must never stick at 'Working on
+   your answer...'.
+3. METHODOLOGY SMOKE: project settings selector lists dembrane (default, framing
+   shown) and patches selection; workspace General tab Methodologies card: create one,
+   edit it (history note), confirm dembrane row has no Edit.
+4. GENERATION QUALITY spot-check: refresh a canvas on a project with real material;
+   confirm the new rules hold (no HTML comments in the stored generation - check via
+   API; no canvas-shell restyle; no cadence talk in the agent's chat replies).
+
+Screenshots per step to wave6d-shots/ (do not git-add). NO code changes in this pass -
+findings only. Report -> echo/docs/plans/smart-loop-briefs/wave6d-REPORT.md with
+PASS/FAIL per item and network evidence for 1 and 2.

--- a/echo/docs/plans/smart-loop-briefs/wave6e-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave6e-REPORT.md
@@ -1,0 +1,147 @@
+# Wave 6e Fix Report
+
+Branch: `sameer/smart-loop-hardening`
+
+## Scope Read
+
+- Read `echo/docs/plans/smart-loop-briefs/wave6e-fixes.md` fully.
+- Read cited reports and evidence:
+  - `echo/docs/plans/smart-loop-briefs/wave6d-REPORT.md`
+  - `echo/docs/plans/smart-loop-briefs/wave6c-REPORT.md`
+  - `echo/docs/plans/smart-loop-briefs/wave6d-shots/wave6d-evidence.json`
+- Re-checked echo-next cited pause run `8a06e15d-e6d4-4dfb-a9b1-104d7d059f25` for chat `1c0c896c-8b88-47d7-b59a-c20d9de01453`: it is still `queued` with only the initial `user.message` event, so production evidence does not prove tool execution for that pause request.
+
+## Fixes
+
+### A. Setup Chat Accidental Stop
+
+- Changed the chat Stop button so `handleStop` only calls `/stop` when the current run was armed by a pointer down or keyboard activation that originated on the Stop control.
+- This preserves normal Stop behavior but ignores the Send-to-Stop morph race where a click started on Send and ended on the newly rendered Stop button.
+- File: `echo/frontend/src/components/chat/AgenticChatPanel.tsx`
+
+### B. Scheduled Canvas Tick Cancellation / Error Visibility
+
+- Made `AsyncDirectusClient` keep a separate `httpx.AsyncClient` per running event loop instead of reusing one async client across FastAPI and Dramatiq/scheduler loops.
+- Kept `_client` compatibility for existing tests that inject a client, while closing every loop-local client in `close()`.
+- Made scheduled tick error handling create an `agent_loop_run` error row even when the failure happens before a generation id exists, and create an error generation only when a report id is available.
+- Files:
+  - `echo/server/dembrane/directus_async.py`
+  - `echo/server/dembrane/canvas/ticks.py`
+
+### C. Canvas Pause/Resume/Stop by Name
+
+- Updated agent canvas lifecycle tool docs and system prompt to resolve named or shorthand canvas references before pause/resume/stop.
+- Added `_resolve_canvas_id()` to accept exact ids, exact names, and unique substring name references; ambiguous or missing references now fail clearly.
+- Preserved backwards compatibility by passing through the reference when the canvas list is unavailable in tests or degraded conditions.
+- File: `echo/agent/agent.py`
+
+### D. Methodology Modal Automation Stability
+
+- New/edit methodology modals now render only while open, preventing hidden stale modal roots from matching test selectors.
+- Added explicit form/cancel test ids and disabled modal focus traps for automation stability.
+- File: `echo/frontend/src/components/methodology/WorkspaceMethodologiesSection.tsx`
+
+## Tests Added / Updated
+
+- Added server regression coverage for loop-local async Directus clients across event loops.
+- Added server regression coverage for canvas tick error run rows when required ids are missing.
+- Added agent regression coverage for resolving a unique canvas name reference before lifecycle updates.
+- Updated the existing agent canvas lifecycle test to avoid counting list-client setup calls as update calls.
+
+## Required Local Reproductions
+
+### A. Full Local Stack Setup Wizard
+
+Stack used:
+
+- Server API: `uv run uvicorn dembrane.main:app --port 8123 --loop asyncio`
+- Agent API: `uv run uvicorn main:app --host 0.0.0.0 --port 8001`
+- Network worker: `uv run dramatiq-gevent --queues network --processes 1 --threads 10 dembrane.tasks`
+- Scheduler: `uv run python -m dembrane.scheduler`
+- Frontend: `corepack pnpm@10 run dev -- --host 127.0.0.1 --port 5175`
+
+Browser reproduction:
+
+- Logged in locally as `admin@dembrane.com`.
+- Created project `Wave 6e Stop Repro 1783468817327`.
+- Used the setup wizard path with "Help me figure it out", then waited on the setup chat.
+- Observed run `b8915b8e-b6bf-41a3-a575-918833f171fb`.
+
+Evidence:
+
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/A-network.json`
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/A-setup-chat.png`
+
+Result:
+
+- Stream requests: 4.
+- Stop requests: 0.
+- No accidental `/stop` call was emitted during setup chat creation/stream reattachment.
+
+### B. Real Worker-Driven Scheduled Tick
+
+Using the same local stack and project `f30f1283-cd47-4dcf-9225-c31f686c15d5`:
+
+- Created canvas `5` named `Wave 6e Scheduled Tick 1783468882573` through the real BFF canvas API.
+- Cadence was set to 2 minutes.
+- The running scheduler and network Dramatiq worker produced scheduled generation `b2af9b26-61c6-4f8c-96e1-ac9bc191d689`.
+
+Evidence:
+
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/B-scheduled-tick.json`
+
+Result:
+
+- Latest generation status: `ok`.
+- Tick kind: `scheduled`.
+- Detail: `null`.
+- No `Attempted to exit cancel scope in a different task than it was entered in` error occurred.
+
+## Verification
+
+Passed:
+
+- `cd echo/server && uv run pytest tests/test_canvas_ticks.py tests/test_directus_retry.py -q`
+  - `14 passed`
+- `cd echo/agent && uv run pytest tests/test_agent_tools.py -q`
+  - `32 passed, 1 warning`
+- `cd echo/frontend && ./node_modules/.bin/biome lint src/components/chat/AgenticChatPanel.tsx src/components/methodology/WorkspaceMethodologiesSection.tsx --diagnostic-level=error && ./node_modules/.bin/tsc --noEmit`
+- `cd echo/frontend && npm run lint && ./node_modules/.bin/tsc --noEmit && npm run messages:compile`
+- `cd echo/agent && uv run pytest -q`
+  - `68 passed, 4 warnings`
+- `cd echo/server && uv run ruff check .`
+  - `All checks passed!`
+
+Formatting:
+
+- `cd echo/frontend && ./node_modules/.bin/biome format --write src/components/chat/AgenticChatPanel.tsx src/components/methodology/WorkspaceMethodologiesSection.tsx`
+- `cd echo/server && uv run ruff format dembrane/directus_async.py dembrane/canvas/ticks.py tests/test_directus_retry.py tests/test_canvas_ticks.py`
+- `cd echo/agent && uv run ruff format agent.py tests/test_agent_tools.py`
+  - Could not run because the agent environment failed to spawn `ruff`; agent files were manually inspected after edits.
+
+Full server suite:
+
+- `cd echo/server && uv run ruff check . && uv run pytest -q`
+- Ruff passed.
+- Full pytest did not pass: `59 failed, 1059 passed, 4 skipped, 14 warnings, 2 errors`.
+- Failures were in broad unrelated areas including agentic API integration cases, billing/price tests, audio/S3 fixture paths such as `big.m4a`, AssemblyAI/transcription, and seat/access tests. The targeted Wave 6e server tests passed.
+
+## Files Modified
+
+- `echo/frontend/src/components/chat/AgenticChatPanel.tsx`
+- `echo/frontend/src/components/methodology/WorkspaceMethodologiesSection.tsx`
+- `echo/server/dembrane/directus_async.py`
+- `echo/server/dembrane/canvas/ticks.py`
+- `echo/server/tests/test_directus_retry.py`
+- `echo/server/tests/test_canvas_ticks.py`
+- `echo/agent/agent.py`
+- `echo/agent/tests/test_agent_tools.py`
+- `echo/docs/plans/smart-loop-briefs/wave6e-REPORT.md`
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/A-network.json`
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/A-setup-chat.png`
+- `echo/docs/plans/smart-loop-briefs/wave6e-shots/B-scheduled-tick.json`
+
+## Remaining Work
+
+- Deploy/post-deploy verification on echo-next is still needed because the current echo-next cited pause run never executed beyond the initial queued event.
+- The unrelated full server pytest failures remain for their owning areas.

--- a/echo/docs/plans/smart-loop-briefs/wave6e-fixes.md
+++ b/echo/docs/plans/smart-loop-briefs/wave6e-fixes.md
@@ -1,0 +1,73 @@
+# Brief: Wave 6e - three verified failures from the post-deploy check
+
+Read wave6d-REPORT.md (the evidence) and wave6c-REPORT.md (the previous attempt).
+Three fixes, each with hard evidence. Branch: sameer/smart-loop-hardening.
+
+## A (HIGH): the seeded setup run STILL gets stopped - find the real caller
+
+wave6d network capture for run f37a72af-6a5b-404b-a766-dd7d706958dd: stream attach
+(after_seq=0), re-attach (after_seq=1), then TWO POST /stop calls with NO user click ->
+AGENT_CANCELLED. The 6c fix (Stop type=button) was not the cause or not the only cause.
+
+- Hunt EVERY path that can reach stopAgenticRun in the frontend: direct calls, effect
+  cleanups, chatId-change effects, unmount handlers, the watchdog added in 6c (could it
+  or its guards call stop?), and anything that "cleans up" a previous run when state
+  changes. Two stops suggests a mount/remount sequence during the create->navigate
+  flow (possible locale-prefix redirect or layout remount) where each instance stops
+  the run it thinks is stale.
+- DESIGN RULE to enforce: the runtime is reconnect-driven - abandoning a stream is
+  SAFE and the run resumes on reattach. The frontend must NEVER stop a run except an
+  explicit user action on the Stop control. Delete/disable any programmatic stop.
+- Reproduce locally (full local stack, wave-4 proxy env vars, echo-host-redis): create
+  a project via the wizard, watch the network tab - prove the stop calls are gone and
+  the stream stays attached. This reproduction is REQUIRED this time; wave 6c shipped
+  without it and the bug survived.
+
+## B (HIGH): scheduled ticks crash with a cancel-scope error in the worker
+
+Evidence (echo-next, canvas_generation): status=error, detail "Attempted to exit
+cancel scope in a different task than it was entered in", tick_kind=scheduled, empty
+content_html. Manual refresh (inline in the API process) works; scheduled ticks (Dramatiq
+worker via run_async_in_new_loop) intermittently crash.
+
+- Root cause class: async clients/objects shared across event loops. This codebase
+  already solved this once - the shared-background-loop fix (grep dembrane/async_helpers
+  and its callers; see how summaries/merge tasks run async work on ONE persistent
+  background loop instead of new loops with shared clients).
+- Fix the tick execution path to either (a) run on the established shared background
+  loop pattern, or (b) construct fresh client instances per tick (no module-level
+  async_directus/httpx/litellm client reuse across loops). Prefer (a) for consistency.
+- Also make the tick record the error detail on the agent_loop_run row (wave6d found
+  error generations but agent_loop_run rows were missing/not queryable for it - ensure
+  every tick writes its run row even on crash).
+- Reproduce locally: run a REAL network-queue Dramatiq worker on the host
+  (`cd echo/server && uv run dramatiq ...` - find the exact entrypoint in the repo/
+  devcontainer config) with the local stack; create a canvas with cadence 2; watch a
+  scheduled tick produce a real generation without the cancel-scope error. REQUIRED.
+
+## C (MEDIUM): "Pause the wall." answers but does not pause
+
+wave6d beat 5: composer returns to idle (6c watchdog works) and the agent replies, but
+the loop stays active. Determine what the agent actually did: pull the run's events from
+echo-next (GET /agentic run events via api.echo-next with a Directus admin token - find
+the run for the 'Pause the wall.' turn in chat on project
+ed606b2f-8d84-45b5-9e6a-efb51e9cb7b6, canvas 5) - did it call pauseCanvasLoop? With what
+canvas_id? What did the tool return?
+- Likely causes: the model answered without calling the tool, or could not resolve
+  "the wall" to a canvas id (does the prompt tell it to listCanvases first?), or the
+  tool errored silently. Fix accordingly (prompt nudge: resolve the canvas via
+  listCanvases before lifecycle calls + confirm by name; or tool accepts a name and
+  resolves server-side - pick the more robust one and say why).
+- Add an agent test for the chosen behavior.
+
+## D (LOW): methodology create/edit modal was un-automatable
+
+wave6d could not script the create/edit flow (focus/field losses). Review the modal:
+proper labels/testIds on every field, no focus traps, stable ids. Add testIds per house
+convention so the flow is verifiable.
+
+QA: gates for everything touched (server whole-tree ruff + tests incl. a new tick-loop
+test; frontend tsc/lint/lingui; agent pytest). The two REQUIRED local reproductions
+(A: no stop calls in the create flow network log; B: a worker-driven scheduled tick
+succeeding) must be described with evidence in the report. No git write commands.
+Report -> echo/docs/plans/smart-loop-briefs/wave6e-REPORT.md.

--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -542,6 +542,7 @@ export const AgenticChatPanel = ({
 	>({});
 	const streamAbortRef = useRef<AbortController | null>(null);
 	const streamRunIdRef = useRef<string | null>(null);
+	const stopArmedRunIdRef = useRef<string | null>(null);
 	const requestedStreamKeyRef = useRef<string | null>(null);
 	const currentRunIdRef = useRef<string | null>(null);
 	const [scrollTargetRef, isVisible] = useElementOnScreen({
@@ -1114,8 +1115,14 @@ export const AgenticChatPanel = ({
 		pendingUserMessage,
 	]);
 
+	const armStopControl = () => {
+		stopArmedRunIdRef.current = runId;
+	};
+
 	const handleStop = async () => {
 		if (!runId || !isInFlightStatus(runStatus)) return;
+		if (stopArmedRunIdRef.current !== runId) return;
+		stopArmedRunIdRef.current = null;
 		setIsStopping(true);
 		setError(null);
 		try {
@@ -1541,6 +1548,12 @@ export const AgenticChatPanel = ({
 												<IconPlayerStop size={14} />
 											)
 										}
+										onPointerDown={armStopControl}
+										onKeyDown={(event) => {
+											if (event.key === "Enter" || event.key === " ") {
+												armStopControl();
+											}
+										}}
 										onClick={() => void handleStop()}
 										disabled={isStopping}
 										{...testId("chat-stop-button")}

--- a/echo/frontend/src/components/methodology/WorkspaceMethodologiesSection.tsx
+++ b/echo/frontend/src/components/methodology/WorkspaceMethodologiesSection.tsx
@@ -223,143 +223,166 @@ export const WorkspaceMethodologiesSection = ({
 				)}
 			</Stack>
 
-			<Modal
-				opened={newOpen}
-				onClose={reset}
-				title={t`New methodology`}
-				{...testId("methodology-new-modal")}
-			>
-				<Stack gap="sm">
-					<TextInput
-						label={t`Name`}
-						value={form.name}
-						onChange={(event) =>
-							setForm((current) => ({ ...current, name: event.currentTarget.value }))
-						}
-						{...testId("methodology-new-name")}
-					/>
-					<TextInput
-						label={t`Description`}
-						value={form.description}
-						onChange={(event) =>
-							setForm((current) => ({
-								...current,
-								description: event.currentTarget.value,
-							}))
-						}
-						{...testId("methodology-new-description")}
-					/>
-					<Textarea
-						label={t`Framing`}
-						value={form.framing}
-						autosize
-						minRows={3}
-						onChange={(event) =>
-							setForm((current) => ({
-								...current,
-								framing: event.currentTarget.value,
-							}))
-						}
-						{...testId("methodology-new-framing")}
-					/>
-					<Group justify="flex-end" gap="xs">
-						<Button variant="subtle" onClick={reset}>
-							<Trans>Cancel</Trans>
-						</Button>
-						<Button
-							loading={createMutation.isPending}
-							onClick={() => void createMethodology()}
-							{...testId("methodology-new-save")}
-						>
-							<Trans>Create</Trans>
-						</Button>
-					</Group>
-				</Stack>
-			</Modal>
-
-			<Modal
-				opened={!!editing}
-				onClose={reset}
-				title={t`Edit methodology`}
-				size="lg"
-				{...testId("methodology-edit-modal")}
-			>
-				<Stack gap="sm">
-					{detailQuery.isLoading ? (
-						<Group gap="sm">
-							<Loader size="xs" />
-							<Text size="sm">
-								<Trans>Loading methodology</Trans>
-							</Text>
+			{newOpen ? (
+				<Modal
+					opened
+					onClose={reset}
+					title={t`New methodology`}
+					trapFocus={false}
+					{...testId("methodology-new-modal")}
+				>
+					<Stack gap="sm" {...testId("methodology-new-form")}>
+						<TextInput
+							label={t`Name`}
+							value={form.name}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									name: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-new-name")}
+						/>
+						<TextInput
+							label={t`Description`}
+							value={form.description}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									description: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-new-description")}
+						/>
+						<Textarea
+							label={t`Framing`}
+							value={form.framing}
+							autosize
+							minRows={3}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									framing: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-new-framing")}
+						/>
+						<Group justify="flex-end" gap="xs">
+							<Button
+								variant="subtle"
+								onClick={reset}
+								{...testId("methodology-new-cancel")}
+							>
+								<Trans>Cancel</Trans>
+							</Button>
+							<Button
+								loading={createMutation.isPending}
+								onClick={() => void createMethodology()}
+								{...testId("methodology-new-save")}
+							>
+								<Trans>Create</Trans>
+							</Button>
 						</Group>
-					) : null}
-					<TextInput
-						label={t`Name`}
-						value={form.name}
-						onChange={(event) =>
-							setForm((current) => ({ ...current, name: event.currentTarget.value }))
-						}
-						{...testId("methodology-edit-name")}
-					/>
-					<TextInput
-						label={t`Description`}
-						value={form.description}
-						onChange={(event) =>
-							setForm((current) => ({
-								...current,
-								description: event.currentTarget.value,
-							}))
-						}
-						{...testId("methodology-edit-description")}
-					/>
-					<Textarea
-						label={t`Framing`}
-						value={form.framing}
-						autosize
-						minRows={3}
-						onChange={(event) =>
-							setForm((current) => ({
-								...current,
-								framing: event.currentTarget.value,
-							}))
-						}
-						{...testId("methodology-edit-framing")}
-					/>
-					<Textarea
-						label={t`Content`}
-						value={form.content}
-						autosize
-						minRows={5}
-						onChange={(event) =>
-							setForm((current) => ({
-								...current,
-								content: event.currentTarget.value,
-							}))
-						}
-						{...testId("methodology-edit-content")}
-					/>
-					<TextInput
-						label={t`History note`}
-						value={form.note}
-						onChange={(event) =>
-							setForm((current) => ({ ...current, note: event.currentTarget.value }))
-						}
-						{...testId("methodology-edit-note")}
-					/>
-					<Group justify="flex-end" gap="xs">
-						<Button variant="subtle" onClick={reset}>
-							<Trans>Cancel</Trans>
-						</Button>
-						<Button
-							loading={editMutation.isPending}
-							onClick={() => void saveMethodology()}
-							{...testId("methodology-edit-save")}
-						>
-							<Trans>Save</Trans>
-						</Button>
-					</Group>
-				</Stack>
-			</Modal>
+					</Stack>
+				</Modal>
+			) : null}
+
+			{editing ? (
+				<Modal
+					opened
+					onClose={reset}
+					title={t`Edit methodology`}
+					size="lg"
+					trapFocus={false}
+					{...testId("methodology-edit-modal")}
+				>
+					<Stack gap="sm" {...testId("methodology-edit-form")}>
+						{detailQuery.isLoading ? (
+							<Group gap="sm">
+								<Loader size="xs" />
+								<Text size="sm">
+									<Trans>Loading methodology</Trans>
+								</Text>
+							</Group>
+						) : null}
+						<TextInput
+							label={t`Name`}
+							value={form.name}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									name: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-edit-name")}
+						/>
+						<TextInput
+							label={t`Description`}
+							value={form.description}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									description: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-edit-description")}
+						/>
+						<Textarea
+							label={t`Framing`}
+							value={form.framing}
+							autosize
+							minRows={3}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									framing: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-edit-framing")}
+						/>
+						<Textarea
+							label={t`Content`}
+							value={form.content}
+							autosize
+							minRows={5}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									content: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-edit-content")}
+						/>
+						<TextInput
+							label={t`History note`}
+							value={form.note}
+							onChange={(event) =>
+								setForm((current) => ({
+									...current,
+									note: event.currentTarget.value,
+								}))
+							}
+							{...testId("methodology-edit-note")}
+						/>
+						<Group justify="flex-end" gap="xs">
+							<Button
+								variant="subtle"
+								onClick={reset}
+								{...testId("methodology-edit-cancel")}
+							>
+								<Trans>Cancel</Trans>
+							</Button>
+							<Button
+								loading={editMutation.isPending}
+								onClick={() => void saveMethodology()}
+								{...testId("methodology-edit-save")}
+							>
+								<Trans>Save</Trans>
+							</Button>
+						</Group>
+					</Stack>
+				</Modal>
+			) : null}
 		</Paper>
 	);
 };

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -51,10 +51,7 @@ def _choice_text(response: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(response, dict):
-        return (
-            ((response.get("choices") or [{}])[0].get("message") or {}).get("content")
-            or ""
-        )
+        return ((response.get("choices") or [{}])[0].get("message") or {}).get("content") or ""
     return ""
 
 
@@ -150,7 +147,9 @@ async def _latest_config(report_id: str) -> dict[str, Any]:
     return config
 
 
-async def _generate_html(*, brief: str, previous_html: str | None, gather_bundle: dict[str, Any]) -> str:
+async def _generate_html(
+    *, brief: str, previous_html: str | None, gather_bundle: dict[str, Any]
+) -> str:
     project = gather_bundle.get("project") or {}
     user = "\n\n".join(
         [
@@ -208,13 +207,16 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
         )
         return {"status": "no_op", "run": run}
 
-    report_id = _as_id(loop.get("report_id"))
-    project_id = _as_id(loop.get("project_id"))
-    acting_user_id = str(loop.get("acting_directus_user_id") or "")
-    if not report_id or not project_id or not acting_user_id:
-        raise RuntimeError("Canvas loop is missing required ids")
-
+    report_id: str | None = None
+    project_id: str | None = None
+    acting_user_id = ""
     try:
+        report_id = _as_id(loop.get("report_id"))
+        project_id = _as_id(loop.get("project_id"))
+        acting_user_id = str(loop.get("acting_directus_user_id") or "")
+        if not report_id or not project_id or not acting_user_id:
+            raise RuntimeError("Canvas loop is missing required ids")
+
         config = await _latest_config(report_id)
         latest_ok = await _latest_ok_generation(report_id)
         gather_bundle = await execute_gather_spec(
@@ -227,7 +229,10 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
         if (
             tick_kind != "manual"
             and latest_ok
-            and (not latest_content_at or (latest_generation_at and latest_content_at <= latest_generation_at))
+            and (
+                not latest_content_at
+                or (latest_generation_at and latest_content_at <= latest_generation_at)
+            )
         ):
             run = await _create_run(
                 loop_id=loop_id,
@@ -274,25 +279,27 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
         return {"status": "ok", "generation": generation, "run": run}
     except (CanvasReaderAccessDenied, CanvasSanitizationError, Exception) as exc:
         detail = str(exc)
-        generation = (
-            await async_directus.create_item(
-                "canvas_generation",
-                {
-                    "id": generate_uuid(),
-                    "report_id": report_id,
-                    "config_revision_id": _as_id((locals().get("config") or {}).get("id")),
-                    "content_html": "",
-                    "status": "error",
-                    "tick_kind": tick_kind,
-                    "detail": detail[:5000],
-                },
-            )
-        )["data"]
+        generation = None
+        if report_id:
+            generation = (
+                await async_directus.create_item(
+                    "canvas_generation",
+                    {
+                        "id": generate_uuid(),
+                        "report_id": report_id,
+                        "config_revision_id": _as_id((locals().get("config") or {}).get("id")),
+                        "content_html": "",
+                        "status": "error",
+                        "tick_kind": tick_kind,
+                        "detail": detail[:5000],
+                    },
+                )
+            )["data"]
         run = await _create_run(
             loop_id=loop_id,
             status="error",
             detail=detail[:5000],
-            generation_id=str(generation["id"]),
+            generation_id=str(generation["id"]) if generation else None,
             started_at=started_at,
         )
         await _update_loop_after_tick(loop, status="error")

--- a/echo/server/dembrane/directus_async.py
+++ b/echo/server/dembrane/directus_async.py
@@ -74,25 +74,44 @@ class AsyncDirectusClient:
     ):
         self.url = url.rstrip("/")
         self.token = token or ""
-        self._client: httpx.AsyncClient | None = None
+        self._clients_by_loop: dict[int, httpx.AsyncClient] = {}
         self._verify = verify
 
+    @property
+    def _client(self) -> httpx.AsyncClient | None:
+        """Compatibility hook for tests that inject the current loop's client."""
+        loop_id = id(asyncio.get_running_loop())
+        return self._clients_by_loop.get(loop_id)
+
+    @_client.setter
+    def _client(self, client: httpx.AsyncClient | None) -> None:
+        loop_id = id(asyncio.get_running_loop())
+        if client is None:
+            self._clients_by_loop.pop(loop_id, None)
+        else:
+            self._clients_by_loop[loop_id] = client
+
     def _get_client(self) -> httpx.AsyncClient:
-        """Lazy-init the httpx.AsyncClient. Reuses connection pool."""
-        if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(
+        """Lazy-init one httpx.AsyncClient per event loop."""
+        loop_id = id(asyncio.get_running_loop())
+        client = self._clients_by_loop.get(loop_id)
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(
                 base_url=self.url,
                 headers={"Authorization": f"Bearer {self.token}"},
                 verify=self._verify,
                 timeout=DEFAULT_TIMEOUT,
             )
-        return self._client
+            self._clients_by_loop[loop_id] = client
+        return client
 
     async def close(self) -> None:
-        """Close the underlying httpx client. Call on shutdown."""
-        if self._client and not self._client.is_closed:
-            await self._client.aclose()
-            self._client = None
+        """Close all underlying httpx clients. Call on shutdown."""
+        clients = list(self._clients_by_loop.values())
+        self._clients_by_loop.clear()
+        for client in clients:
+            if not client.is_closed:
+                await client.aclose()
 
     # ------------------------------------------------------------------
     # Low-level request with retry
@@ -202,7 +221,8 @@ class AsyncDirectusClient:
             except Exception:
                 logger.warning(
                     "SEARCH %s returned non-JSON body (status=%s)",
-                    path, response.status_code,
+                    path,
+                    response.status_code,
                 )
                 return {"error": "non-json response"}
             if isinstance(body, dict) and "data" in body:
@@ -215,12 +235,15 @@ class AsyncDirectusClient:
                 msg = first.get("message") or "unknown error"
                 logger.warning(
                     "SEARCH %s (status=%s) errored: %s",
-                    path, response.status_code, msg,
+                    path,
+                    response.status_code,
+                    msg,
                 )
                 return {"error": msg}
             logger.warning(
                 "SEARCH %s returned unexpected shape (status=%s)",
-                path, response.status_code,
+                path,
+                response.status_code,
             )
             return {"error": "unexpected response shape"}
         except httpx.ConnectError as exc:
@@ -267,9 +290,7 @@ class AsyncDirectusClient:
     async def get_item(self, collection: str, item_id: str, **kwargs: Any) -> Any:
         """Get a single item, or None when it doesn't exist / isn't accessible
         (Directus answers 403 FORBIDDEN for both)."""
-        return await self.get(
-            f"/items/{collection}/{item_id}", none_on_forbidden=True, **kwargs
-        )
+        return await self.get(f"/items/{collection}/{item_id}", none_on_forbidden=True, **kwargs)
 
     async def create_item(
         self, collection: str, data: dict[str, Any] | list[dict[str, Any]], **kwargs: Any
@@ -323,14 +344,17 @@ class AsyncDirectusClient:
         Requires admin token. Uses Directus's configured email transport
         (SendGrid SMTP) and Liquid templates from directus/templates/.
         """
-        return await self.post("/utils/mail/send", json={
-            "to": to if isinstance(to, list) else [to],
-            "subject": subject,
-            "template": {
-                "name": template_name,
-                "data": template_data,
+        return await self.post(
+            "/utils/mail/send",
+            json={
+                "to": to if isinstance(to, list) else [to],
+                "subject": subject,
+                "template": {
+                    "name": template_name,
+                    "data": template_data,
+                },
             },
-        })
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/echo/server/tests/test_canvas_ticks.py
+++ b/echo/server/tests/test_canvas_ticks.py
@@ -59,7 +59,11 @@ async def test_tick_no_op_when_no_new_content(monkeypatch) -> None:
         return {"id": "cfg1", "brief": "brief", "gather_spec": {}, "cadence_minutes": 5}
 
     async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
-        return {"latest_content_at": "2026-07-07T10:00:00+00:00", "project": {}, "conversations": []}
+        return {
+            "latest_content_at": "2026-07-07T10:00:00+00:00",
+            "project": {},
+            "conversations": [],
+        }
 
     async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
         return None
@@ -85,7 +89,11 @@ async def test_tick_error_stores_error_generation_and_pauses_after_three(monkeyp
         return {"id": "cfg1", "brief": "brief", "gather_spec": {}, "cadence_minutes": 5}
 
     async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
-        return {"latest_content_at": "2026-07-07T10:20:00+00:00", "project": {}, "conversations": []}
+        return {
+            "latest_content_at": "2026-07-07T10:20:00+00:00",
+            "project": {},
+            "conversations": [],
+        }
 
     async def _generate(**kwargs) -> str:  # noqa: ARG001
         return "garbage"
@@ -105,6 +113,26 @@ async def test_tick_error_stores_error_generation_and_pauses_after_three(monkeyp
     assert fake.created["canvas_generation"][0]["status"] == "error"
     assert fake.created["agent_loop_run"][0]["status"] == "error"
     assert ("agent_loop", "loop1", {"failure_count": 3, "status": "paused"}) in fake.updated
+
+
+@pytest.mark.asyncio
+async def test_tick_missing_ids_records_error_run_without_generation(monkeypatch) -> None:
+    fake = _FakeDirectus()
+    fake.items["agent_loop"]["loop1"]["report_id"] = None
+
+    async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(ticks, "async_directus", fake)
+    monkeypatch.setattr(ticks, "_enqueue_next_if_due", _enqueue)
+
+    result = await ticks.run_tick("loop1", "scheduled")
+
+    assert result["status"] == "error"
+    assert "canvas_generation" not in fake.created
+    assert fake.created["agent_loop_run"][0]["status"] == "error"
+    assert fake.created["agent_loop_run"][0]["generation_id"] is None
+    assert "missing required ids" in fake.created["agent_loop_run"][0]["detail"]
 
 
 @pytest.mark.asyncio

--- a/echo/server/tests/test_directus_retry.py
+++ b/echo/server/tests/test_directus_retry.py
@@ -12,6 +12,7 @@ sleep, and a 4th request. Desired contract:
 - transport errors raise after exhausting retries
 """
 
+import threading
 from unittest.mock import patch
 
 import httpx
@@ -227,3 +228,24 @@ async def test_get_item_raises_on_non_forbidden_403():
     with patch("dembrane.directus_async.asyncio.sleep"):
         with pytest.raises(DirectusBadRequest):
             await client.get_item("conversation", "abc")
+
+
+def test_async_client_uses_separate_httpx_clients_per_event_loop():
+    client = AsyncDirectusClient(url="http://directus.test", token="t")
+    seen: list[int] = []
+
+    async def _capture() -> None:
+        seen.append(id(client._get_client()))  # noqa: SLF001
+
+    def _run_in_thread() -> None:
+        import asyncio
+
+        asyncio.run(_capture())
+
+    _run_in_thread()
+    thread = threading.Thread(target=_run_in_thread)
+    thread.start()
+    thread.join()
+
+    assert len(seen) == 2
+    assert seen[0] != seen[1]


### PR DESCRIPTION
Clean re-cut of #809 (that branch carried pre-#808 squash history). Content identical — see #809 for discussion. Fixes the three wave-6d verified failures, with the required local reproductions in `echo/docs/plans/smart-loop-briefs/wave6e-REPORT.md`:

- **Setup seed run cancelled** — Send→Stop morph race; Stop only fires when activation originated on it. Reproduced fixed on the full local stack: 4 stream requests, zero `/stop` calls.
- **Scheduled ticks crashing** (cancel-scope) — one httpx client per event loop in AsyncDirectusClient; ticks always write their run row on crash. Reproduced fixed: real worker-driven scheduled generation, status ok.
- **"Pause the wall." not pausing** — lifecycle tools resolve id/name/unique-substring, fail plainly on ambiguity.
- Methodology modals: render-only-while-open + testIds.

Post-merge: wave-6f verification on echo-next (beats 1, 5, methodology create/edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)