### PR TITLE
Tabbed living canvas: additive ledgers + model extraction with mechanical receipts

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -270,11 +270,13 @@ participant reflections, quotes, or the synthesis text the loop should generate
 fresh from transcripts each tick. The Wednesday Check in failure is the
 counterexample: a brief bloated with person-by-person summaries, open issues,
 and discussion questions freezes content that belongs in generated canvas
-output. When a host asks to "add X's reflection", first confirm the canvas
-instructions already call for person-by-person reflections; if needed, offer a
-refresh or propose a concise standing instruction. Do not paste X's reflection
-into the brief. When revising a brief, rewrite it cleanly and consolidate
-standing edits. Do not append forever just because revision history exists.
+output. When a host says "put X on the wall", "add <person>'s reflection",
+"pin that", or otherwise asks you to place exact host-provided text onto an
+existing canvas, resolve the canvas and call addToCanvas in the same turn. Do
+not paste the item into the brief and do not create a proposal card. Use
+removeFromCanvas when the host asks to unpin or remove one of those host-added
+items. When revising a brief, rewrite it cleanly and consolidate standing edits.
+Do not append forever just because revision history exists.
 The generated canvas content can include presentation guidance within the
 dembrane kit's brand system: emphasis, contrast, visual tone, and what to
 highlight. If the host says a canvas is hard to read, too dim, the colors do not
@@ -1510,6 +1512,74 @@ def create_agent_graph(
             else None,
         }
 
+    @tool
+    async def addToCanvas(
+        canvas: str,
+        text: str,
+        target_tab: str = "story",
+        person: str = "",
+    ) -> dict[str, Any]:
+        """Add exact host-provided text to an existing canvas immediately.
+
+        Use this when the host says to put something on the wall, pin that,
+        or add a named person's reflection. `canvas` may be an id or unique
+        canvas name/reference. `target_tab` is one of crux, concept_cloud, or
+        story. Do not paraphrase `text`.
+        """
+        resolved_canvas_id, resolved_name = await _resolve_canvas_id(canvas)
+        normalized_text = text.strip()
+        if not normalized_text:
+            raise ValueError("text is required.")
+        client = _create_echo_client()
+        try:
+            result = await client.add_canvas_host_item(
+                project_id,
+                resolved_canvas_id,
+                normalized_text,
+                target_tab,
+                person=person.strip() or None,
+                chat_id=chat_id or None,
+                message_id=message_id or None,
+            )
+        finally:
+            await client.close()
+        return {
+            "canvas_id": resolved_canvas_id,
+            "canvas_name": resolved_name,
+            "status": result.get("status"),
+            "host_item": result.get("host_item"),
+        }
+
+    @tool
+    async def removeFromCanvas(canvas: str, item: str) -> dict[str, Any]:
+        """Remove a host-added canvas item by id or matching text.
+
+        Use this when the host asks to unpin or remove something they
+        previously added with addToCanvas. `canvas` may be an id or unique
+        canvas name/reference.
+        """
+        resolved_canvas_id, resolved_name = await _resolve_canvas_id(canvas)
+        normalized_item = item.strip()
+        if not normalized_item:
+            raise ValueError("item is required.")
+        client = _create_echo_client()
+        try:
+            result = await client.remove_canvas_host_item(
+                project_id,
+                resolved_canvas_id,
+                normalized_item,
+                chat_id=chat_id or None,
+                message_id=message_id or None,
+            )
+        finally:
+            await client.close()
+        return {
+            "canvas_id": resolved_canvas_id,
+            "canvas_name": resolved_name,
+            "status": result.get("status"),
+            "item": result.get("item"),
+        }
+
     async def _resolve_canvas_id(reference: str) -> tuple[str, str | None]:
         normalized_reference = reference.strip()
         if not normalized_reference:
@@ -1639,6 +1709,8 @@ def create_agent_graph(
         listMethodologies,
         listCanvases,
         editCanvas,
+        addToCanvas,
+        removeFromCanvas,
         pauseCanvasLoop,
         resumeCanvasLoop,
         stopCanvasLoop,

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -204,6 +204,52 @@ class EchoClient:
         payload = response.json()
         return payload if isinstance(payload, dict) else {}
 
+    async def add_canvas_host_item(
+        self,
+        project_id: str,
+        canvas_id: str,
+        text: str,
+        target_tab: str,
+        person: str | None = None,
+        chat_id: str | None = None,
+        message_id: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, "target_tab": target_tab}
+        if person:
+            body["person"] = person
+        if chat_id:
+            body["chat_id"] = chat_id
+        if message_id:
+            body["message_id"] = message_id
+        response = await self._client.post(
+            f"/agentic/projects/{project_id}/canvases/{canvas_id}/host-items",
+            json=body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    async def remove_canvas_host_item(
+        self,
+        project_id: str,
+        canvas_id: str,
+        item: str,
+        chat_id: str | None = None,
+        message_id: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"item": item}
+        if chat_id:
+            body["chat_id"] = chat_id
+        if message_id:
+            body["message_id"] = message_id
+        response = await self._client.post(
+            f"/agentic/projects/{project_id}/canvases/{canvas_id}/host-items/remove",
+            json=body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
     async def update_canvas_loop(
         self,
         project_id: str,

--- a/echo/agent/tests/test_agent_graph.py
+++ b/echo/agent/tests/test_agent_graph.py
@@ -222,6 +222,8 @@ def test_create_agent_graph_binds_edit_canvas_tool():
     tool_map = {tool.name: tool for tool in llm.bound_tools}
 
     assert "editCanvas" in tool_map
+    assert "addToCanvas" in tool_map
+    assert "removeFromCanvas" in tool_map
 
 
 @pytest.mark.asyncio

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -37,6 +37,8 @@ class _FakeEchoClient:
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
         canvas_loop_response: dict | None = None,
+        canvas_host_item_response: dict | None = None,
+        canvas_remove_item_response: dict | None = None,
     ):
         self.bearer_token = bearer_token
         self.search_payload = search_payload or {}
@@ -64,6 +66,8 @@ class _FakeEchoClient:
         self.project_tags_payload = project_tags_payload or []
         self.canvases_payload = canvases_payload or []
         self.canvas_loop_response = canvas_loop_response or {}
+        self.canvas_host_item_response = canvas_host_item_response or {"status": "added"}
+        self.canvas_remove_item_response = canvas_remove_item_response or {"status": "removed"}
         self.search_calls: list[dict[str, object]] = []
         self.transcript_calls: list[str] = []
         self.project_conversations_calls: list[dict[str, object]] = []
@@ -74,6 +78,8 @@ class _FakeEchoClient:
         self.list_project_tags_calls: list[str] = []
         self.list_canvases_calls: list[str] = []
         self.canvas_loop_calls: list[dict[str, str]] = []
+        self.canvas_host_item_calls: list[dict[str, object]] = []
+        self.canvas_remove_item_calls: list[dict[str, object]] = []
         self.closed = False
 
     async def search_home(self, query: str, limit: int = 5) -> dict:
@@ -210,6 +216,48 @@ class _FakeEchoClient:
         )
         return self.canvas_loop_response
 
+    async def add_canvas_host_item(
+        self,
+        project_id: str,
+        canvas_id: str,
+        text: str,
+        target_tab: str,
+        person: str | None = None,
+        chat_id: str | None = None,
+        message_id: str | None = None,
+    ) -> dict:
+        self.canvas_host_item_calls.append(
+            {
+                "project_id": project_id,
+                "canvas_id": canvas_id,
+                "text": text,
+                "target_tab": target_tab,
+                "person": person,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            }
+        )
+        return self.canvas_host_item_response
+
+    async def remove_canvas_host_item(
+        self,
+        project_id: str,
+        canvas_id: str,
+        item: str,
+        chat_id: str | None = None,
+        message_id: str | None = None,
+    ) -> dict:
+        self.canvas_remove_item_calls.append(
+            {
+                "project_id": project_id,
+                "canvas_id": canvas_id,
+                "item": item,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            }
+        )
+        return self.canvas_remove_item_response
+
     async def write_memory(
         self,
         project_id: str,
@@ -251,6 +299,8 @@ class _FakeEchoClientFactory:
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
         canvas_loop_response: dict | None = None,
+        canvas_host_item_response: dict | None = None,
+        canvas_remove_item_response: dict | None = None,
     ):
         self.search_payload = search_payload
         self.search_payload_by_query = search_payload_by_query
@@ -270,6 +320,8 @@ class _FakeEchoClientFactory:
         self.project_tags_payload = project_tags_payload
         self.canvases_payload = canvases_payload
         self.canvas_loop_response = canvas_loop_response
+        self.canvas_host_item_response = canvas_host_item_response
+        self.canvas_remove_item_response = canvas_remove_item_response
         self.instances: list[_FakeEchoClient] = []
 
     def __call__(self, bearer_token: str) -> _FakeEchoClient:
@@ -291,6 +343,8 @@ class _FakeEchoClientFactory:
             project_tags_payload=self.project_tags_payload,
             canvases_payload=self.canvases_payload,
             canvas_loop_response=self.canvas_loop_response,
+            canvas_host_item_response=self.canvas_host_item_response,
+            canvas_remove_item_response=self.canvas_remove_item_response,
         )
         self.instances.append(client)
         return client
@@ -352,7 +406,8 @@ def test_system_prompt_contains_conversational_and_research_directives():
     assert "target_canvas_id" in prompt
     assert "briefs are durable instructions only" in prompt
     assert "wednesday check in" in prompt
-    assert "do not paste x's reflection" in prompt
+    assert "call addtocanvas in the same turn" in prompt
+    assert "paste the item into the brief" in prompt
     assert "do not append forever" in prompt
     assert "gathered content" in prompt
     # Product-learning insights are quiet and distinct from support requests.
@@ -1589,6 +1644,95 @@ async def test_canvas_loop_tool_resolves_unique_name_reference():
         {"project_id": "project-1", "canvas_id": "canvas-1", "action": "pause"}
     ]
     assert all(instance.closed for instance in factory.instances)
