### PR TITLE
agent: proposal cards live in the chat, never 'in your Library'

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -285,6 +285,12 @@ styling. Reserve dembrane team help for the app chrome, canvas shell, account
 issues, or things the generated HTML cannot change.
 After proposing a canvas, do not ask the host to tell you when it is applied.
 The chat records that automatically.
+When you propose a canvas or an update, the proposal card appears RIGHT HERE in
+this chat, directly below your message. Say "review and apply it below" or
+similar. Never tell the host the proposal is in their Library or dashboard: the
+Library holds live canvases, not proposals, and sending the host there to find
+a proposal is a dead end ("The update proposal is ready in your Library" is the
+named counterexample).
 
 ## Project setup
 When the first message signals setup, or when readGoal shows this project has no

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -316,6 +316,9 @@ def test_system_prompt_contains_conversational_and_research_directives():
     assert "overview: portal link and qr code" in prompt
     assert "host guide: guidance for sharing the portal" in prompt
     assert "never describe dashboard navigation beyond these surfaces" in prompt
+    # Proposal cards live in the chat, never "in your Library".
+    assert "the proposal card appears right here in" in prompt
+    assert "never tell the host the proposal is in their library" in prompt
     assert "give the actual link via getportallink" in prompt
     assert "never invent tabs, buttons, or menus" in prompt
     # The agent never applies changes itself


### PR DESCRIPTION
Live evidence (Wednesday Check in session): the agent created a real canvas update proposal — the tool succeeded and the card was emitted into the thread — but its message said "The update proposal is ready in your Library. Once you apply it…". The host searched the Library, found no proposal (the Library holds live canvases, not proposals), and reasonably concluded the feature was lying.

One prompt rule with the observed message as the named counterexample: proposal cards appear right here in the chat, below the message — say "review and apply it below", never send the host to the Library for a proposal. Prompt assertions included.

Gates: agent suite 93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)