### PR TITLE
methodology: never send null content (echo-next 500)

### DIFF
--- a/echo/docs/plans/smart-loop-briefs/wave6h-verify.md
+++ b/echo/docs/plans/smart-loop-briefs/wave6h-verify.md
@@ -1,0 +1,32 @@
+# Brief: Wave 6h - the mirror verification (after the composer redesign)
+
+Read wave6g-REPORT.md (what changed) and wave6f-REPORT.md (the failures to mirror).
+READ-ONLY against https://dashboard.echo-next.dembrane.com (admin@dembrane.com /
+dembrane2024, Playwright). No code changes, no git writes.
+
+0. FRESHNESS: api health 200 AND the composer carries the redesign - open any agentic
+   chat, start a turn, and confirm the Send control REMAINS Send while the run is in
+   flight, with a separate small Stop icon control present. If the morph is still
+   there, the frontend is stale: wait and retry.
+1. BEAT 1, including the killer behavior: fresh project -> setup chat -> while the
+   assistant is STILL WORKING, type an answer and CLICK the send control (this is what
+   broke 6d and 6f). NETWORK: zero /stop calls; the mid-turn message appends and gets
+   answered when the current step finishes. Continue the interview as Marieke -> a
+   GOAL proposal card (not project-update) -> Apply -> project settings shows the goal
+   attributed to the interview. Capture run id + network log.
+2. BEAT 5, inside the CANVAS PROJECT'S chat (not new Ask-home chats): 'Pause the
+   wall.' -> canvas page shows Paused; 'Resume the wall.' -> active; 'What's in my
+   library?' -> lists canvases. Confirm tool events exist in the run via the API.
+3. METHODOLOGY: workspace General -> create 'Wave 6h methodology' -> edit framing +
+   history note -> history count increments -> select it on a project -> PATCH fires,
+   framing shows. (The crash from 6f is supposedly fixed; if the error boundary
+   appears again, capture the console error verbatim.)
+4. TICK SELF-HEALING + QUALITY: create a fresh 2h canvas with cadence 5 on a project
+   with real material; confirm a SCHEDULED generation appears within ~7 minutes
+   without manual refresh (proves chain + sweep). Then check the newest generation
+   rows via the API: fresh scheduled entries ok/no_op; note any banned-copy detections
+   recorded in detail fields.
+
+Screenshots to wave6h-shots/ (no git-add). Report ->
+echo/docs/plans/smart-loop-briefs/wave6h-REPORT.md: PASS/FAIL per item with evidence,
+plus the one-line verdict: is the Marieke v1 story fully working on echo-next?

--- a/echo/server/dembrane/api/v2/bff/goals.py
+++ b/echo/server/dembrane/api/v2/bff/goals.py
@@ -196,7 +196,9 @@ async def create_methodology(
     version_payload = {
         "id": version_id,
         "methodology_id": methodology_id,
-        "content": body.content,
+        # methodology_version.content is NOT NULL in the schema; an omitted
+        # content must land as an empty object, not null (echo-next 500).
+        "content": body.content if body.content is not None else {},
         "note": "Initial history",
         "created_by": auth.user_id,
     }
@@ -249,7 +251,7 @@ async def update_methodology(
         version_payload = {
             "id": generate_uuid(),
             "methodology_id": methodology_id,
-            "content": body.content,
+            "content": body.content if body.content is not None else {},
             "note": _trim_optional(body.note, "note") if "note" in body.model_fields_set else None,
             "created_by": auth.user_id,
         }

--- a/echo/server/tests/api/test_bff_goals.py
+++ b/echo/server/tests/api/test_bff_goals.py
@@ -389,3 +389,57 @@ async def test_seeded_methodology_is_read_only(monkeypatch) -> None:
     assert res.json() == {"detail": "The dembrane methodology is read-only"}
     assert directus.updated == []
     assert directus.created == []
+
+
+@pytest.mark.asyncio
+async def test_create_methodology_without_content_sends_empty_object(monkeypatch) -> None:
+    # methodology_version.content is NOT NULL in Directus; omitting content in
+    # the create form must persist {} - null crashed echo-next (wave 6h).
+    captured: list[dict] = []
+
+    class _Fake:
+        async def create_item(self, collection, payload):
+            captured.append({"collection": collection, "payload": payload})
+            return {"data": {**payload}}
+
+        async def get_items(self, collection, query):  # noqa: ARG002
+            return []
+
+    import dembrane.api.v2.bff.goals as goals_bff
+
+    monkeypatch.setattr(goals_bff, "async_directus", _Fake())
+
+    class _Ctx:
+        workspace_id = "ws-1"
+        app_user_id = "au-1"
+
+        def has_policy(self, _p):
+            return True
+
+    async def _ctx(workspace_id, auth):  # noqa: ARG001
+        return _Ctx()
+
+    monkeypatch.setattr(goals_bff, "get_workspace_context", _ctx)
+
+    from httpx import AsyncClient, ASGITransport
+    from fastapi import FastAPI
+
+    from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+
+    app = FastAPI()
+    app.include_router(goals_bff.methodologies_router, prefix="/api/v2/bff/methodologies")
+
+    async def _override():
+        return DirectusSession(user_id="du-1", is_admin=False, access_token="t", client=None)
+
+    app.dependency_overrides[require_directus_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        res = await client.post(
+            "/api/v2/bff/methodologies",
+            json={"workspace_id": "ws-1", "name": "n", "description": "d", "framing": "f"},
+        )
+
+    assert res.status_code == 200
+    version_creates = [c for c in captured if c["collection"] == "methodology_version"]
+    assert version_creates and version_creates[0]["payload"]["content"] == {}


### PR DESCRIPTION
One-class fix for the last wave-6h FAIL: `methodology_version.content` is NOT NULL; create/edit sent null when the form omitted content — Directus rejected after the methodology row existed (half-created rows; the 500 surfaced as a CORS error in the browser). Both payload sites coalesce to `{}`; regression test included. Root-caused from the echo-next pod traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)