+
+
+@pytest.mark.asyncio
+async def test_add_to_canvas_resolves_canvas_and_posts_exact_host_item():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        canvases_payload=[
+            {
+                "id": "canvas-1",
+                "name": "Live wall",
+                "loop": {"status": "active"},
+            },
+        ],
+        canvas_host_item_response={
+            "status": "added",
+            "host_item": {"id": "item-1", "text": "Maya said keep the doorway open."},
+        },
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+        chat_id="chat-1",
+        message_id="msg-1",
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["addToCanvas"].ainvoke(
+        {
+            "canvas": "wall",
+            "text": "Maya said keep the doorway open.",
+            "target_tab": "story",
+            "person": "Maya",
+        }
+    )
+
+    assert result["status"] == "added"
+    assert result["canvas_id"] == "canvas-1"
+    assert factory.instances[1].canvas_host_item_calls == [
+        {
+            "project_id": "project-1",
+            "canvas_id": "canvas-1",
+            "text": "Maya said keep the doorway open.",
+            "target_tab": "story",
+            "person": "Maya",
+            "chat_id": "chat-1",
+            "message_id": "msg-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remove_from_canvas_resolves_canvas_and_posts_item_match():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        canvases_payload=[{"id": "canvas-1", "name": "Live wall"}],
+        canvas_remove_item_response={"status": "removed", "item": "doorway open"},
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+        chat_id="chat-1",
+        message_id="msg-1",
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["removeFromCanvas"].ainvoke(
+        {"canvas": "wall", "item": "doorway open"}
+    )
+
+    assert result["status"] == "removed"
+    assert factory.instances[1].canvas_remove_item_calls == [
+        {
+            "project_id": "project-1",
+            "canvas_id": "canvas-1",
+            "item": "doorway open",
+            "chat_id": "chat-1",
+            "message_id": "msg-1",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/echo/agent/tests/test_echo_client.py
+++ b/echo/agent/tests/test_echo_client.py
@@ -270,3 +270,55 @@ async def test_update_canvas_loop_uses_expected_path(monkeypatch):
         client._client.calls[0]["path"]
         == "/agentic/projects/project-1/canvases/canvas-1/loop/pause"
     )
+
+
+@pytest.mark.asyncio
+async def test_add_canvas_host_item_uses_expected_path_and_body(monkeypatch):
+    monkeypatch.setattr("echo_client.httpx.AsyncClient", _FakeAsyncClient)
+
+    client = EchoClient(bearer_token="token-1")
+    await client.add_canvas_host_item(
+        "project-1",
+        "canvas-1",
+        "Pin this exact line.",
+        "story",
+        person="Maya",
+        chat_id="chat-1",
+        message_id="msg-1",
+    )
+
+    assert (
+        client._client.calls[0]["path"]
+        == "/agentic/projects/project-1/canvases/canvas-1/host-items"
+    )
+    assert client._client.calls[0]["json"] == {
+        "text": "Pin this exact line.",
+        "target_tab": "story",
+        "person": "Maya",
+        "chat_id": "chat-1",
+        "message_id": "msg-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_remove_canvas_host_item_uses_expected_path_and_body(monkeypatch):
+    monkeypatch.setattr("echo_client.httpx.AsyncClient", _FakeAsyncClient)
+
+    client = EchoClient(bearer_token="token-1")
+    await client.remove_canvas_host_item(
+        "project-1",
+        "canvas-1",
+        "Pin this exact line.",
+        chat_id="chat-1",
+        message_id="msg-1",
+    )
+
+    assert (
+        client._client.calls[0]["path"]
+        == "/agentic/projects/project-1/canvases/canvas-1/host-items/remove"
+    )
+    assert client._client.calls[0]["json"] == {
+        "item": "Pin this exact line.",
+        "chat_id": "chat-1",
+        "message_id": "msg-1",
+    }

--- a/echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py
+++ b/echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Idempotent migration for SMART loop Wave 28 canvas ledgers.
+
+Run against local Directus, then pull the snapshot:
+
+  python3 add_smart_loop_wave28_canvas_ledgers.py \
+      -u http://localhost:8055 -e admin@dembrane.com -p admin
+  cd echo/directus && bash sync.sh -u http://localhost:8055 \
+      -e admin@dembrane.com -p admin pull
+"""
+
+from __future__ import annotations
+
+import sys
+import argparse
+from pathlib import Path
+
+SERVER_PATH = Path(__file__).resolve().parents[2] / "server"
+if str(SERVER_PATH) not in sys.path:
+    sys.path.insert(0, str(SERVER_PATH))
+
+from add_smart_loop_phase0_schema import (  # noqa: E402
+    Directus,
+    login,
+    json_field,
+    ensure_field,
+    ensure_schema,
+)
+
+
+def ensure_wave28_schema(dx: Directus) -> None:
+    print("Step 0/1: phase 0 dependencies")
+    ensure_schema(dx)
+
+    print("Step 1/1: agent_loop canvas ledger fields")
+    for sort, field in enumerate(
+        (
+            "canvas_tabs",
+            "canvas_quotes_ledger",
+            "canvas_concepts_ledger",
+            "canvas_crux",
+            "canvas_host_items",
+            "canvas_story_slides",
+        ),
+        start=30,
+    ):
+        ensure_field(dx, "agent_loop", json_field("agent_loop", field, sort=sort))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-u", "--url", required=True)
+    parser.add_argument("-e", "--email", required=True)
+    parser.add_argument("-p", "--password", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    token = login(args.url, args.email, args.password)
+    ensure_wave28_schema(Directus(args.url, token, dry_run=args.dry_run))
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/echo/docs/plans/canvas-ux-handoff.md
+++ b/echo/docs/plans/canvas-ux-handoff.md
@@ -1,0 +1,192 @@
+# Canvas UX handoff (from Oren's Notion page, 2026-07-08)
+
+Source: Notion "Canvas user experience — design handoff for Sam"
+(3979cd84-2705-8103-bc6e-dfc9c81a37b3), distilled from the 13th-week live
+canvas. Look and feel + judgment rules; technical implementation is free.
+
+## Tokens
+
+```css
+:root {
+  --parchment: #F6F4F1;  /* page ground */
+  --card: #FFFFFF;       /* every surface */
+  --ink: #2D2D2C;        /* text */
+  --ink-soft: #6E6B66;   /* secondary text */
+  --royal: #4169E1;      /* the ONE interactive color */
+  --hairline: #E6E3DF;   /* all borders */
+  /* data accents only, never chrome: */
+  --green: #1EFFA1; --amber: #FFD166; --cyan: #00FFFF;
+  --pink: #FFC2FF; --yellow: #F4FF81; --coral: #FF9AA2;
+}
+```
+
+## Spacing
+
+- Page frame: `padding: 14px 26px 80px`; fixed chrome sits `bottom: 20px`,
+  `left/right: 22px`.
+- Content measures per surface, all `margin: 0 auto`: slides 1000px,
+  trace/feed 760-780px, audit 860px, questions 720px, cloud 1060px.
+- Card padding tiers: dense grid `12px 13px`, reading cards `15px 18px`,
+  hero tiles `20px 26px`. Never below 9px, never above 26px.
+- Gap tiers: tight grid 9px, card grids 12-14px, tab-to-tab 26px, section
+  breathing 22-30px top margin.
+- Body copy maxes at ~620px (.lede).
+
+## Look and feel
+
+- Borders do the work, not shadows: everything `1px solid var(--hairline)`
+  on white. Shadows only on floating chrome (fixed buttons, panels, popups).
+- Sharp corners everywhere. Exactly one pill (`border-radius: 9999px`),
+  reserved for the primary action button. One circle: the minimized bubble.
+- Royal is the ONLY interactive color: active tab underline, asks, links,
+  dotted provenance underlines, the current/open item. If it is royal, you
+  can do something with it or it is live.
+- 3px left border = "this one matters now" (newest feed item, evidence
+  cards, the block ask). Importance is an accent stripe, not a bigger box.
+- Emphasis by weight and size, never color-shouting. Weights 400/500/600
+  only; no bold-700 anywhere. Bright accents only as data color (5px accent
+  bars, dot markers, tile borders).
+- Amber tint = just landed: `rgba(255,209,102,0.35)` background + same-color
+  3px outline, cleared after the next update so it always means newest.
+
+## Type
+
+- DM Sans throughout, line-height 1.45 body, antialiased.
+- Display headings: weight 500 (never bold), negative tracking,
+  `text-wrap: balance`. h1 `clamp(32px, 4.6vw, 48px) / -0.015em`;
+  h2 `clamp(24px, 3.4vw, 36px) / -0.01em`; line-height 1.12-1.2.
+- Eyebrows/labels: 10-12px, weight 600, uppercase, letter-spacing
+  0.08-0.1em, usually royal. AT MOST ONE kicker per screen (room feedback:
+  it was over-used; only where a stranger needs orienting).
+- Body: 16px lede (soft ink; key phrases re-inked via
+  `b { color: var(--ink); font-weight: 500 }`), 13.5px UI text, 12-12.5px
+  card body, 11px meta.
+- Numbers: `font-variant-numeric: tabular-nums` for timestamps, counters,
+  stats. Big stats `clamp(32px, 4.2vw, 46px)`, weight 600, -0.02em.
+- The middot (·) is the universal separator. Typographic quotes, colored
+  royal when quoting voices. No em dashes, ever. dembrane always lowercase.
+
+## Tab bar
+
+Quiet text on the page ground; no boxes, no pills, no backgrounds.
+Identity = ink vs soft-ink plus a 2px royal underline. 26px between tabs.
+Row closes with a royal +.
+
+```css
+.tabbar { display: flex; border-bottom: 1px solid var(--hairline); }
+.tabbar button {
+  font-size: 14.5px; font-weight: 500; color: var(--ink-soft);
+  background: none; border: 0; border-bottom: 2px solid transparent;
+  padding: 10px 2px; margin-right: 26px; cursor: pointer;
+}
+.tabbar button[aria-selected="true"] { color: var(--ink); border-bottom-color: var(--royal); }
+```
+
+(If the sanitizer strips buttons/JS, reproduce this look with a CSS-only
+mechanism; the visual identity is what must survive.)
+
+## Per-tab feel
+
+| Tab | Feel | Key styling |
+| --- | --- | --- |
+| Story (slides) | full-bleed calm, one idea per screen | `min-height: 80vh`, centered column, eyebrow + display heading + 620px lede |
+| Canvas | dense wall of white blocks | 5-col grid, 9px gaps, `12px 13px` blocks, italic royal ask with 3px left bar |
+| Concept cloud | floating, alive, slightly untidy | tiles rotate ±1.2°, 7s float, four size classes from 12px to `clamp(24px, 2.8vw, 34px)` |
+| Trace | quiet reading room | 780px column, big balanced claim, quote cards with royal left stripe and royal quote marks |
+| Munching | terminal-meets-theater | newest item bigger + royal-bordered, older items settle small and grey |
+| Audit log | pull-request formality | white accordions, royal border when open, tabular timestamps |
+
+## Motion
+
+Small, singular, honest. Land flash 700ms once; feed entries slide up 8px
+over 400ms, only genuinely new ones; cloud float ±5px over 7s; pulse dot
+2.2s. Nothing loops for attention while idle. Every animation has a
+`prefers-reduced-motion: reduce` fallback.
+
+## The judgment layer
+
+Written so a Flash-class model (eager, extrapolates when unsure) can follow
+it. Core insight: almost all of the judgment is subtractive. A hallucinating
+model adds; every rule below forbids adding.
+
+### Quote tracing (the architecture)
+
+Separate ingest from linking; verbatim quotes are the ONLY currency between
+them. The model never writes "what the room meant"; it moves exact slices of
+what the room said.
+
+```
+INGEST (dumb on purpose)
+  every transcript/comment lands as immutable raw input
+  NEVER summarize at ingest — summarizing destroys the receipts forever
+
+PROCESS (one batch at a time)
+  while reading raw text, when a passage does real work (names a decision,
+  coins a phrase, answers an open question, contradicts the wall):
+    push { id, who, quote: verbatim slice trimmed at sentence boundaries,
+           source, when, link_to_conversation? }
+    // verbatim = COPIED, transcription quirks included. never cleaned,
+    // never paraphrased. copying is the anti-hallucination mechanism.
+
+LINK (only now may the wall change)
+  claim    = shortest phrase that survives without context
+  evidence = quotes that DIRECTLY support it (1..n ids)
+  if evidence empty: claim is the agent's own synthesis -> NO underline,
+  or it does not go up at all
+  else: render claim as traceable, carrying [ids]
+
+RENDER
+  traceable = dotted underline; click -> claim big, then one card per
+  quote: exact words · speaker · when · source · link
+  a claim built from many quotes shows EVERY voice — never merge quotes
+  into one composite quote
+```
+
+Invariants that must never break:
+1. No receipt, no underline. An underline on unsupported text is a forged
+   receipt; it poisons trust in every real one.
+2. The quote outranks the claim. If they drift apart during editing,
+   rewrite the claim, never the quote.
+
+### Concept cloud checklist (paste into the tick prompt nearly as-is)
+
+1. Extract, never generate. A concept is a phrase FROM the transcript. You
+   are a magnet, not a mint.
+2. The grep test: for every tile you must be able to point at the exact
+   line(s) it came from. Cannot point -> the tile does not exist. Collect
+   the quote FIRST, then make the tile.
+3. Size = repetition × spread. Said by two people beats said twice by one
+   person beats said once memorably. XL is for phrases the room kept
+   returning to unprompted.
+4. Scarcity forces judgment: exactly 3 XL, hard cap ~20 tiles.
+5. Subtract words, never add. "falling in love with the game again" is the
+   transcript minus filler; "renewed passion for the mission" is
+   hallucination in a nice coat.
+6. The room's metaphors only. Transcript says "prune the tree" -> tile says
+   prune the tree, not "focus our efforts".
+7. Keep 1-2 jokes, small. The wall should feel like the room, not minutes.
+8. Gentleness on hard content. Grief goes up in the speaker's own softest
+   phrasing or not at all. Sensitive strategy (money, legal, personnel)
+   stays off even when said out loud — and the audit trail says so, so
+   nothing is silently swallowed.
+9. When unsure, leave it out and say so ("left off the wall on judgment;
+   say the word if it should be on").
+
+### Crux rules (the one big question)
+
+- One question at a time. A fixture: UPDATED, never appended to, never
+  removed.
+- A newcomer can answer it out loud: no internal references, no jargon, no
+  numbers needing context.
+- Phrase as an invitation with a concrete first move ("scan the code and
+  give your first answer out loud: one move, one bet, one reason it works").
+
+### Room feedback
+
+- All-caps royal kicker: at most one per screen.
+- Open questions: idea right, format unsolved (a stack of white boxes felt
+  off; consider small quiet text or living inside the surfaces they came
+  from).
+- Protect: the sculptural typography, the fun subtle animation, quote
+  tracing "coming from the transcript in a way that makes sense", the
+  concept cloud, the one main question.

--- a/echo/docs/plans/smart-loop-briefs/wave28-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28-REPORT.md
@@ -1,0 +1,49 @@
+# Wave 28 Report: Tabbed Living Canvas
+
+## What shipped
+
+- Added a tabbed v1 canvas renderer with fixed tabs in owner order: Crux, Concept cloud, Story.
+- Added additive canvas ledgers on `agent_loop`: quote receipts, concept tiles, crux state/history, host items, and tab config.
+- Updated ticks so scheduled no-new-content still no-ops, while content-bearing/manual ticks merge ledgers additively before rendering a sanitized CSS-only tab fragment.
+- Preserved chunk IDs in canvas gather output so quote receipts can point to conversation/chunk sources when available.
+- Added CSS-only tabs with hidden radios/labels and CSS-only trace expansion through `details`/`summary`; sanitizer round-trip coverage verifies both survive.
+- Added `addToCanvas` and `removeFromCanvas` to the agent, plus agentic/BFF endpoints and client methods. Host-added items are stored exactly, target a tab, and enqueue a manual tick immediately.
+- Added an idempotent Directus migration script for the new `agent_loop` JSON fields.
+
+## File list
+
+- `echo/server/dembrane/canvas/ledgers.py`
+- `echo/server/dembrane/canvas/ticks.py`
+- `echo/server/dembrane/canvas/gather.py`
+- `echo/server/dembrane/canvas/service.py`
+- `echo/server/dembrane/api/agentic.py`
+- `echo/server/dembrane/api/v2/bff/canvases.py`
+- `echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py`
+- `echo/agent/agent.py`
+- `echo/agent/echo_client.py`
+- `echo/server/tests/test_canvas_ledgers.py`
+- `echo/server/tests/test_canvas_sanitize.py`
+- `echo/server/tests/test_canvas_ticks.py`
+- `echo/agent/tests/test_agent_graph.py`
+- `echo/agent/tests/test_agent_tools.py`
+- `echo/agent/tests/test_echo_client.py`
+- `echo/docs/plans/canvas-ux-handoff.md`
+- `echo/docs/plans/smart-loop-briefs/wave28-tabbed-canvas.md`
+- `echo/docs/plans/smart-loop-briefs/wave28-REPORT.md`
+
+## QA gates
+
+- `cd echo/server && uv run ruff check .` passed.
+- `cd echo/server && DIRECTUS_SECRET=test DIRECTUS_TOKEN=test DATABASE_URL=postgresql://user:pass@localhost:5432/db REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=test STORAGE_S3_ENDPOINT=http://localhost:9000 STORAGE_S3_KEY=test STORAGE_S3_SECRET=test uv run pytest -q tests/test_canvas_ledgers.py tests/test_canvas_ticks.py tests/test_canvas_sanitize.py tests/test_canvas_gather.py tests/test_canvas_service.py tests/api/test_bff_canvases.py` passed: 31 passed.
+- `cd echo/agent && uv run pytest -q` passed: 97 passed.
+- Migration was not run against a scratch Directus because no local Directus credentials/runtime were available in this worker. The migration uses the existing `ensure_field` guards and calls phase 0 `ensure_schema`, so reruns skip existing fields.
+- Frontend was not touched, so no frontend gates were run.
+
+## Compatibility decision
+
+Existing canvas loops without tab/ledger fields default to the v1 tab set on the next tick through `fresh_canvas_state`. Existing stored generations remain renderable until the next tick or preview; the next successful tick stores the tabbed fragment and writes the additive state back to `agent_loop`.
+
+## Cut or constrained
+
+- `echo/docs/plans/canvas-update-modes.md` was required by the brief but absent after checkout and full filename search. I attempted to ask the coordinator twice; both `orca orchestration ask` calls lost their runtime connection before a response, so I proceeded from the wave brief and `canvas-ux-handoff.md`.
+- The per-tab jobs are implemented as deterministic additive ledger merges plus deterministic rendering. The legacy model prompt fallback still carries the Flash-class discipline checklist, but the live tabbed renderer does not depend on a model to restyle or rebuild the HTML.

--- a/echo/docs/plans/smart-loop-briefs/wave28-tabbed-canvas.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28-tabbed-canvas.md
@@ -1,0 +1,103 @@
+# Brief: Wave 28 — the tabbed living canvas
+
+Start: `git fetch origin && git checkout -b sameer/tabbed-canvas origin/main`.
+Do NOT run any other git write commands.
+
+Required reading, in order:
+1. echo/docs/plans/canvas-ux-handoff.md — the design contract (styling +
+   judgment rules). This file is on disk, untracked; treat it as source
+   material and keep it in the tree.
+2. echo/docs/plans/canvas-update-modes.md — why updates must be additive.
+3. echo/server/dembrane/canvas/ (service.py, ticks.py) and the generation
+   prompt path — current single-HTML tick architecture.
+
+## The model (decided by the owners, 2026-07-08)
+
+The canvas is a set of TABS. Each tab is a smart default with a FIXED shape;
+only its content updates. The tick is a sequence of per-tab jobs and every
+job is ADDITIVE — nothing rebuilds from scratch, unchanged tabs render
+unchanged.
+
+v1 tabs, in this order: **Crux**, **Concept cloud**, **Story**.
+(Trace behaves as an interaction inside cloud/story, not its own tab.
+Audit log / Munching / Host guide / Monitor are later waves — leave room.)
+
+## What to build
+
+1. **Ledgers (the additive substrate).** Persist per-loop working state so
+   ticks append instead of regenerate:
+   - quotes ledger: {id, who (or null — attribution perfect or absent),
+     quote (verbatim, uncleaned), source conversation_id + chunk id if
+     available, when}
+   - concepts ledger: {id, phrase (from the transcript only), quote_ids,
+     size tier, first_seen, last_reinforced}
+   - crux: single current question + history of updates
+   - host_items: entries the host adds via chat (see tool below): {id, text,
+     person/label optional, target tab, source chat_id/message_id, added_at}
+   Choose storage pragmatically (JSON fields on the loop or a small
+   collection; migration must be idempotent, echo/directus/migrations
+   add_*_schema.py pattern).
+
+2. **Per-tab tick jobs**, replacing the monolithic regenerate:
+   a. extract NEW verbatim quotes from transcript added since the last tick
+      -> append to quotes ledger (quote-tracing rules in the handoff:
+      verbatim copied, sentence boundaries, no receipt no entry).
+   b. merge concepts additively (checklist in the handoff: grep test,
+      size = repetition × spread, exactly 3 XL, ~20 tile cap, room's
+      metaphors only). Existing concepts may grow/shrink tier; they are
+      never dropped silently — removals must be logged in the run record.
+   c. update the crux (rules in handoff: one question, updated never
+      appended, newcomer-answerable, invitation phrasing).
+   d. refresh the story slides around the durable material.
+   e. render host_items faithfully inside their target tab — exact text,
+      never paraphrased, never lost on refresh.
+   The no-new-content no_op must still short-circuit scheduled ticks when
+   nothing new arrived (manual ticks bypass, as today).
+
+3. **Rendering: single sanitized HTML fragment** (same pipeline as today —
+   generations stay body fragments, SSE nudge unchanged). Inside it:
+   - the tab bar per the handoff (quiet text, 2px royal underline). The
+     sanitizer likely strips <script>; use a CSS-only tab mechanism
+     (hidden radio inputs + labels, or :target) — verify it SURVIVES
+     _sanitize round-trip with a unit test.
+   - brand kit v2: the handoff tokens replace the current canvas kit
+     (parchment ground, royal as the only interactive color, borders not
+     shadows, DM Sans 400/500/600, amber = just-landed, max one kicker per
+     screen). Keep whitelabel logo behavior as-is.
+   - traceable quotes: dotted royal underline; CSS-only expansion (e.g.
+     details/summary styled per the trace row: quote card with royal left
+     stripe, speaker, when). Claims without quote ids get NO underline.
+   - concept cloud styling per handoff (±1.2° rotation, 7s float, four
+     size classes, reduced-motion fallback).
+   - mobile responsive: no page-in-page, no absurd margins (owner rule).
+
+4. **Agent chat verb** in echo/agent/agent.py: `addToCanvas` (and
+   `removeFromCanvas`) — appends/removes a host_item with target tab.
+   Acts IMMEDIATELY like editCanvas (no proposal card), echoes one plain
+   sentence, then enqueues a manual tick so the wall shows it in seconds.
+   Prompt: when the host says "put X on the wall", "add <person>'s
+   reflection", "pin that" — use this tool in the same turn, never stuff
+   the item into the brief (named antipattern).
+
+5. **Model discipline**: the tick prompts must be written for a Flash-class
+   model — explicit checklists from the handoff pasted in, subtractive
+   rules, no room for extrapolation. Keep prompts in code (config-in-code).
+
+Compatibility: existing canvases without tab config keep working (default
+them to the v1 tab set on next tick or render legacy-style — your call,
+document it). Preview/try-now must produce the same tabbed output.
+
+## QA gates
+
+- server: `cd echo/server && uv run ruff check .` + focused pytest for
+  canvas/ticks/ledgers + the sanitizer round-trip test for the tab
+  mechanism and trace expansion.
+- agent: `cd echo/agent && uv run pytest -q` (tool + prompt-rule tests).
+- migration: idempotent (run twice locally against a scratch check if
+  feasible, else assert guards in code).
+- frontend untouched unless strictly needed; if touched: tsc, biome lint,
+  lingui extract+compile.
+- No git write commands beyond the initial checkout.
+
+Report -> echo/docs/plans/smart-loop-briefs/wave28-REPORT.md: what shipped,
+file list, gate results, the compatibility decision, and anything cut.

--- a/echo/docs/plans/smart-loop-briefs/wave28b-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28b-REPORT.md
@@ -1,0 +1,49 @@
+# Wave 28b Report: Model Extraction Restored
+
+## What shipped
+
+- Replaced Wave 28's deterministic sentence/concept/crux extraction path with one structured `MODELS.MULTI_MODAL_FAST` extraction call for transcript-bearing ticks.
+- Added a model prompt with the handoff's quote tracing, concept cloud, and crux checklists embedded in code.
+- Added mechanical receipt validation:
+  - quotes are accepted only when the proposed text appears verbatim, after whitespace normalization, in the gathered transcript for that conversation;
+  - concepts are accepted only when their phrase appears inside at least one accepted supporting quote;
+  - story slide quote references are filtered to accepted quote IDs only.
+- Preserved deterministic rendering, CSS-only tabs, host items, add/remove canvas tools, and migration behavior from Wave 28.
+- Added persisted `canvas_story_slides` alongside the other loop ledger JSON fields.
+- Changed model failure behavior to `no_op` with a run detail and no loop-state write, so failed extraction leaves the previous wall untouched.
+- Added rejection details to generation/run detail text so fabricated receipts and unsupported concepts are visible to operators.
+
+## File list
+
+- `echo/server/dembrane/canvas/ledgers.py`
+- `echo/server/dembrane/canvas/ticks.py`
+- `echo/server/dembrane/canvas/service.py`
+- `echo/server/dembrane/api/v2/bff/canvases.py`
+- `echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py`
+- `echo/server/tests/test_canvas_ledgers.py`
+- `echo/server/tests/test_canvas_ticks.py`
+- `echo/docs/plans/smart-loop-briefs/wave28b-REPORT.md`
+
+Wave 28 files for host-item tools/API remain part of the worktree but were not materially changed for 28b.
+
+## QA gates
+
+- `cd echo/server && uv run ruff check .` passed.
+- `cd echo/server && DIRECTUS_SECRET=test DIRECTUS_TOKEN=test DATABASE_URL=postgresql://user:pass@localhost:5432/db REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=test STORAGE_S3_ENDPOINT=http://localhost:9000 STORAGE_S3_KEY=test STORAGE_S3_SECRET=test uv run pytest -q tests/test_canvas_ledgers.py tests/test_canvas_ticks.py tests/test_canvas_sanitize.py tests/test_canvas_gather.py tests/test_canvas_service.py tests/api/test_bff_canvases.py` passed: 36 passed.
+- `cd echo/agent && uv run pytest -q` passed: 97 passed.
+
+## Coverage added
+
+- Verbatim quote accepted and deduped.
+- Fabricated quote rejected and recorded.
+- Concept with no accepted supporting quote rejected and recorded.
+- Concept caps and exactly three XL tiers enforced in code.
+- Crux updates in place and preserves history.
+- Tick model failure returns `no_op`, creates no generation, and does not update loop state.
+- Tick model success stores accepted state and records rejected receipts in generation detail.
+
+## Notes
+
+- `canvas-update-modes.md` remains absent and Wave 28b explicitly said to ignore that.
+- Migration was not run against a real Directus scratch instance in this worker. It remains idempotent through the existing `ensure_field` guards.
+- `wave18-shots/` is still unrelated untracked workspace state and was not touched.

--- a/echo/docs/plans/smart-loop-briefs/wave28b-model-extraction.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28b-model-extraction.md
@@ -1,0 +1,69 @@
+# Brief: Wave 28b — put the model back in the tick
+
+Continue on branch sameer/tabbed-canvas (your wave-28 work). No git write
+commands. (canvas-update-modes.md being absent was fine — ignore.)
+
+## What is wrong
+
+Wave 28 made the per-tab jobs fully deterministic: every transcript
+sentence >=16 chars becomes a "quote", `_concept_phrase` picks the first
+half of non-stopword words as a "concept", and the crux is a template
+string. That is ingestion wearing the judgment layer's clothes. The
+handoff's checklists are instructions FOR A MODEL ("written so a
+Flash-class model can follow it") — the design is model judgment +
+mechanical receipt verification + deterministic render. You built the
+third part well; restore the first and add the second.
+
+## The fix
+
+1. **One MULTI_MODAL_FAST structured call per content-bearing tick**
+   (same router used by the legacy path). Input: the NEW transcript since
+   the last tick (cap the window sensibly) + a compact summary of current
+   ledgers (existing concept phrases + tiers, current crux, story
+   headings). Prompt = the judgment-layer checklists from
+   echo/docs/plans/canvas-ux-handoff.md pasted nearly verbatim (quote
+   tracing PROCESS rules, concept cloud checklist 1-9, crux rules).
+   Output JSON:
+   - quotes: [{who|null, quote, conversation_id, chunk_id|null}] — only
+     passages that do real work (name a decision, coin a phrase, answer or
+     contradict). A 30-min transcript should yield dozens, not hundreds.
+   - concepts: [{phrase, supporting_quote_indices}] — new or reinforced.
+   - crux: {question} or null if unchanged.
+   - story_slides: [{eyebrow|null, heading, lede, quote_indices}].
+
+2. **Mechanical receipt validation in code (the grep test, enforced).**
+   After the model returns:
+   - accept a quote ONLY if it appears verbatim (whitespace-normalized,
+     case-preserved) as a substring of the gathered transcript text for
+     that conversation; otherwise drop it and record the rejection in the
+     run record (nothing silently swallowed).
+   - accept a concept ONLY if its phrase is a substring of at least one of
+     its accepted supporting quotes.
+   - a slide lede references quote ids only when those quotes were
+     accepted; otherwise render it as plain synthesis (no trace markup —
+     no receipt, no underline).
+   Keep repetition × spread scoring and the 3 XL / ~20 tile caps in code
+   as you have them — code enforces scarcity, the model proposes.
+
+3. **Crux**: the model writes it (one question, newcomer-answerable,
+   invitation phrasing); code keeps your update-not-append history logic
+   and rejects empty/over-long questions.
+
+4. **On model failure**: keep previous state untouched, no_op the tick,
+   record the error on the run record. DELETE the deterministic
+   sentence-spam path (_sentences-as-quotes, _concept_phrase) rather than
+   keeping it as a fallback — a garbage wall is worse than an unchanged
+   wall.
+
+5. Rendering, ledgers persistence, host_items, addToCanvas, migration,
+   CSS-only tabs: unchanged from wave 28.
+
+## QA gates
+
+- Update tests: mock the model call (as existing tick tests do); add
+  rejection tests (fabricated quote -> dropped + recorded; concept without
+  a home quote -> dropped), caps, crux update-not-append, model-failure ->
+  no_op with previous state intact.
+- cd echo/server && uv run ruff check . ; focused pytest for canvas files.
+- cd echo/agent && uv run pytest -q (should be untouched).
+- Report -> echo/docs/plans/smart-loop-briefs/wave28b-REPORT.md.

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -30,8 +30,10 @@ from dembrane.canvas.service import (
     apply_loop_action,
     get_latest_config,
     get_loop_for_report,
+    add_canvas_host_item,
     get_latest_generation,
     list_canvas_summaries,
+    remove_canvas_host_item,
     apply_direct_canvas_edit,
 )
 from dembrane.directus_async import async_directus
@@ -95,6 +97,20 @@ class AgenticCanvasEditSchema(BaseModel):
     instruction: str = Field(..., min_length=1)
     content_html: str = Field(..., min_length=1)
     chat_id: Optional[str] = None
+
+
+class AgenticCanvasHostItemSchema(BaseModel):
+    text: str = Field(..., min_length=1, max_length=2000)
+    target_tab: str = Field(default="story", min_length=1, max_length=80)
+    person: Optional[str] = Field(default=None, max_length=160)
+    chat_id: Optional[str] = None
+    message_id: Optional[str] = None
+
+
+class AgenticCanvasRemoveHostItemSchema(BaseModel):
+    item: str = Field(..., min_length=1, max_length=2000)
+    chat_id: Optional[str] = None
+    message_id: Optional[str] = None
 
 
 # Agent memory: three scopes the agent both reads and writes. Private or
@@ -164,7 +180,9 @@ async def _assert_project_access(project_id: str, auth: DirectusSession) -> None
     access.require("chat:use")
 
 
-def _exclude_others_private_chats(base_filter: dict[str, Any], auth: DirectusSession) -> dict[str, Any]:
+def _exclude_others_private_chats(
+    base_filter: dict[str, Any], auth: DirectusSession
+) -> dict[str, Any]:
     """Hide chats that are private and owned by someone else.
 
     A chat is hidden when `is_private == true` AND `user_created != caller`.
@@ -597,7 +615,9 @@ def _list_project_conversations_for_agent(
                 is_new_conversation = conversation_identifier not in conversations_by_id
                 if is_new_conversation and len(conversations_by_id) >= normalized_limit:
                     continue
-                existing_matches = conversations_by_id.get(conversation_identifier, {}).get("matches")
+                existing_matches = conversations_by_id.get(conversation_identifier, {}).get(
+                    "matches"
+                )
                 normalized_existing_matches = (
                     existing_matches if isinstance(existing_matches, list) else []
                 )
@@ -1377,6 +1397,47 @@ async def edit_project_canvas(
         "generation": edited["generation"],
         "config_revision": edited["config_revision"],
     }
+
+
+@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/host-items")
+async def add_project_canvas_host_item(
+    project_id: str,
+    canvas_id: str,
+    body: AgenticCanvasHostItemSchema,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    _require_agent_token(auth)
+    await _assert_project_access(project_id, auth)
+    await _get_project_canvas_or_404(project_id, canvas_id)
+    try:
+        return await add_canvas_host_item(
+            report_id=canvas_id,
+            text=body.text,
+            target_tab=body.target_tab,
+            person=body.person,
+            chat_id=body.chat_id,
+            message_id=body.message_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/host-items/remove")
+async def remove_project_canvas_host_item(
+    project_id: str,
+    canvas_id: str,
+    body: AgenticCanvasRemoveHostItemSchema,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    _require_agent_token(auth)
+    await _assert_project_access(project_id, auth)
+    await _get_project_canvas_or_404(project_id, canvas_id)
+    return await remove_canvas_host_item(
+        report_id=canvas_id,
+        item=body.item,
+        chat_id=body.chat_id,
+        message_id=body.message_id,
+    )
 
 
 @AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/loop/{action}")

--- a/echo/server/dembrane/api/v2/bff/canvases.py
+++ b/echo/server/dembrane/api/v2/bff/canvases.py
@@ -12,9 +12,15 @@ from pydantic import Field, BaseModel
 from fastapi.responses import StreamingResponse
 
 from dembrane.redis_async import get_redis_client
-from dembrane.canvas.ticks import run_tick, _generate_html
+from dembrane.canvas.ticks import (
+    run_tick,
+    _generate_html,
+    _gather_has_transcript,
+    _extract_living_canvas_update,
+)
 from dembrane.canvas.events import read_generation_nudge, subscribe_generation_nudges
 from dembrane.canvas.gather import execute_gather_spec
+from dembrane.canvas.ledgers import fresh_canvas_state, apply_model_extraction
 from dembrane.canvas.service import (
     create_canvas,
     list_generations,
@@ -22,10 +28,12 @@ from dembrane.canvas.service import (
     get_latest_config,
     get_latest_loop_run,
     get_loop_for_report,
+    add_canvas_host_item,
     update_canvas_config,
     update_loop_settings,
     get_latest_generation,
     list_canvas_summaries,
+    remove_canvas_host_item,
 )
 from dembrane.directus_async import async_directus
 from dembrane.canvas.sanitize import sanitize_canvas_html
@@ -68,6 +76,20 @@ class PreviewCanvasBody(BaseModel):
     project_id: str
     brief: str = Field(min_length=1, max_length=8000)
     gather_spec: dict[str, Any] | None = None
+
+
+class CanvasHostItemBody(BaseModel):
+    text: str = Field(min_length=1, max_length=2000)
+    target_tab: str = Field(default="story", min_length=1, max_length=80)
+    person: str | None = Field(default=None, max_length=160)
+    chat_id: str | None = None
+    message_id: str | None = None
+
+
+class CanvasRemoveHostItemBody(BaseModel):
+    item: str = Field(min_length=1, max_length=2000)
+    chat_id: str | None = None
+    message_id: str | None = None
 
 
 def _as_id(value: Any) -> str | None:
@@ -254,10 +276,22 @@ async def preview_canvas(
         gather_spec=body.gather_spec or {},
         preview_sample=True,
     )
+    living_state = fresh_canvas_state()
+    if _gather_has_transcript(gather_bundle):
+        try:
+            extraction = await _extract_living_canvas_update(
+                gather_bundle=gather_bundle,
+                current_state=living_state,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"Canvas extraction failed: {exc}") from exc
+        living_state, _detail = apply_model_extraction(living_state, gather_bundle, extraction)
+
     raw_html = await _generate_html(
         brief=body.brief,
         previous_html=None,
         gather_bundle=gather_bundle,
+        living_state=living_state,
     )
     sanitized = sanitize_canvas_html(raw_html)
     return {"content_html": sanitized.html}
@@ -367,6 +401,40 @@ async def refresh_canvas(canvas_id: str, auth: DependencyDirectusSession) -> dic
         raise HTTPException(status_code=429, detail="Just refreshed")
     await run_tick(str(loop["id"]), "manual")
     return {"generation": "pending"}
+
+
+@router.post("/{canvas_id}/host-items")
+async def add_host_item_endpoint(
+    canvas_id: str,
+    body: CanvasHostItemBody,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    report, access = await _require_canvas(canvas_id, auth)
+    access.require("project:update")
+    return await add_canvas_host_item(
+        report_id=_report_id(report),
+        text=body.text,
+        target_tab=body.target_tab,
+        person=body.person,
+        chat_id=await _validated_chat_id(body.chat_id, _as_id(report.get("project_id"))),
+        message_id=body.message_id,
+    )
+
+
+@router.post("/{canvas_id}/host-items/remove")
+async def remove_host_item_endpoint(
+    canvas_id: str,
+    body: CanvasRemoveHostItemBody,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    report, access = await _require_canvas(canvas_id, auth)
+    access.require("project:update")
+    return await remove_canvas_host_item(
+        report_id=_report_id(report),
+        item=body.item,
+        chat_id=await _validated_chat_id(body.chat_id, _as_id(report.get("project_id"))),
+        message_id=body.message_id,
+    )
 
 
 @router.post("/{canvas_id}/loop/{action}")

--- a/echo/server/dembrane/canvas/gather.py
+++ b/echo/server/dembrane/canvas/gather.py
@@ -152,12 +152,21 @@ async def execute_gather_spec(
         )
         chunks = chunks_raw if isinstance(chunks_raw, list) else []
         text_parts: list[str] = []
+        chunk_rows: list[dict[str, Any]] = []
         for chunk in chunks:
             transcript = str(chunk.get("transcript") or "").strip()
             if not transcript:
                 continue
             chunks_seen += 1
             text_parts.append(transcript)
+            chunk_rows.append(
+                {
+                    "id": _as_id(chunk.get("id")),
+                    "transcript": transcript,
+                    "created_at": chunk.get("created_at"),
+                    "timestamp": chunk.get("timestamp"),
+                }
+            )
             chunk_time = chunk.get("created_at") or chunk.get("timestamp")
             if chunk_time and (latest_content_at is None or str(chunk_time) > latest_content_at):
                 latest_content_at = str(chunk_time)
@@ -175,6 +184,7 @@ async def execute_gather_spec(
                 "label": conv.get("participant_name") or "participant",
                 "created_at": conv.get("created_at"),
                 "latest_transcript": clipped,
+                "chunks": chunk_rows,
             }
         )
 
@@ -202,9 +212,7 @@ async def execute_gather_spec(
         "latest_content_at": latest_content_at,
         "sample_mode": sample_mode,
         "sample_notice": (
-            "Sample conversations, your real conversations replace these."
-            if sample_mode
-            else None
+            "Sample conversations, your real conversations replace these." if sample_mode else None
         ),
         "conversations": conversations_out,
     }

--- a/echo/server/dembrane/canvas/ledgers.py
+++ b/echo/server/dembrane/canvas/ledgers.py
@@ -1,0 +1,653 @@
+"""Additive ledger state and tabbed canvas rendering."""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+from datetime import datetime, timezone
+
+from dembrane.utils import generate_uuid
+
+CANVAS_TAB_SET_V1 = ("crux", "concept_cloud", "story")
+CANVAS_TAB_LABELS = {
+    "crux": "Crux",
+    "concept_cloud": "Concept cloud",
+    "story": "Story",
+}
+HOST_TARGET_TABS = set(CANVAS_TAB_SET_V1)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fresh_canvas_state(loop: dict[str, Any] | None = None) -> dict[str, Any]:
+    loop = loop or {}
+    return {
+        "schema_version": 1,
+        "tabs": list(loop.get("tabs") or loop.get("canvas_tabs") or CANVAS_TAB_SET_V1),
+        "quotes_ledger": _list(loop.get("quotes_ledger") or loop.get("canvas_quotes_ledger")),
+        "concepts_ledger": _list(loop.get("concepts_ledger") or loop.get("canvas_concepts_ledger")),
+        "crux": _dict(loop.get("crux") or loop.get("canvas_crux"))
+        or {"question": "", "history": []},
+        "host_items": _list(loop.get("host_items") or loop.get("canvas_host_items")),
+        "story_slides": _list(loop.get("story_slides") or loop.get("canvas_story_slides")),
+    }
+
+
+def state_patch(state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "canvas_tabs": state.get("tabs") or list(CANVAS_TAB_SET_V1),
+        "canvas_quotes_ledger": state.get("quotes_ledger") or [],
+        "canvas_concepts_ledger": state.get("concepts_ledger") or [],
+        "canvas_crux": state.get("crux") or {"question": "", "history": []},
+        "canvas_host_items": state.get("host_items") or [],
+        "canvas_story_slides": state.get("story_slides") or [],
+    }
+
+
+def host_item(
+    *,
+    text: str,
+    target_tab: str,
+    person: str | None,
+    chat_id: str | None,
+    message_id: str | None,
+) -> dict[str, Any]:
+    normalized_target = normalize_target_tab(target_tab)
+    return {
+        "id": generate_uuid(),
+        "text": text.strip(),
+        "person": person.strip() if person else None,
+        "target_tab": normalized_target,
+        "source": {"chat_id": chat_id, "message_id": message_id},
+        "added_at": utc_now_iso(),
+        "removed_at": None,
+    }
+
+
+def normalize_target_tab(target_tab: str | None) -> str:
+    normalized = (target_tab or "story").strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {"cloud": "concept_cloud", "concept": "concept_cloud", "concepts": "concept_cloud"}
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in HOST_TARGET_TABS:
+        raise ValueError("target_tab must be one of crux, concept_cloud, or story")
+    return normalized
+
+
+def append_host_item(state: dict[str, Any], item: dict[str, Any]) -> dict[str, Any]:
+    state = fresh_canvas_state(state)
+    state["host_items"] = [*state["host_items"], item]
+    return state
+
+
+def remove_host_item(state: dict[str, Any], item_id_or_text: str) -> tuple[dict[str, Any], bool]:
+    state = fresh_canvas_state(state)
+    needle = item_id_or_text.strip().lower()
+    removed = False
+    items: list[dict[str, Any]] = []
+    for item in state["host_items"]:
+        if item.get("removed_at"):
+            items.append(item)
+            continue
+        matches_id = str(item.get("id") or "").lower() == needle
+        matches_text = needle and needle in str(item.get("text") or "").lower()
+        if matches_id or matches_text:
+            item = {**item, "removed_at": utc_now_iso()}
+            removed = True
+        items.append(item)
+    state["host_items"] = items
+    return state, removed
+
+
+def apply_model_extraction(
+    state: dict[str, Any],
+    gather_bundle: dict[str, Any],
+    extraction: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    state = fresh_canvas_state(state)
+    now = utc_now_iso()
+    transcript_index = _transcript_index(gather_bundle)
+    accepted_quotes, quote_index_to_id, quote_rejections = _accept_model_quotes(
+        state,
+        extraction,
+        transcript_index,
+        now,
+    )
+    concept_changes, concept_rejections = _merge_model_concepts(
+        state,
+        extraction,
+        quote_index_to_id,
+        now,
+    )
+    crux_changed, crux_rejections = _update_model_crux(state, extraction, now)
+    story_changed, story_rejections = _merge_story_slides(state, extraction, quote_index_to_id, now)
+    return state, {
+        "quotes_added": accepted_quotes,
+        "concepts_changed": concept_changes,
+        "crux_changed": crux_changed,
+        "story_changed": story_changed,
+        "concepts_removed": [],
+        "rejections": quote_rejections + concept_rejections + crux_rejections + story_rejections,
+    }
+
+
+def ledger_prompt_summary(state: dict[str, Any]) -> dict[str, Any]:
+    state = fresh_canvas_state(state)
+    ranked_concepts = sorted(
+        state["concepts_ledger"],
+        key=lambda c: (_concept_score(c, state["quotes_ledger"]), c.get("last_reinforced") or ""),
+        reverse=True,
+    )[:24]
+    return {
+        "concepts": [
+            {"phrase": c.get("phrase"), "size_tier": c.get("size_tier")}
+            for c in ranked_concepts
+            if c.get("phrase")
+        ],
+        "crux": (state.get("crux") or {}).get("question") or None,
+        "story_headings": [
+            slide.get("heading")
+            for slide in state.get("story_slides") or []
+            if isinstance(slide, dict) and slide.get("heading")
+        ][:8],
+    }
+
+
+def _transcript_index(gather_bundle: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for conv in _list(gather_bundle.get("conversations")):
+        conv_id = str(conv.get("id") or "")
+        if not conv_id:
+            continue
+        chunks = _list(conv.get("chunks"))
+        if not chunks:
+            chunks = [
+                {
+                    "id": None,
+                    "transcript": conv.get("latest_transcript") or "",
+                    "created_at": conv.get("created_at"),
+                }
+            ]
+        transcript_parts = [str(chunk.get("transcript") or "") for chunk in chunks]
+        index[conv_id] = {
+            "label": conv.get("label") if conv.get("label") != "participant" else None,
+            "created_at": conv.get("created_at"),
+            "text": "\n".join(part for part in transcript_parts if part),
+            "chunks": {
+                str(chunk.get("id") or ""): {
+                    "text": str(chunk.get("transcript") or ""),
+                    "created_at": chunk.get("created_at") or chunk.get("timestamp"),
+                }
+                for chunk in chunks
+            },
+        }
+    return index
+
+
+def _accept_model_quotes(
+    state: dict[str, Any],
+    extraction: dict[str, Any],
+    transcript_index: dict[str, dict[str, Any]],
+    now: str,
+) -> tuple[int, dict[int, str], list[str]]:
+    seen = {
+        (
+            str(q.get("source", {}).get("conversation_id") or ""),
+            str(q.get("source", {}).get("chunk_id") or ""),
+            str(q.get("quote") or "").strip(),
+        )
+        for q in state["quotes_ledger"]
+    }
+    appended = 0
+    quote_index_to_id: dict[int, str] = {}
+    rejections: list[str] = []
+    for model_index, quote in enumerate(_list(extraction.get("quotes"))):
+        text = str(quote.get("quote") or "").strip()
+        conv_id = str(quote.get("conversation_id") or "")
+        raw_chunk_id = quote.get("chunk_id")
+        chunk_id = str(raw_chunk_id) if raw_chunk_id else ""
+        conv = transcript_index.get(conv_id)
+        if not text or not conv:
+            rejections.append(f"quote[{model_index}] missing text or conversation: {text[:80]}")
+            continue
+        if _normalize_ws(text) not in _normalize_ws(str(conv.get("text") or "")):
+            rejections.append(f"quote[{model_index}] not found verbatim: {text[:120]}")
+            continue
+        key = (conv_id, chunk_id, text)
+        existing_id = _existing_quote_id(state, conv_id, chunk_id, text)
+        if existing_id:
+            quote_index_to_id[model_index] = existing_id
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        chunk = (conv.get("chunks") or {}).get(chunk_id) or {}
+        quote_id = generate_uuid()
+        quote_index_to_id[model_index] = quote_id
+        state["quotes_ledger"].append(
+            {
+                "id": quote_id,
+                "who": quote.get("who") or conv.get("label"),
+                "quote": text,
+                "source": {"conversation_id": conv_id, "chunk_id": chunk_id or None},
+                "when": chunk.get("created_at") or conv.get("created_at") or now,
+            }
+        )
+        appended += 1
+    return appended, quote_index_to_id, rejections
+
+
+def _merge_model_concepts(
+    state: dict[str, Any],
+    extraction: dict[str, Any],
+    quote_index_to_id: dict[int, str],
+    now: str,
+) -> tuple[int, list[str]]:
+    by_phrase = {
+        str(concept.get("phrase") or "").lower(): concept
+        for concept in state["concepts_ledger"]
+        if concept.get("phrase")
+    }
+    changed = 0
+    rejections: list[str] = []
+    quotes_by_id = {str(quote.get("id")): quote for quote in state["quotes_ledger"]}
+    for model_index, concept_input in enumerate(_list(extraction.get("concepts"))):
+        phrase = str(concept_input.get("phrase") or "").strip()
+        if not phrase:
+            rejections.append(f"concept[{model_index}] empty phrase")
+            continue
+        quote_ids = _supported_quote_ids(
+            concept_input.get("supporting_quote_indices"), quote_index_to_id
+        )
+        if not quote_ids:
+            rejections.append(
+                f"concept[{model_index}] has no accepted supporting quote: {phrase[:80]}"
+            )
+            continue
+        if not any(
+            _normalize_ws(phrase) in _normalize_ws(str(quotes_by_id[qid].get("quote") or ""))
+            for qid in quote_ids
+            if qid in quotes_by_id
+        ):
+            rejections.append(
+                f"concept[{model_index}] phrase not found in supporting quote: {phrase[:80]}"
+            )
+            continue
+        key = phrase.lower()
+        concept = by_phrase.get(key)
+        if not concept:
+            concept = {
+                "id": generate_uuid(),
+                "phrase": phrase,
+                "quote_ids": [],
+                "size_tier": "s",
+                "first_seen": now,
+                "last_reinforced": now,
+            }
+            state["concepts_ledger"].append(concept)
+            by_phrase[key] = concept
+            changed += 1
+        for quote_id in quote_ids:
+            if quote_id in concept["quote_ids"]:
+                continue
+            concept["quote_ids"].append(quote_id)
+            concept["last_reinforced"] = now
+            changed += 1
+
+    ranked = sorted(
+        state["concepts_ledger"],
+        key=lambda c: (_concept_score(c, state["quotes_ledger"]), c.get("first_seen") or ""),
+        reverse=True,
+    )
+    for index, concept in enumerate(ranked):
+        old = concept.get("size_tier")
+        if index < 3 and len(ranked) >= 3:
+            tier = "xl"
+        elif index < 7:
+            tier = "l"
+        elif index < 13:
+            tier = "m"
+        else:
+            tier = "s"
+        if old != tier:
+            concept["size_tier"] = tier
+            changed += 1
+    return changed, rejections
+
+
+def _update_model_crux(
+    state: dict[str, Any], extraction: dict[str, Any], now: str
+) -> tuple[bool, list[str]]:
+    crux_input = extraction.get("crux")
+    if crux_input is None:
+        return False, []
+    if not isinstance(crux_input, dict):
+        return False, ["crux was not an object or null"]
+    question = str(crux_input.get("question") or "").strip()
+    if not question:
+        return False, ["crux question was empty"]
+    if len(question) > 180:
+        return False, ["crux question was over 180 characters"]
+    current = str((state.get("crux") or {}).get("question") or "").strip()
+    if question == current:
+        return False, []
+    crux = state.setdefault("crux", {"question": "", "history": []})
+    if current:
+        crux.setdefault("history", []).append({"question": current, "replaced_at": now})
+    crux["question"] = question
+    crux["updated_at"] = now
+    return True, []
+
+
+def _merge_story_slides(
+    state: dict[str, Any],
+    extraction: dict[str, Any],
+    quote_index_to_id: dict[int, str],
+    now: str,
+) -> tuple[bool, list[str]]:
+    slides = _list(extraction.get("story_slides"))
+    if not slides:
+        return False, []
+    accepted: list[dict[str, Any]] = []
+    rejections: list[str] = []
+    for index, slide in enumerate(slides[:8]):
+        heading = str(slide.get("heading") or "").strip()
+        if not heading:
+            rejections.append(f"story_slides[{index}] empty heading")
+            continue
+        accepted.append(
+            {
+                "id": str(slide.get("id") or generate_uuid()),
+                "eyebrow": str(slide.get("eyebrow") or "").strip() or None,
+                "heading": heading[:180],
+                "lede": str(slide.get("lede") or "").strip()[:600],
+                "quote_ids": _supported_quote_ids(slide.get("quote_indices"), quote_index_to_id),
+                "updated_at": now,
+            }
+        )
+    if not accepted:
+        return False, rejections
+    state["story_slides"] = accepted
+    return True, rejections
+
+
+def render_tabbed_canvas(
+    *,
+    state: dict[str, Any],
+    project: dict[str, Any],
+    sample_notice: str | None = None,
+) -> str:
+    state = fresh_canvas_state(state)
+    tabs = [tab for tab in CANVAS_TAB_SET_V1 if tab in state["tabs"]]
+    if not tabs:
+        tabs = list(CANVAS_TAB_SET_V1)
+    project_name = html.escape(str(project.get("name") or "Canvas"))
+    sample = (
+        f'<p class="tabbed-canvas-notice">{html.escape(sample_notice)}</p>' if sample_notice else ""
+    )
+    controls = "\n".join(
+        f'<input class="tabbed-canvas-radio" type="radio" name="canvas-tab" id="canvas-tab-{tab}" {"checked" if index == 0 else ""}>'
+        for index, tab in enumerate(tabs)
+    )
+    labels = "\n".join(
+        f'<label class="tabbed-canvas-tab" for="canvas-tab-{tab}">{html.escape(CANVAS_TAB_LABELS[tab])}</label>'
+        for tab in tabs
+    )
+    panels = "\n".join(_panel(tab, state) for tab in tabs)
+    return f"""
+<div class="canvas-shell tabbed-canvas" data-canvas-schema="tabbed-v1">
+  <style>{_CSS}</style>
+  <div class="tabbed-canvas-frame">
+    <p class="tabbed-canvas-kicker">{project_name}</p>
+    {sample}
+    {controls}
+    <nav class="tabbed-canvas-tabbar" aria-label="Canvas tabs">
+      {labels}
+      <span class="tabbed-canvas-add" aria-hidden="true">+</span>
+    </nav>
+    {panels}
+  </div>
+</div>
+""".strip()
+
+
+def _panel(tab: str, state: dict[str, Any]) -> str:
+    label = html.escape(CANVAS_TAB_LABELS[tab])
+    if tab == "crux":
+        body = _render_crux(state)
+    elif tab == "concept_cloud":
+        body = _render_cloud(state)
+    else:
+        body = _render_story(state)
+    return f'<section class="tabbed-canvas-panel tabbed-canvas-panel-{tab}" data-tab-panel="{tab}" aria-label="{label}">{body}</section>'
+
+
+def _render_crux(state: dict[str, Any]) -> str:
+    question = html.escape(
+        str((state.get("crux") or {}).get("question") or "What should we listen for next?")
+    )
+    host = _render_host_items(state, "crux")
+    return f"""
+<div class="tabbed-crux">
+  <p class="tabbed-canvas-kicker">Crux</p>
+  <h1>{question}</h1>
+  <p class="tabbed-canvas-lede">Scan the room and give your first answer out loud: one move, one bet, one reason it works.</p>
+  {host}
+</div>
+""".strip()
+
+
+def _render_cloud(state: dict[str, Any]) -> str:
+    concepts = sorted(
+        state["concepts_ledger"],
+        key=lambda c: (
+            {"xl": 4, "l": 3, "m": 2, "s": 1}.get(str(c.get("size_tier")), 1),
+            c.get("last_reinforced") or "",
+        ),
+        reverse=True,
+    )[:20]
+    if not concepts:
+        tiles = (
+            '<p class="tabbed-canvas-empty">Concepts will appear as transcript receipts arrive.</p>'
+        )
+    else:
+        tiles = "\n".join(
+            _concept_tile(concept, state["quotes_ledger"], index)
+            for index, concept in enumerate(concepts)
+        )
+    return f'<div class="tabbed-cloud">{tiles}{_render_host_items(state, "concept_cloud")}</div>'
+
+
+def _render_story(state: dict[str, Any]) -> str:
+    slides = state.get("story_slides") or []
+    if slides:
+        slide_html = "\n".join(_story_slide(slide, state["quotes_ledger"]) for slide in slides)
+    else:
+        quotes = state["quotes_ledger"][-4:]
+        if quotes:
+            slide_html = "\n".join(_quote_block(q) for q in quotes)
+        else:
+            slide_html = '<p class="tabbed-canvas-empty">The story is waiting for the first usable room quotes.</p>'
+    heading = html.escape(str((state.get("crux") or {}).get("question") or "What is emerging?"))
+    return f"""
+<div class="tabbed-story">
+  <p class="tabbed-canvas-kicker">Story</p>
+  <h2>{heading}</h2>
+  <div class="tabbed-story-quotes">{slide_html}</div>
+  {_render_host_items(state, "story")}
+</div>
+""".strip()
+
+
+def _story_slide(slide: dict[str, Any], quotes: list[dict[str, Any]]) -> str:
+    eyebrow = str(slide.get("eyebrow") or "").strip()
+    eyebrow_html = f'<p class="tabbed-canvas-kicker">{html.escape(eyebrow)}</p>' if eyebrow else ""
+    quote_ids = {str(qid) for qid in slide.get("quote_ids") or []}
+    evidence = [quote for quote in quotes if str(quote.get("id")) in quote_ids]
+    trace = "\n".join(_quote_block(q) for q in evidence[:3])
+    lede = html.escape(str(slide.get("lede") or ""))
+    if lede and evidence:
+        lede_html = f'<details class="tabbed-slide-trace"><summary><span class="tabbed-traceable">{lede}</span></summary><div class="tabbed-trace">{trace}</div></details>'
+    elif lede:
+        lede_html = f'<p class="tabbed-canvas-lede">{lede}</p>'
+    else:
+        lede_html = trace
+    return f"""
+<article class="tabbed-story-slide">
+  {eyebrow_html}
+  <h3>{html.escape(str(slide.get("heading") or ""))}</h3>
+  {lede_html}
+</article>
+""".strip()
+
+
+def _legacy_story_quotes(state: dict[str, Any]) -> str:
+    quotes = state["quotes_ledger"][-4:]
+    if not quotes:
+        quote_html = '<p class="tabbed-canvas-empty">The story is waiting for the first usable room quotes.</p>'
+    else:
+        quote_html = "\n".join(_quote_block(q) for q in quotes)
+    return quote_html
+
+
+def _concept_tile(concept: dict[str, Any], quotes: list[dict[str, Any]], index: int) -> str:
+    phrase = html.escape(str(concept.get("phrase") or ""))
+    tier = html.escape(str(concept.get("size_tier") or "s"))
+    quote_ids = [str(qid) for qid in concept.get("quote_ids") or []]
+    evidence = [q for q in quotes if str(q.get("id")) in quote_ids]
+    trace = "\n".join(_quote_block(q) for q in evidence[:4])
+    rotation = "pos" if index % 2 else "neg"
+    if trace:
+        return f"""
+<details class="tabbed-concept tabbed-concept-{tier} tabbed-tilt-{rotation}">
+  <summary><span class="tabbed-traceable">{phrase}</span></summary>
+  <div class="tabbed-trace">{trace}</div>
+</details>
+""".strip()
+    return f'<div class="tabbed-concept tabbed-concept-{tier} tabbed-tilt-{rotation}"><span>{phrase}</span></div>'
+
+
+def _quote_block(quote: dict[str, Any]) -> str:
+    text = html.escape(str(quote.get("quote") or ""))
+    who = html.escape(str(quote.get("who") or "participant"))
+    when = html.escape(str(quote.get("when") or ""))
+    return f'<blockquote class="tabbed-quote"><p>“{text}”</p><footer>{who} · {when}</footer></blockquote>'
+
+
+def _render_host_items(state: dict[str, Any], tab: str) -> str:
+    items = [
+        item
+        for item in state["host_items"]
+        if not item.get("removed_at") and item.get("target_tab") == tab
+    ]
+    if not items:
+        return ""
+    rows = "\n".join(
+        f'<div class="tabbed-host-item"><p>{html.escape(str(item.get("text") or ""))}</p><footer>{html.escape(str(item.get("person") or "host"))}</footer></div>'
+        for item in items
+    )
+    return f'<div class="tabbed-host-items">{rows}</div>'
+
+
+def _normalize_ws(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _existing_quote_id(
+    state: dict[str, Any],
+    conversation_id: str,
+    chunk_id: str,
+    quote_text: str,
+) -> str | None:
+    normalized_quote = _normalize_ws(quote_text)
+    for quote in state["quotes_ledger"]:
+        source = quote.get("source") or {}
+        if str(source.get("conversation_id") or "") != conversation_id:
+            continue
+        if str(source.get("chunk_id") or "") != chunk_id:
+            continue
+        if _normalize_ws(str(quote.get("quote") or "")) == normalized_quote:
+            return str(quote.get("id") or "")
+    return None
+
+
+def _supported_quote_ids(
+    raw_indices: Any,
+    quote_index_to_id: dict[int, str],
+) -> list[str]:
+    out: list[str] = []
+    for raw_index in raw_indices if isinstance(raw_indices, list) else []:
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            continue
+        quote_id = quote_index_to_id.get(index)
+        if quote_id and quote_id not in out:
+            out.append(quote_id)
+    return out
+
+
+def _concept_score(concept: dict[str, Any], quotes: list[dict[str, Any]]) -> int:
+    quote_ids = {str(qid) for qid in concept.get("quote_ids") or []}
+    spread = {
+        str(q.get("source", {}).get("conversation_id") or "")
+        for q in quotes
+        if str(q.get("id")) in quote_ids
+    }
+    return len(quote_ids) + len(spread) * 2
+
+
+def _list(value: Any) -> list[dict[str, Any]]:
+    return value if isinstance(value, list) else []
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+_CSS = """
+:root{--parchment:#F6F4F1;--card:#FFFFFF;--ink:#2D2D2C;--ink-soft:#6E6B66;--royal:#4169E1;--hairline:#E6E3DF;--amber:#FFD166}
+.tabbed-canvas{font-family:"DM Sans",system-ui,sans-serif;color:var(--ink);background:var(--parchment)}
+.tabbed-canvas-frame{padding:14px 26px 80px}
+.tabbed-canvas-kicker{margin:0 0 10px;font-size:11px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;color:var(--royal)}
+.tabbed-canvas-notice{border:1px solid var(--amber);background:rgba(255,209,102,.35);padding:12px 13px;margin:0 0 14px}
+.tabbed-canvas-radio{position:absolute;opacity:0;pointer-events:none}
+.tabbed-canvas-tabbar{display:flex;align-items:end;border-bottom:1px solid var(--hairline);gap:26px;margin:0 0 26px}
+.tabbed-canvas-tab{font-size:14.5px;font-weight:500;color:var(--ink-soft);border-bottom:2px solid transparent;padding:10px 2px;cursor:pointer}
+.tabbed-canvas-add{margin-left:auto;color:var(--royal);font-size:22px;line-height:1.6}
+.tabbed-canvas-panel{display:none}
+#canvas-tab-crux:checked~.tabbed-canvas-tabbar label[for=canvas-tab-crux],
+#canvas-tab-concept_cloud:checked~.tabbed-canvas-tabbar label[for=canvas-tab-concept_cloud],
+#canvas-tab-story:checked~.tabbed-canvas-tabbar label[for=canvas-tab-story]{color:var(--ink);border-bottom-color:var(--royal)}
+#canvas-tab-crux:checked~[data-tab-panel=crux],
+#canvas-tab-concept_cloud:checked~[data-tab-panel=concept_cloud],
+#canvas-tab-story:checked~[data-tab-panel=story]{display:block}
+.tabbed-crux,.tabbed-story{max-width:1000px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center}
+.tabbed-crux h1,.tabbed-story h2{max-width:900px;margin:0;font-weight:500;line-height:1.14;text-wrap:balance}
+.tabbed-crux h1{font-size:clamp(32px,4.6vw,48px)}
+.tabbed-story h2{font-size:clamp(24px,3.4vw,36px)}
+.tabbed-canvas-lede{max-width:620px;font-size:16px;line-height:1.45;color:var(--ink-soft)}
+.tabbed-cloud{max-width:1060px;margin:0 auto;display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:center;padding:30px 0}
+.tabbed-concept{background:var(--card);border:1px solid var(--hairline);padding:12px 13px;animation:tabbedFloat 7s ease-in-out infinite}
+.tabbed-concept summary{list-style:none;cursor:pointer}
+.tabbed-concept summary::-webkit-details-marker{display:none}
+.tabbed-concept-xl{font-size:clamp(24px,2.8vw,34px);font-weight:600}
+.tabbed-concept-l{font-size:22px;font-weight:500}
+.tabbed-concept-m{font-size:16px;font-weight:500}
+.tabbed-concept-s{font-size:12px;font-weight:400}
+.tabbed-tilt-neg{transform:rotate(-1.2deg)}
+.tabbed-tilt-pos{transform:rotate(1.2deg)}
+.tabbed-traceable{border-bottom:1px dotted var(--royal)}
+.tabbed-trace{margin-top:12px;max-width:520px}
+.tabbed-quote{margin:12px 0;padding:15px 18px;border:1px solid var(--hairline);border-left:3px solid var(--royal);background:var(--card)}
+.tabbed-quote p{margin:0;font-size:14px;line-height:1.45}
+.tabbed-quote footer,.tabbed-host-item footer{margin-top:8px;font-size:11px;color:var(--ink-soft);font-variant-numeric:tabular-nums}
+.tabbed-host-items{margin-top:22px;display:grid;gap:12px}
+.tabbed-host-item{border:1px solid var(--hairline);border-left:3px solid var(--royal);background:var(--card);padding:15px 18px}
+.tabbed-host-item p{margin:0;white-space:pre-wrap}
+.tabbed-canvas-empty{color:var(--ink-soft)}
+@keyframes tabbedFloat{0%,100%{translate:0 0}50%{translate:0 -5px}}
+@media (prefers-reduced-motion:reduce){.tabbed-concept{animation:none}}
+@media (max-width:720px){.tabbed-canvas-frame{padding:14px 14px 60px}.tabbed-canvas-tabbar{gap:16px}.tabbed-crux,.tabbed-story{min-height:58vh}}
+"""

--- a/echo/server/dembrane/canvas/service.py
+++ b/echo/server/dembrane/canvas/service.py
@@ -8,6 +8,13 @@ from datetime import datetime, timezone
 from dembrane.utils import generate_uuid
 from dembrane.settings import get_settings
 from dembrane.canvas.events import publish_generation_nudge
+from dembrane.canvas.ledgers import (
+    host_item,
+    state_patch,
+    append_host_item,
+    remove_host_item,
+    fresh_canvas_state,
+)
 from dembrane.directus_async import async_directus
 from dembrane.canvas.sanitize import sanitize_canvas_html
 from dembrane.scheduled_tasks import TASK_CANVAS_TICK, schedule_task, cancel_pending_tasks
@@ -299,6 +306,12 @@ async def get_loop_for_report(report_id: str) -> dict[str, Any] | None:
                     "acting_directus_user_id",
                     "created_from_chat_id",
                     "failure_count",
+                    "canvas_tabs",
+                    "canvas_quotes_ledger",
+                    "canvas_concepts_ledger",
+                    "canvas_crux",
+                    "canvas_host_items",
+                    "canvas_story_slides",
                     "created_at",
                     "updated_at",
                 ],
@@ -409,7 +422,9 @@ async def apply_direct_canvas_edit(
     standing_config = await revise_config(
         report_id=report_id,
         brief=_brief_with_standing_edit(str(config.get("brief") or ""), normalized_instruction),
-        gather_spec=config.get("gather_spec") if isinstance(config.get("gather_spec"), dict) else None,
+        gather_spec=config.get("gather_spec")
+        if isinstance(config.get("gather_spec"), dict)
+        else None,
         cadence_minutes=int(config.get("cadence_minutes") or DEFAULT_CADENCE_MINUTES),
         created_by=created_by,
         note="direct edit",
@@ -427,6 +442,64 @@ async def apply_direct_canvas_edit(
         "config_revision": standing_config,
         "generation": generation,
         "loop": loop,
+    }
+
+
+async def add_canvas_host_item(
+    *,
+    report_id: str,
+    text: str,
+    target_tab: str,
+    person: str | None,
+    chat_id: str | None,
+    message_id: str | None,
+) -> dict[str, Any]:
+    normalized_text = text.strip()
+    if not normalized_text:
+        raise ValueError("text is required")
+    loop = await get_loop_for_report(report_id)
+    if not loop:
+        raise ValueError("Canvas loop not found")
+    item = host_item(
+        text=normalized_text,
+        target_tab=target_tab,
+        person=person,
+        chat_id=chat_id,
+        message_id=message_id,
+    )
+    state = append_host_item(fresh_canvas_state(loop), item)
+    updated = _data(
+        await async_directus.update_item("agent_loop", str(loop["id"]), state_patch(state))
+    )
+    await enqueue_canvas_tick(str(loop["id"]), tick_kind="manual")
+    return {"status": "added", "host_item": item, "loop": updated}
+
+
+async def remove_canvas_host_item(
+    *,
+    report_id: str,
+    item: str,
+    chat_id: str | None,
+    message_id: str | None,
+) -> dict[str, Any]:
+    normalized_item = item.strip()
+    if not normalized_item:
+        raise ValueError("item is required")
+    loop = await get_loop_for_report(report_id)
+    if not loop:
+        raise ValueError("Canvas loop not found")
+    state, removed = remove_host_item(fresh_canvas_state(loop), normalized_item)
+    updated = _data(
+        await async_directus.update_item("agent_loop", str(loop["id"]), state_patch(state))
+    )
+    if removed:
+        await enqueue_canvas_tick(str(loop["id"]), tick_kind="manual")
+    return {
+        "status": "removed" if removed else "not_found",
+        "item": normalized_item,
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "loop": updated,
     }
 
 

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -17,6 +17,13 @@ from dembrane.redis_async import get_redis_client
 from dembrane.canvas.access import CanvasReaderAccessDenied
 from dembrane.canvas.events import publish_generation_nudge
 from dembrane.canvas.gather import execute_gather_spec
+from dembrane.canvas.ledgers import (
+    state_patch,
+    fresh_canvas_state,
+    render_tabbed_canvas,
+    ledger_prompt_summary,
+    apply_model_extraction,
+)
 from dembrane.directus_async import async_directus
 from dembrane.canvas.sanitize import CanvasSanitizationError, sanitize_canvas_html
 
@@ -112,13 +119,81 @@ def _banned_visible_copy(html: str) -> list[str]:
     return found
 
 
-def _generation_detail(*, stripped_references: int, banned_copy: list[str]) -> str | None:
+def _generation_detail(
+    *,
+    stripped_references: int,
+    banned_copy: list[str],
+    ledger_detail: dict[str, Any] | None = None,
+) -> str | None:
     details: list[str] = []
     if stripped_references:
         details.append(f"stripped {stripped_references} external reference(s)")
     if banned_copy:
         details.append("banned visible copy: " + ", ".join(banned_copy))
+    if ledger_detail:
+        details.append(
+            "ledger update: "
+            f"{ledger_detail.get('quotes_added', 0)} quote(s), "
+            f"{ledger_detail.get('concepts_changed', 0)} concept change(s), "
+            f"crux {'changed' if ledger_detail.get('crux_changed') else 'unchanged'}, "
+            f"story {'changed' if ledger_detail.get('story_changed') else 'unchanged'}"
+        )
+        removed = ledger_detail.get("concepts_removed") or []
+        if removed:
+            details.append("concept removals: " + ", ".join(map(str, removed)))
+        rejections = ledger_detail.get("rejections") or []
+        if rejections:
+            details.append("rejections: " + " | ".join(map(str, rejections[:12])))
     return "; ".join(details) if details else None
+
+
+LIVING_CANVAS_MODEL_DISCIPLINE = """
+Tabbed living canvas discipline for Flash-class models:
+- Quote tracing: copied transcript sentence boundaries only; no receipt means no underline.
+- Concept cloud: extract phrases from transcript only; every tile must pass a grep test.
+- Size = repetition times spread; exactly 3 XL when there are at least three concepts; cap visible tiles around 20.
+- Subtract words, never add; use the room's metaphors only; keep 1-2 jokes small.
+- Crux is one newcomer-answerable invitation question, updated in place rather than appended.
+- Host items are exact host text, rendered in their target tab, never paraphrased or dropped.
+"""
+
+MODEL_EXTRACTION_SYSTEM_PROMPT = """
+You update a dembrane tabbed living canvas. Return JSON only.
+
+Quote tracing PROCESS rules:
+- While reading raw text, when a passage does real work (names a decision,
+  coins a phrase, answers an open question, contradicts the wall), push a
+  verbatim slice trimmed at sentence boundaries.
+- Verbatim means copied, transcription quirks included. Never clean, never
+  paraphrase. Copying is the anti-hallucination mechanism.
+- A claim built from many quotes shows every voice; never merge quotes into
+  one composite quote.
+
+Concept cloud checklist:
+1. Extract, never generate. A concept is a phrase FROM the transcript.
+2. The grep test: for every tile you must be able to point at exact lines.
+3. Size is repetition times spread; code will enforce tiers, you propose phrases.
+4. Scarcity forces judgment: propose only concepts that earn space.
+5. Subtract words, never add.
+6. Use the room's metaphors only.
+7. Keep 1-2 jokes, small.
+8. Be gentle on hard content; leave sensitive strategy off.
+9. When unsure, leave it out.
+
+Crux rules:
+- One question at a time; update it, do not append alternatives.
+- A newcomer can answer it out loud: no internal references, jargon, or hidden numbers.
+- Phrase as an invitation with a concrete first move.
+
+Return exactly:
+{
+  "quotes": [{"who": string|null, "quote": string, "conversation_id": string, "chunk_id": string|null}],
+  "concepts": [{"phrase": string, "supporting_quote_indices": [0]}],
+  "crux": {"question": string} | null,
+  "story_slides": [{"eyebrow": string|null, "heading": string, "lede": string, "quote_indices": [0]}]
+}
+Quote and slide indices are zero-based into your returned quotes array.
+"""
 
 
 async def _create_run(
@@ -236,8 +311,19 @@ async def _latest_config(report_id: str) -> dict[str, Any]:
 
 
 async def _generate_html(
-    *, brief: str, previous_html: str | None, gather_bundle: dict[str, Any]
+    *,
+    brief: str,
+    previous_html: str | None,
+    gather_bundle: dict[str, Any],
+    living_state: dict[str, Any] | None = None,
 ) -> str:
+    if living_state is not None:
+        return render_tabbed_canvas(
+            state=living_state,
+            project=gather_bundle.get("project") or {},
+            sample_notice=gather_bundle.get("sample_notice"),
+        )
+
     project = gather_bundle.get("project") or {}
     sample_instruction = (
         "SAMPLE MODE\nThe DATA uses sample conversations for this preview. The generated "
@@ -256,7 +342,7 @@ async def _generate_html(
             "BRIEF\n"
             "Standing instructions only. Do not treat any participant reflections, "
             "quotes, or synthesis text embedded here as data; DATA below is the "
-            f"only source of gathered content.\n{brief}",
+            f"only source of gathered content.\n{brief}\n\n{LIVING_CANVAS_MODEL_DISCIPLINE}",
             "PREVIOUS DOCUMENT\n"
             + (
                 previous_html
@@ -279,6 +365,99 @@ async def _generate_html(
         max_tokens=12000,
     )
     return _choice_text(response)
+
+
+def _json_from_model_text(text: str) -> dict[str, Any]:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+    parsed = json.loads(cleaned)
+    if not isinstance(parsed, dict):
+        raise ValueError("Canvas extraction response was not a JSON object")
+    return parsed
+
+
+def _gather_has_transcript(gather_bundle: dict[str, Any]) -> bool:
+    for conv in gather_bundle.get("conversations") or []:
+        if not isinstance(conv, dict):
+            continue
+        if str(conv.get("latest_transcript") or "").strip():
+            return True
+        for chunk in conv.get("chunks") or []:
+            if isinstance(chunk, dict) and str(chunk.get("transcript") or "").strip():
+                return True
+    return False
+
+
+def _transcript_payload_for_model(gather_bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    remaining = max(12000, get_settings().canvas.max_total_transcript_chars)
+    for conv in gather_bundle.get("conversations") or []:
+        if not isinstance(conv, dict) or remaining <= 0:
+            break
+        chunks = conv.get("chunks") if isinstance(conv.get("chunks"), list) else []
+        if not chunks:
+            chunks = [
+                {
+                    "id": None,
+                    "transcript": conv.get("latest_transcript") or "",
+                    "created_at": conv.get("created_at"),
+                }
+            ]
+        chunk_payload: list[dict[str, Any]] = []
+        for chunk in chunks:
+            if not isinstance(chunk, dict) or remaining <= 0:
+                break
+            transcript = str(chunk.get("transcript") or "").strip()
+            if not transcript:
+                continue
+            clipped = transcript[:remaining]
+            remaining -= len(clipped)
+            chunk_payload.append(
+                {
+                    "chunk_id": chunk.get("id"),
+                    "created_at": chunk.get("created_at") or chunk.get("timestamp"),
+                    "transcript": clipped,
+                }
+            )
+        if chunk_payload:
+            out.append(
+                {
+                    "conversation_id": conv.get("id"),
+                    "who": conv.get("label"),
+                    "chunks": chunk_payload,
+                }
+            )
+    return out
+
+
+async def _extract_living_canvas_update(
+    *,
+    gather_bundle: dict[str, Any],
+    current_state: dict[str, Any],
+) -> dict[str, Any]:
+    project = gather_bundle.get("project") or {}
+    user_payload = {
+        "project": {
+            "name": project.get("name"),
+            "language": project.get("language") or "en",
+            "context": project.get("context") or "",
+            "anonymize_transcripts": project.get("anonymize_transcripts"),
+        },
+        "current_ledgers": ledger_prompt_summary(current_state),
+        "new_transcript": _transcript_payload_for_model(gather_bundle),
+    }
+    response = await arouter_completion(
+        MODELS.MULTI_MODAL_FAST,
+        messages=[
+            {"role": "system", "content": MODEL_EXTRACTION_SYSTEM_PROMPT},
+            {"role": "user", "content": json.dumps(user_payload, ensure_ascii=False, indent=2)},
+        ],
+        temperature=0.1,
+        max_tokens=8000,
+    )
+    return _json_from_model_text(_choice_text(response))
 
 
 async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]:
@@ -352,10 +531,47 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
             await _enqueue_next_if_due(loop)
             return {"status": "no_op", "run": run}
 
+        living_state = fresh_canvas_state(loop)
+        if _gather_has_transcript(gather_bundle):
+            try:
+                extraction = await _extract_living_canvas_update(
+                    gather_bundle=gather_bundle,
+                    current_state=living_state,
+                )
+            except Exception as exc:
+                run = await _create_run(
+                    loop_id=loop_id,
+                    status="no_op",
+                    detail=f"Model extraction failed: {exc}",
+                    started_at=started_at,
+                )
+                await _enqueue_next_if_due(loop)
+                return {"status": "no_op", "run": run}
+            living_state, ledger_detail = apply_model_extraction(
+                living_state,
+                gather_bundle,
+                extraction,
+            )
+            await async_directus.update_item(
+                "agent_loop",
+                str(loop["id"]),
+                state_patch(living_state),
+            )
+        else:
+            ledger_detail = {
+                "quotes_added": 0,
+                "concepts_changed": 0,
+                "crux_changed": False,
+                "story_changed": False,
+                "concepts_removed": [],
+                "rejections": [],
+            }
+
         raw_html = await _generate_html(
             brief=str(config.get("brief") or ""),
             previous_html=(latest_ok or {}).get("content_html"),
             gather_bundle=gather_bundle,
+            living_state=living_state,
         )
         sanitized = sanitize_canvas_html(raw_html, max_bytes=get_settings().canvas.max_html_bytes)
         banned_copy = _banned_visible_copy(sanitized.html)
@@ -372,6 +588,7 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
                     "detail": _generation_detail(
                         stripped_references=sanitized.stripped_references,
                         banned_copy=banned_copy,
+                        ledger_detail=ledger_detail,
                     ),
                 },
             )

--- a/echo/server/tests/test_canvas_ledgers.py
+++ b/echo/server/tests/test_canvas_ledgers.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dembrane.canvas.ledgers import (
+    host_item,
+    state_patch,
+    append_host_item,
+    fresh_canvas_state,
+    render_tabbed_canvas,
+    apply_model_extraction,
+)
+
+
+def _bundle() -> dict:
+    return {
+        "project": {"name": "Room"},
+        "conversations": [
+            {
+                "id": "conv-1",
+                "label": "Maya",
+                "chunks": [
+                    {
+                        "id": "chunk-1",
+                        "transcript": "Keep the doorway open. This should remain easy to explain.",
+                        "created_at": "2026-07-08T10:00:00+00:00",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_apply_model_extraction_accepts_verbatim_receipts_and_updates_crux() -> None:
+    state = fresh_canvas_state()
+    extraction = {
+        "quotes": [
+            {
+                "who": "Maya",
+                "quote": "Keep the doorway open.",
+                "conversation_id": "conv-1",
+                "chunk_id": "chunk-1",
+            }
+        ],
+        "concepts": [{"phrase": "doorway open", "supporting_quote_indices": [0]}],
+        "crux": {"question": "What first move keeps the doorway open?"},
+        "story_slides": [
+            {
+                "eyebrow": "Signal",
+                "heading": "The doorway matters",
+                "lede": "People want the doorway open.",
+                "quote_indices": [0],
+            }
+        ],
+    }
+
+    state, detail = apply_model_extraction(state, _bundle(), extraction)
+    state, second_detail = apply_model_extraction(state, _bundle(), extraction)
+
+    assert detail["quotes_added"] == 1
+    assert second_detail["quotes_added"] == 0
+    assert state["quotes_ledger"][0]["quote"] == "Keep the doorway open."
+    assert state["concepts_ledger"][0]["phrase"] == "doorway open"
+    assert state["crux"]["question"] == "What first move keeps the doorway open?"
+    assert state["story_slides"][0]["quote_ids"] == [state["quotes_ledger"][0]["id"]]
+    assert state_patch(state)["canvas_tabs"] == ["crux", "concept_cloud", "story"]
+    assert state_patch(state)["canvas_story_slides"]
+
+
+def test_apply_model_extraction_rejects_fabricated_quote_and_homeless_concept() -> None:
+    state = fresh_canvas_state()
+    extraction = {
+        "quotes": [
+            {
+                "who": "Maya",
+                "quote": "This was never said.",
+                "conversation_id": "conv-1",
+                "chunk_id": "chunk-1",
+            }
+        ],
+        "concepts": [{"phrase": "never said", "supporting_quote_indices": [0]}],
+        "crux": None,
+        "story_slides": [],
+    }
+
+    state, detail = apply_model_extraction(state, _bundle(), extraction)
+
+    assert state["quotes_ledger"] == []
+    assert state["concepts_ledger"] == []
+    assert detail["quotes_added"] == 0
+    assert any("not found verbatim" in rejection for rejection in detail["rejections"])
+    assert any("no accepted supporting quote" in rejection for rejection in detail["rejections"])
+
+
+def test_crux_updates_in_place_and_keeps_history() -> None:
+    state = fresh_canvas_state(
+        {"canvas_crux": {"question": "What should we try first?", "history": []}}
+    )
+
+    state, detail = apply_model_extraction(
+        state,
+        _bundle(),
+        {
+            "quotes": [],
+            "concepts": [],
+            "crux": {"question": "What first move keeps the doorway open?"},
+            "story_slides": [],
+        },
+    )
+
+    assert detail["crux_changed"] is True
+    assert state["crux"]["question"] == "What first move keeps the doorway open?"
+    assert state["crux"]["history"] == [
+        {
+            "question": "What should we try first?",
+            "replaced_at": state["crux"]["updated_at"],
+        }
+    ]
+
+
+def test_concept_caps_and_three_xl_are_enforced_in_code() -> None:
+    state = fresh_canvas_state()
+    bundle = {
+        "conversations": [
+            {
+                "id": "conv-1",
+                "label": "Maya",
+                "latest_transcript": " ".join(f"phrase {i} matters." for i in range(24)),
+            }
+        ]
+    }
+    extraction = {
+        "quotes": [
+            {
+                "who": "Maya",
+                "quote": f"phrase {i} matters.",
+                "conversation_id": "conv-1",
+                "chunk_id": None,
+            }
+            for i in range(24)
+        ],
+        "concepts": [{"phrase": f"phrase {i}", "supporting_quote_indices": [i]} for i in range(24)],
+        "crux": None,
+        "story_slides": [],
+    }
+
+    state, _detail = apply_model_extraction(state, bundle, extraction)
+
+    assert sum(1 for concept in state["concepts_ledger"] if concept["size_tier"] == "xl") == 3
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+    assert html.count('class="tabbed-concept ') == 20
+
+
+def test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items() -> None:
+    state = fresh_canvas_state()
+    state, _detail = apply_model_extraction(
+        state,
+        _bundle(),
+        {
+            "quotes": [
+                {
+                    "who": "Maya",
+                    "quote": "Keep the doorway open.",
+                    "conversation_id": "conv-1",
+                    "chunk_id": "chunk-1",
+                }
+            ],
+            "concepts": [{"phrase": "doorway open", "supporting_quote_indices": [0]}],
+            "crux": {"question": "What first move keeps the doorway open?"},
+            "story_slides": [],
+        },
+    )
+    item = host_item(
+        text="Host says: hold this exact reflection.",
+        target_tab="story",
+        person="Host",
+        chat_id="chat-1",
+        message_id="msg-1",
+    )
+    state = append_host_item(state, item)
+
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert 'type="radio"' in html
+    assert 'for="canvas-tab-crux"' in html
+    assert "tabbed-traceable" in html
+    assert "Host says: hold this exact reflection." in html

--- a/echo/server/tests/test_canvas_sanitize.py
+++ b/echo/server/tests/test_canvas_sanitize.py
@@ -49,7 +49,7 @@ def test_sanitize_unwraps_full_documents_to_body_fragments() -> None:
 
 def test_sanitize_accepts_plain_fragments() -> None:
     result = sanitize_canvas_html('<div class="canvas-shell">ok</div>', max_bytes=2000)
-    assert result.html == '<div class="canvas-shell">ok</div>' 
+    assert result.html == '<div class="canvas-shell">ok</div>'
 
 
 def test_sanitize_strips_html_comments() -> None:
@@ -59,3 +59,29 @@ def test_sanitize_strips_html_comments() -> None:
     )
     assert "<!--" not in result.html
     assert "ok" in result.html
+
+
+def test_sanitize_preserves_css_only_tabs_and_trace_expansion() -> None:
+    result = sanitize_canvas_html(
+        """
+        <div class="canvas-shell tabbed-canvas">
+          <input class="tabbed-canvas-radio" type="radio" name="canvas-tab" id="canvas-tab-crux" checked>
+          <nav class="tabbed-canvas-tabbar">
+            <label for="canvas-tab-crux">Crux</label>
+          </nav>
+          <section data-tab-panel="crux">
+            <details class="tabbed-concept">
+              <summary><span class="tabbed-traceable">doorway open</span></summary>
+              <blockquote class="tabbed-quote">Keep the doorway open.</blockquote>
+            </details>
+          </section>
+        </div>
+        """,
+        max_bytes=4000,
+    )
+
+    assert 'type="radio"' in result.html
+    assert 'for="canvas-tab-crux"' in result.html
+    assert "<details" in result.html
+    assert "<summary>" in result.html
+    assert "tabbed-traceable" in result.html

--- a/echo/server/tests/test_canvas_ticks.py
+++ b/echo/server/tests/test_canvas_ticks.py
@@ -164,6 +164,138 @@ async def test_tick_error_stores_error_generation_and_pauses_after_three(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_tick_model_failure_noops_without_touching_loop_state(monkeypatch) -> None:
+    fake = _FakeDirectus()
+    fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"] = [
+        {"id": "q-old", "quote": "Keep this.", "source": {}}
+    ]
+
+    async def _config(report_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"id": "cfg1", "brief": "brief", "gather_spec": {}, "cadence_minutes": 5}
+
+    async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "latest_content_at": "2026-07-07T10:20:00+00:00",
+            "project": {},
+            "conversations": [
+                {
+                    "id": "conv-1",
+                    "label": "Maya",
+                    "latest_transcript": "Keep the doorway open.",
+                }
+            ],
+        }
+
+    async def _extract(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        raise RuntimeError("model unavailable")
+
+    async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(ticks, "async_directus", fake)
+    monkeypatch.setattr(ticks, "_latest_config", _config)
+    monkeypatch.setattr(ticks, "execute_gather_spec", _gather)
+    monkeypatch.setattr(ticks, "_extract_living_canvas_update", _extract)
+    monkeypatch.setattr(ticks, "_enqueue_next_if_due", _enqueue)
+
+    result = await ticks.run_tick("loop1", "scheduled")
+
+    assert result["status"] == "no_op"
+    assert fake.created["agent_loop_run"][0]["status"] == "no_op"
+    assert (
+        "Model extraction failed: model unavailable" in fake.created["agent_loop_run"][0]["detail"]
+    )
+    assert "canvas_generation" not in fake.created
+    assert fake.updated == []
+    assert fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"] == [
+        {"id": "q-old", "quote": "Keep this.", "source": {}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tick_uses_model_extraction_and_records_receipt_rejections(monkeypatch) -> None:
+    fake = _FakeDirectus()
+
+    async def _config(report_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"id": "cfg1", "brief": "brief", "gather_spec": {}, "cadence_minutes": 5}
+
+    async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "latest_content_at": "2026-07-07T10:20:00+00:00",
+            "project": {"name": "Room"},
+            "conversations": [
+                {
+                    "id": "conv-1",
+                    "label": "Maya",
+                    "chunks": [
+                        {
+                            "id": "chunk-1",
+                            "transcript": "Keep the doorway open.",
+                            "created_at": "2026-07-07T10:20:00+00:00",
+                        }
+                    ],
+                }
+            ],
+        }
+
+    async def _extract(**kwargs) -> dict[str, Any]:
+        assert kwargs["current_state"]["quotes_ledger"] == []
+        return {
+            "quotes": [
+                {
+                    "who": "Maya",
+                    "quote": "Keep the doorway open.",
+                    "conversation_id": "conv-1",
+                    "chunk_id": "chunk-1",
+                },
+                {
+                    "who": "Maya",
+                    "quote": "Invented receipt.",
+                    "conversation_id": "conv-1",
+                    "chunk_id": "chunk-1",
+                },
+            ],
+            "concepts": [
+                {"phrase": "doorway open", "supporting_quote_indices": [0]},
+                {"phrase": "invented", "supporting_quote_indices": [1]},
+            ],
+            "crux": {"question": "What first move keeps the doorway open?"},
+            "story_slides": [
+                {
+                    "eyebrow": "Signal",
+                    "heading": "Doorway",
+                    "lede": "People want the doorway open.",
+                    "quote_indices": [0, 1],
+                }
+            ],
+        }
+
+    async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
+        return None
+
+    async def _publish(report_id: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(ticks, "async_directus", fake)
+    monkeypatch.setattr(ticks, "_latest_config", _config)
+    monkeypatch.setattr(ticks, "execute_gather_spec", _gather)
+    monkeypatch.setattr(ticks, "_extract_living_canvas_update", _extract)
+    monkeypatch.setattr(ticks, "_enqueue_next_if_due", _enqueue)
+    monkeypatch.setattr(ticks, "publish_generation_nudge", _publish)
+
+    result = await ticks.run_tick("loop1", "scheduled")
+
+    assert result["status"] == "ok"
+    assert fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"][0]["quote"] == (
+        "Keep the doorway open."
+    )
+    generation = result["generation"]
+    assert "Keep the doorway open." in generation["content_html"]
+    assert "not found verbatim" in generation["detail"]
+    assert "no accepted supporting quote" in generation["detail"]
+
+
+@pytest.mark.asyncio
 async def test_tick_missing_ids_records_error_run_without_generation(monkeypatch) -> None:
     fake = _FakeDirectus()
     fake.items["agent_loop"]["loop1"]["report_id"] = None
@@ -239,7 +371,10 @@ async def test_tick_ok_records_banned_visible_copy_without_rewriting(monkeypatch
     generation = result["generation"]
     assert generation["status"] == "ok"
     assert "Real-time reflections" in generation["content_html"]
-    assert generation["detail"] == "banned visible copy: real-time, AI, successfully, em dash"
+    assert generation["detail"].startswith(
+        "banned visible copy: real-time, AI, successfully, em dash"
+    )
+    assert "ledger update:" in generation["detail"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implements the tab model from the 2026-07-08 owner conversations plus Oren's design handoff (distilled to `docs/plans/canvas-ux-handoff.md`).

- **Tabs with fixed shapes** (v1: Crux, Concept cloud, Story) rendered as one sanitized fragment; CSS-only tab bar + trace expansion survive the sanitizer (round-trip tested)
- **Additive ledgers** persisted on `agent_loop`: quotes, concepts, crux + history, host items, story slides — ticks append, nothing rebuilds, unchanged tabs render unchanged
- **Model proposes, code verifies**: one structured Flash extraction per content-bearing tick with the judgment checklists in the prompt; mechanical receipt validation (verbatim-substring grep test for quotes, concepts must live inside an accepted quote, no receipt = no underline); rejections recorded on the run, never silently swallowed
- **Caps in code**: exactly 3 XL / ~20 tiles, crux updated never appended; model failure = no_op with previous wall intact
- **`addToCanvas` / `removeFromCanvas`** agent verbs: host-made items stored exactly, routed to a tab, manual tick fires immediately ("put Cesare's reflection on the wall")
- Idempotent Directus migration for the ledger fields; existing loops default to the v1 tab set on next tick

Gates: server ruff + 36 canvas tests, agent 97 tests. Reports: `wave28-REPORT.md`, `wave28b-REPORT.md` (28b restored model-driven extraction after the first pass went fully deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)