### PR TITLE
The canvas speaks back: one pointed question at a real fork

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -22,6 +22,8 @@ logger = getLogger("agent")
 VERTEX_AUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 MAX_AMBIENT_MEMORY_ITEMS = 12
 MAX_AMBIENT_MEMORY_CHARS = 3000
+MAX_CANVAS_ACTIVITY_RUNS = 5
+MAX_CANVAS_ACTIVITY_DETAIL_CHARS = 220
 
 DashboardPageKey = Literal[
     "overview",
@@ -293,6 +295,19 @@ similar. Never tell the host the proposal is in their Library or dashboard: the
 Library holds live canvases, not proposals, and sending the host there to find
 a proposal is a dead end ("The update proposal is ready in your Library" is the
 named counterexample).
+Canvas activity may appear in a "Canvas activity since last turn" system block.
+Use it only as evidence that a linked canvas loop did something after your last
+reply. If that activity shows a genuine fork, you may ask AT MOST ONE pointed
+question in the same turn as the rest of your reply. A real fork means the host
+must choose a direction, for example: receipts were rejected ("I dropped two
+quotes I could not verify verbatim. Want me to relisten to that stretch of
+Cesare's conversation?"); a tab is starving ("nothing has earned XL in the cloud
+yet. Loosen the two-people rule, or wait?"); repeated no_ops while the host keeps
+asking for updates ("the loop has heard nothing new for 40 minutes. Is the
+recorder still on?"). Counterexamples: never ask permission to do something you
+can already do; never ask more than one question; never ask when there is no
+fork, silence is correct then. Ground any question in the injected run details
+only. Never invent canvas activity.
 
 ## Project setup
 When the first message signals setup, or when readGoal shows this project has no
@@ -391,6 +406,72 @@ def _format_memory_section(memories: list[Any]) -> str:
             break
 
     return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _truncate_canvas_activity_detail(detail: Any) -> str:
+    normalized = str(detail or "").strip()
+    if len(normalized) <= MAX_CANVAS_ACTIVITY_DETAIL_CHARS:
+        return normalized
+    return normalized[: MAX_CANVAS_ACTIVITY_DETAIL_CHARS - 3].rstrip() + "..."
+
+
+def _canvas_activity_runs_for_canvas(canvas: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_runs = canvas.get("recent_runs")
+    if not isinstance(raw_runs, list):
+        raw_runs = canvas.get("runs")
+    if isinstance(raw_runs, list):
+        return [run for run in raw_runs if isinstance(run, dict)]
+
+    loop = canvas.get("loop")
+    if not isinstance(loop, dict):
+        return []
+
+    status = loop.get("last_run_status")
+    detail = loop.get("last_run_detail")
+    if not status and not detail:
+        return []
+    return [
+        {
+            "status": status,
+            "detail": detail,
+            "started_at": loop.get("last_run_started_at"),
+        }
+    ]
+
+
+def _format_canvas_activity_section(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+
+    canvases = payload.get("canvases")
+    if not isinstance(canvases, list) or not canvases:
+        return ""
+
+    lines: list[str] = ["## Canvas activity since last turn"]
+    rendered_runs = 0
+    for canvas in canvases:
+        if not isinstance(canvas, dict):
+            continue
+        canvas_name = str(canvas.get("name") or canvas.get("id") or "Canvas").strip()
+        canvas_id = str(canvas.get("id") or "").strip()
+        canvas_label = canvas_name if not canvas_id else f"{canvas_name} ({canvas_id})"
+        runs = _canvas_activity_runs_for_canvas(canvas)
+        if not runs:
+            continue
+        lines.append(f"- {canvas_label}")
+        for run in runs:
+            status = str(run.get("status") or "unknown").strip() or "unknown"
+            detail = _truncate_canvas_activity_detail(run.get("detail"))
+            started_at = str(run.get("started_at") or "").strip()
+            prefix = f"  - {status}"
+            if started_at:
+                prefix = f"{prefix} at {started_at}"
+            lines.append(f"{prefix}: {detail}" if detail else prefix)
+            rendered_runs += 1
+            if rendered_runs >= MAX_CANVAS_ACTIVITY_RUNS:
+                return "\n".join(lines)
+
+    return "\n".join(lines) if rendered_runs else ""
 
 
 def _split_concatenated_json_objects(raw: str, expected_count: int) -> list[Any] | None:
@@ -1742,6 +1823,25 @@ def create_agent_graph(
 
         return ambient_memory_section
 
+    async def _load_canvas_activity_section() -> str:
+        if not chat_id:
+            return ""
+
+        client = _create_echo_client()
+        try:
+            payload = await client.list_chat_canvas_activity(
+                project_id=project_id,
+                chat_id=chat_id,
+                limit=MAX_CANVAS_ACTIVITY_RUNS,
+            )
+        except Exception:
+            logger.exception("Failed to load canvas activity for chat %s", chat_id)
+            return ""
+        finally:
+            await client.close()
+
+        return _format_canvas_activity_section(payload)
+
     def should_continue(state: dict) -> str:
         messages = state.get("messages", [])
         if not messages:
@@ -1767,9 +1867,11 @@ def create_agent_graph(
         raw_messages = state.get("messages", [])
         messages = [_with_placeholder_content(message) for message in raw_messages]
         memory_section = await _load_ambient_memory_section()
-        effective_system_prompt = (
-            f"{system_prompt}\n\n{memory_section}" if memory_section else system_prompt
-        )
+        canvas_activity_section = await _load_canvas_activity_section()
+        system_sections = [
+            section for section in [system_prompt, memory_section, canvas_activity_section] if section
+        ]
+        effective_system_prompt = "\n\n".join(system_sections)
         # Build invocation list with system prompt, but don't persist duplicates
         if not messages or not isinstance(messages[0], SystemMessage):
             invocation_messages = [SystemMessage(content=effective_system_prompt)] + messages

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -178,6 +178,20 @@ class EchoClient:
         payload = await self.get(f"/agentic/projects/{project_id}/canvases")
         return payload if isinstance(payload, list) else []
 
+    async def list_chat_canvas_activity(
+        self,
+        project_id: str,
+        chat_id: str,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        response = await self._client.get(
+            f"/agentic/projects/{project_id}/chats/{chat_id}/canvas-activity",
+            params={"limit": limit},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
     async def get_canvas(self, project_id: str, canvas_id: str) -> dict[str, Any]:
         payload = await self.get(f"/agentic/projects/{project_id}/canvases/{canvas_id}")
         return payload if isinstance(payload, dict) else {}

--- a/echo/agent/tests/test_agent_graph.py
+++ b/echo/agent/tests/test_agent_graph.py
@@ -6,6 +6,7 @@ from agent import (
     POST_NUDGE_CONTINUATION_SYSTEM_PROMPT,
     SYSTEM_PROMPT,
     _build_llm,
+    _format_canvas_activity_section,
     _normalize_fused_tool_calls,
     create_agent_graph,
 )
@@ -58,6 +59,35 @@ class MemoryClientFactory:
 
     def __call__(self, _bearer_token: str) -> MemoryClient:
         client = MemoryClient(self.payload)
+        self.instances.append(client)
+        return client
+
+
+class CanvasActivityClient(MemoryClient):
+    def __init__(self, payload: dict | None = None) -> None:
+        super().__init__({"memories": []})
+        self.canvas_activity_payload = payload or {"canvases": []}
+        self.canvas_activity_calls: list[dict[str, object]] = []
+
+    async def list_chat_canvas_activity(
+        self,
+        project_id: str,
+        chat_id: str,
+        limit: int = 5,
+    ) -> dict:
+        self.canvas_activity_calls.append(
+            {"project_id": project_id, "chat_id": chat_id, "limit": limit}
+        )
+        return self.canvas_activity_payload
+
+
+class CanvasActivityClientFactory:
+    def __init__(self, payload: dict | None = None) -> None:
+        self.payload = payload or {"canvases": []}
+        self.instances: list[CanvasActivityClient] = []
+
+    def __call__(self, _bearer_token: str) -> CanvasActivityClient:
+        client = CanvasActivityClient(self.payload)
         self.instances.append(client)
         return client
 
@@ -368,11 +398,103 @@ async def test_ambient_memory_is_injected_into_first_model_invocation():
     assert factory.instances[0].closed is True
 
 
+@pytest.mark.asyncio
+async def test_canvas_activity_is_injected_into_first_model_invocation():
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    factory = CanvasActivityClientFactory(
+        {
+            "canvases": [
+                {
+                    "id": "canvas-1",
+                    "name": "Pulse wall",
+                    "recent_runs": [
+                        {
+                            "status": "ok",
+                            "detail": "rejections: quote[3] not found verbatim",
+                            "started_at": "2026-07-08T10:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+        chat_id="chat-1",
+    )
+
+    await graph.ainvoke(
+        {"messages": [HumanMessage(content="hello")]},
+        config={"configurable": {"thread_id": "thread-canvas-activity"}},
+    )
+
+    first_system = next(
+        message for message in llm.invocations[0] if isinstance(message, SystemMessage)
+    )
+    assert "## Canvas activity since last turn" in first_system.content
+    assert "Pulse wall (canvas-1)" in first_system.content
+    assert "rejections: quote[3] not found verbatim" in first_system.content
+    assert factory.instances[1].canvas_activity_calls == [
+        {"project_id": "project-1", "chat_id": "chat-1", "limit": 5}
+    ]
+    assert factory.instances[1].closed is True
+
+
 def test_system_prompt_forbids_claiming_actions_without_successful_tool_result():
     prompt = SYSTEM_PROMPT.lower()
     assert "only say you saved, logged, proposed, updated" in prompt
     assert "corresponding action returned success in this turn" in prompt
     assert "akshita" in prompt
+
+
+def test_system_prompt_contains_canvas_one_question_rule_and_counterexamples():
+    prompt = " ".join(SYSTEM_PROMPT.lower().split())
+    assert "canvas activity since last turn" in prompt
+    assert "at most one pointed" in prompt
+    assert "question in the same turn" in prompt
+    assert "real fork" in prompt
+    assert "never ask permission to do something you can already do" in prompt
+    assert "never ask more than one question" in prompt
+    assert "never ask when there is no fork" in prompt
+    assert "never invent canvas activity" in prompt
+
+
+def test_canvas_activity_section_renders_run_details_and_truncates_detail():
+    section = _format_canvas_activity_section(
+        {
+            "canvases": [
+                {
+                    "id": "canvas-1",
+                    "name": "Pulse wall",
+                    "recent_runs": [
+                        {
+                            "status": "ok",
+                            "detail": "rejections: quote[3] not found verbatim",
+                            "started_at": "2026-07-08T10:00:00Z",
+                        },
+                        {
+                            "status": "no_op",
+                            "detail": "0 quote(s), 0 concept change(s)",
+                            "started_at": "2026-07-08T10:05:00Z",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    assert "## Canvas activity since last turn" in section
+    assert "Pulse wall (canvas-1)" in section
+    assert "ok at 2026-07-08T10:00:00Z: rejections: quote[3] not found verbatim" in section
+    assert "no_op at 2026-07-08T10:05:00Z: 0 quote(s), 0 concept change(s)" in section
+
+
+def test_canvas_activity_section_returns_empty_without_canvas_runs():
+    assert _format_canvas_activity_section({"canvases": []}) == ""
+    assert _format_canvas_activity_section({"canvases": [{"id": "canvas-1"}]}) == ""
 
 
 def test_fused_parallel_tool_call_name_is_split_with_concatenated_json_args():

--- a/echo/agent/tests/test_echo_client.py
+++ b/echo/agent/tests/test_echo_client.py
@@ -156,6 +156,28 @@ class _FakeAsyncClient:
                     }
                 ],
             )
+        if path == "/agentic/projects/project-1/chats/chat-1/canvas-activity":
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                json={
+                    "project_id": "project-1",
+                    "chat_id": "chat-1",
+                    "canvases": [
+                        {
+                            "id": "canvas-1",
+                            "name": "Pulse wall",
+                            "recent_runs": [
+                                {
+                                    "status": "ok",
+                                    "detail": "backfill: 5 conversations",
+                                    "started_at": "2026-07-08T10:00:00Z",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
         if path.startswith("/conversations/") and path.endswith("/transcript"):
             return httpx.Response(status_code=200, request=request, json="transcript text")
         return httpx.Response(status_code=200, request=request, json={"ok": True})
@@ -256,6 +278,22 @@ async def test_list_canvases_uses_expected_path(monkeypatch):
 
     assert payload[0]["id"] == "canvas-1"
     assert client._client.calls[0]["path"] == "/agentic/projects/project-1/canvases"
+
+
+@pytest.mark.asyncio
+async def test_list_chat_canvas_activity_uses_expected_path_and_limit(monkeypatch):
+    monkeypatch.setattr("echo_client.httpx.AsyncClient", _FakeAsyncClient)
+
+    client = EchoClient(bearer_token="token-1")
+    payload = await client.list_chat_canvas_activity("project-1", "chat-1", limit=5)
+
+    assert payload["chat_id"] == "chat-1"
+    assert payload["canvases"][0]["recent_runs"][0]["detail"] == "backfill: 5 conversations"
+    assert (
+        client._client.calls[0]["path"]
+        == "/agentic/projects/project-1/chats/chat-1/canvas-activity"
+    )
+    assert client._client.calls[0]["params"] == {"limit": 5}
 
 
 @pytest.mark.asyncio

--- a/echo/docs/plans/smart-loop-briefs/wave30-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave30-REPORT.md
@@ -1,0 +1,28 @@
+# Wave 30 Canvas Speaks Back Report
+
+## Summary
+
+- Added a compact canvas activity context path for agent runs. When a chat has linked canvas activity, the agent fetches recent canvas run details and injects a `## Canvas activity since last turn` system block.
+- Added prompt rules that allow at most one pointed question only at a real fork, with the requested examples and counterexamples. The rule explicitly forbids invented canvas activity and questions when there is no fork.
+- Added an Echo client fetch for chat canvas activity and tests for the client path, context rendering, no-canvas silence, prompt rule coverage, and graph-level system prompt injection.
+
+## Files Changed
+
+- `echo/agent/agent.py`
+- `echo/agent/echo_client.py`
+- `echo/agent/tests/test_agent_graph.py`
+- `echo/agent/tests/test_echo_client.py`
+
+## QA Gates
+
+- `cd echo/agent && uv run pytest -q`: passed, `102 passed, 4 warnings`.
+- Focused checks also passed for:
+  - `tests/test_agent_graph.py::test_canvas_activity_section_renders_run_details_and_truncates_detail`
+  - `tests/test_agent_graph.py::test_canvas_activity_is_injected_into_first_model_invocation`
+  - `tests/test_echo_client.py::test_list_chat_canvas_activity_uses_expected_path_and_limit`
+
+## Notes
+
+- Server and frontend were left untouched per the brief.
+- `uv run ruff ...` was attempted for local formatting/checking, but `ruff` is not an `echo/agent` dependency, so the required pytest gate is the authoritative QA result.
+- The activity block is omitted on empty or failed activity fetches. That keeps silence as the default when there is no real linked canvas signal.

--- a/echo/docs/plans/smart-loop-briefs/wave30-canvas-speaks-back.md
+++ b/echo/docs/plans/smart-loop-briefs/wave30-canvas-speaks-back.md
@@ -1,0 +1,52 @@
+# Brief: Wave 30 — the canvas speaks back
+
+Start: `git fetch origin && git checkout -b sameer/canvas-speaks-back
+origin/main` (main now includes the tabbed canvas, #830). No other git
+write commands.
+
+## The gap (owner's words, 2026-07-08)
+
+"I did not find it speaking to me. I constantly found myself saying: hey,
+I'm not seeing this. It never once asked what I really want." The host
+always had to tell the canvas what was missing; the agent never asked.
+
+## What to build
+
+When the host is in a chat and a canvas tick has produced signal since the
+last agent turn, the agent may ask AT MOST ONE pointed question — and only
+at a REAL fork. Not a survey, not "anything else?", not a menu.
+
+1. **Context injection** (echo/agent/agent.py + echo_client.py): for the
+   chat's linked canvas(es), fetch the most recent agent_loop_run rows
+   (status + detail — details now carry ledger deltas and receipt
+   rejections, e.g. "rejections: quote[3] not found verbatim", "backfill:
+   5 conversations", "0 quote(s), 0 concept change(s)") and inject a
+   compact "## Canvas activity since last turn" block into the system
+   context for the run. Keep it small: last ~5 runs, detail strings
+   truncated.
+
+2. **Prompt rule**: if the activity shows a genuine fork, ask ONE pointed
+   question in the same turn as the rest of the reply. Real forks, with
+   examples:
+   - receipts were rejected ("I dropped two quotes I could not verify
+     verbatim — want me to relisten to that stretch of Cesare's
+     conversation?")
+   - a tab is starving ("nothing has earned XL in the cloud yet — loosen
+     the two-people rule, or wait?")
+   - repeated no_ops while the host keeps asking for updates ("the loop
+     has heard nothing new for 40 minutes — is the recorder still on?")
+   Named counterexamples (put these in the prompt): never ask permission
+   to do something you can already do; never ask more than one question;
+   never ask when there is no fork — silence is correct then.
+
+3. **Honesty**: the question must be grounded in the injected run details
+   only — never invent activity (no-phantom-actions rule applies).
+
+## QA gates
+
+- cd echo/agent && uv run pytest -q; add tests: prompt contains the
+  one-question rule + counterexamples; context builder renders run
+  details; no canvas -> no activity block.
+- If echo_client changes: client tests for the new fetch.
+- Server untouched (the run details already exist). Frontend untouched.
+- Report -> echo/docs/plans/smart-loop-briefs/wave30-REPORT.md.

--- a/echo/docs/plans/smart-loop-briefs/wave30b-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave30b-REPORT.md
@@ -1,0 +1,30 @@
+# Wave 30b Canvas Activity Endpoint Report
+
+## Summary
+
+- Added `GET /agentic/projects/{project_id}/chats/{chat_id}/canvas-activity` on the server, mounted through the existing `/api/agentic` router prefix.
+- The route requires the agent bearer token, checks project access, verifies the chat belongs to the requested project, and hides private chats owned by someone else.
+- The response is `{"canvases": [...]}` from the project's `agent_loop` rows, with best-effort report names and latest per-loop `agent_loop_run` records limited to `status`, `detail`, and `started_at`.
+- Empty or missing loop/report/run data returns an empty canvas/run shape instead of a 500.
+
+## Files Changed
+
+- `echo/server/dembrane/api/agentic.py`
+- `echo/server/tests/api/test_agentic_api.py`
+- `echo/docs/plans/smart-loop-briefs/wave30b-REPORT.md`
+
+## End-to-End Path Sanity
+
+- Client call in `echo/agent/echo_client.py`: `/agentic/projects/{project_id}/chats/{chat_id}/canvas-activity`
+- Server route after the app's `/api` prefix: `/agentic/projects/{project_id}/chats/{chat_id}/canvas-activity`
+- These strings are identical after the existing client/server `/api` base split.
+
+## QA Gates
+
+- `cd echo/server && DIRECTUS_SECRET=t DIRECTUS_TOKEN=t DATABASE_URL=postgresql+psycopg://u:p@localhost:5432/db REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=t STORAGE_S3_ENDPOINT=http://localhost STORAGE_S3_KEY=t STORAGE_S3_SECRET=t uv run ruff check .`: passed.
+- `cd echo/server && DIRECTUS_SECRET=t DIRECTUS_TOKEN=t DATABASE_URL=postgresql+psycopg://u:p@localhost:5432/db REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=t STORAGE_S3_ENDPOINT=http://localhost STORAGE_S3_KEY=t STORAGE_S3_SECRET=t uv run pytest -q tests/api/test_agentic_api.py`: passed, `34 passed, 2 warnings`.
+- `cd echo/agent && uv run pytest -q`: passed, `102 passed, 4 warnings`.
+
+## Notes
+
+- The first server pytest attempt without environment placeholders failed during settings import because `DIRECTUS_SECRET`, `DIRECTUS_TOKEN`, and then `DATABASE_URL` were unset. The reruns used dummy values because the focused tests mock external Directus/service paths.

--- a/echo/docs/plans/smart-loop-briefs/wave30b-activity-endpoint.md
+++ b/echo/docs/plans/smart-loop-briefs/wave30b-activity-endpoint.md
@@ -1,0 +1,37 @@
+# Brief: Wave 30b — the canvas-activity endpoint actually has to exist
+
+Continue on branch sameer/canvas-speaks-back. No git write commands.
+
+Wave 30's brief was wrong to claim the server needed no changes: the client
+now calls `GET /agentic/projects/{project_id}/chats/{chat_id}/canvas-activity`
+but no such route exists, and the agent's silent fallback means the feature
+would simply never fire. Add the endpoint.
+
+## What to build (echo/server/dembrane/api/agentic.py)
+
+`GET /agentic/projects/{project_id}/chats/{chat_id}/canvas-activity?limit=N`
+(same auth pattern as the other agentic chat routes; verify the chat
+belongs to the project as its siblings do). Response shape the wave-30
+client/formatter already expects:
+
+```json
+{"canvases": [{"id": "...", "name": "...", "recent_runs": [
+  {"status": "ok|no_op|error", "detail": "...", "started_at": "..."}]}]}
+```
+
+- canvases: the project's agent_loop rows (report_id + report name where
+  cheap; loop id is fine as id if reports are awkward — keep it consistent
+  with what the formatter labels).
+- recent_runs: latest N (default 5, cap 10) agent_loop_run rows per loop,
+  newest first, fields status/detail/started_at only.
+- No loops -> {"canvases": []}. Never 500 on missing data.
+
+## QA gates
+
+- Server test for the route (exists, auth, shape, empty case) +
+  `cd echo/server && uv run ruff check .` + focused pytest including the
+  existing agentic API tests.
+- cd echo/agent && uv run pytest -q (unchanged, should stay green).
+- End-to-end sanity in the report: show the client path and the route path
+  are string-identical.
+- Report -> echo/docs/plans/smart-loop-briefs/wave30b-REPORT.md.

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -1339,6 +1339,31 @@ async def _get_project_canvas_or_404(project_id: str, canvas_id: str) -> dict[st
     return report
 
 
+async def _get_project_chat_or_404(
+    project_id: str,
+    chat_id: str,
+    auth: DirectusSession,
+) -> dict[str, Any]:
+    try:
+        chat = await async_directus.get_item("project_chat", chat_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Chat %s not found while reading canvas activity: %s", chat_id, exc)
+        raise HTTPException(status_code=404, detail="Chat not found") from exc
+    if (
+        not isinstance(chat, dict)
+        or _to_related_id(chat.get("project_id")) != project_id
+        or chat.get("deleted_at") is not None
+    ):
+        raise HTTPException(status_code=404, detail="Chat not found")
+    if (
+        not auth.is_admin
+        and bool(chat.get("is_private"))
+        and chat.get("user_created") != auth.user_id
+    ):
+        raise HTTPException(status_code=404, detail="Chat not found")
+    return chat
+
+
 @AgenticRouter.get("/projects/{project_id}/canvases")
 async def list_project_canvases(
     project_id: str,
@@ -1347,6 +1372,120 @@ async def list_project_canvases(
     _require_agent_token(auth)
     await _assert_project_access(project_id, auth)
     return await list_canvas_summaries(project_id)
+
+
+async def _project_report_names_by_id(report_ids: list[str]) -> dict[str, str]:
+    if not report_ids:
+        return {}
+    try:
+        rows = await async_directus.get_items(
+            "project_report",
+            {
+                "query": {
+                    "filter": {"id": {"_in": report_ids}},
+                    "fields": ["id", "user_instructions", "name"],
+                    "limit": -1,
+                }
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load canvas report names for agent activity: %s", exc)
+        return {}
+
+    names: dict[str, str] = {}
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        report_id = _to_non_empty_string(row.get("id"))
+        name = _to_non_empty_string(row.get("user_instructions")) or _to_non_empty_string(
+            row.get("name")
+        )
+        if report_id and name:
+            names[report_id] = name
+    return names
+
+
+async def _recent_loop_runs(loop_id: str, limit: int) -> list[dict[str, Any]]:
+    try:
+        rows = await async_directus.get_items(
+            "agent_loop_run",
+            {
+                "query": {
+                    "filter": {"loop_id": {"_eq": loop_id}},
+                    "fields": ["status", "detail", "started_at"],
+                    "sort": ["-started_at"],
+                    "limit": limit,
+                }
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load canvas activity for loop %s: %s", loop_id, exc)
+        return []
+
+    return [
+        {
+            "status": row.get("status"),
+            "detail": row.get("detail"),
+            "started_at": row.get("started_at"),
+        }
+        for row in (rows if isinstance(rows, list) else [])
+        if isinstance(row, dict)
+    ]
+
+
+@AgenticRouter.get("/projects/{project_id}/chats/{chat_id}/canvas-activity")
+async def list_chat_canvas_activity(
+    project_id: str,
+    chat_id: str,
+    auth: DependencyDirectusSession,
+    limit: int = Query(default=5, ge=1),
+) -> dict[str, Any]:
+    _require_agent_token(auth)
+    await _assert_project_access(project_id, auth)
+    await _get_project_chat_or_404(project_id, chat_id, auth)
+
+    run_limit = min(limit, 10)
+    try:
+        loops = await async_directus.get_items(
+            "agent_loop",
+            {
+                "query": {
+                    "filter": {"project_id": {"_eq": project_id}},
+                    "fields": ["id", "project_id", "report_id", "name"],
+                    "limit": -1,
+                }
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load canvas loops for project %s: %s", project_id, exc)
+        return {"canvases": []}
+
+    loop_rows = [row for row in (loops if isinstance(loops, list) else []) if isinstance(row, dict)]
+    report_ids = [
+        report_id
+        for report_id in (_to_related_id(row.get("report_id")) for row in loop_rows)
+        if report_id is not None
+    ]
+    report_names = await _project_report_names_by_id(report_ids)
+
+    canvases: list[dict[str, Any]] = []
+    for loop in loop_rows:
+        loop_id = _to_non_empty_string(loop.get("id"))
+        if loop_id is None:
+            continue
+        report_id = _to_related_id(loop.get("report_id"))
+        canvas_id = report_id or loop_id
+        canvases.append(
+            {
+                "id": canvas_id,
+                "name": _to_non_empty_string(loop.get("name"))
+                or (report_names.get(report_id) if report_id else None)
+                or "Canvas",
+                "recent_runs": await _recent_loop_runs(loop_id, run_limit),
+            }
+        )
+
+    return {"canvases": canvases}
 
 
 @AgenticRouter.get("/projects/{project_id}/canvases/{canvas_id}")

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -1032,6 +1032,147 @@ async def test_agentic_list_canvases_requires_host_token_and_project_access(monk
 
 
 @pytest.mark.asyncio
+async def test_agentic_canvas_activity_returns_recent_loop_runs_and_caps_limit(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+    session = _make_session(user_id="user-1")
+
+    class _AsyncDirectus:
+        def __init__(self) -> None:
+            self.run_limits: list[int] = []
+
+        async def get_item(self, collection: str, item_id: str) -> dict[str, Any]:
+            assert collection == "project_chat"
+            assert item_id == "chat-1"
+            return {"id": "chat-1", "project_id": {"id": "project-1"}, "user_created": "user-1"}
+
+        async def get_items(self, collection: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+            query = params["query"]
+            if collection == "agent_loop":
+                assert query["filter"] == {"project_id": {"_eq": "project-1"}}
+                return [
+                    {"id": "loop-1", "report_id": "canvas-1", "name": None},
+                    {"id": "loop-2", "report_id": None, "name": "Loose loop"},
+                ]
+            if collection == "project_report":
+                assert query["filter"] == {"id": {"_in": ["canvas-1"]}}
+                return [{"id": "canvas-1", "user_instructions": "Pulse wall"}]
+            if collection == "agent_loop_run":
+                self.run_limits.append(query["limit"])
+                assert query["sort"] == ["-started_at"]
+                loop_id = query["filter"]["loop_id"]["_eq"]
+                if loop_id == "loop-1":
+                    return [
+                        {
+                            "status": "ok",
+                            "detail": "backfill: 5 conversations",
+                            "started_at": "2026-07-09T12:00:00Z",
+                            "ignored": "field",
+                        },
+                        {
+                            "status": "no_op",
+                            "detail": "No fresh quotes",
+                            "started_at": "2026-07-09T11:55:00Z",
+                        },
+                    ]
+                return []
+            raise AssertionError(f"unexpected collection {collection}")
+
+    fake_directus = _AsyncDirectus()
+    monkeypatch.setattr(agentic_api, "async_directus", fake_directus)
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=session,
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+    ) as client:
+        response = await client.get(
+            "/api/agentic/projects/project-1/chats/chat-1/canvas-activity?limit=999"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "canvases": [
+            {
+                "id": "canvas-1",
+                "name": "Pulse wall",
+                "recent_runs": [
+                    {
+                        "status": "ok",
+                        "detail": "backfill: 5 conversations",
+                        "started_at": "2026-07-09T12:00:00Z",
+                    },
+                    {
+                        "status": "no_op",
+                        "detail": "No fresh quotes",
+                        "started_at": "2026-07-09T11:55:00Z",
+                    },
+                ],
+            },
+            {"id": "loop-2", "name": "Loose loop", "recent_runs": []},
+        ]
+    }
+    assert fake_directus.run_limits == [10, 10]
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=_make_session(user_id="user-1", access_token=None),
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+    ) as client:
+        response = await client.get("/api/agentic/projects/project-1/chats/chat-1/canvas-activity")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_agentic_canvas_activity_requires_chat_in_project(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+
+    class _AsyncDirectus:
+        async def get_item(self, collection: str, item_id: str) -> dict[str, Any]:  # noqa: ARG002
+            return {"id": "chat-1", "project_id": "other-project", "user_created": "user-1"}
+
+    monkeypatch.setattr(agentic_api, "async_directus", _AsyncDirectus())
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=_make_session(user_id="user-1"),
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+    ) as client:
+        response = await client.get("/api/agentic/projects/project-1/chats/chat-1/canvas-activity")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_agentic_canvas_activity_returns_empty_when_project_has_no_loops(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+
+    class _AsyncDirectus:
+        async def get_item(self, collection: str, item_id: str) -> dict[str, Any]:  # noqa: ARG002
+            return {"id": "chat-1", "project_id": "project-1", "user_created": "user-1"}
+
+        async def get_items(self, collection: str, params: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: ARG002
+            assert collection == "agent_loop"
+            return []
+
+    monkeypatch.setattr(agentic_api, "async_directus", _AsyncDirectus())
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=_make_session(user_id="user-1"),
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+    ) as client:
+        response = await client.get("/api/agentic/projects/project-1/chats/chat-1/canvas-activity")
+
+    assert response.status_code == 200
+    assert response.json() == {"canvases": []}
+
+
+@pytest.mark.asyncio
 async def test_agentic_canvas_lifecycle_delegates_to_shared_service(monkeypatch) -> None:
     run_service = AgenticRunService(directus_client=InMemoryDirectus())
     session = _make_session(user_id="user-1")


### PR DESCRIPTION
The owner's named gap from the live retro: *"I did not find it speaking to me... It never once asked what I really want."*

- New `GET /agentic/projects/{project_id}/chats/{chat_id}/canvas-activity` endpoint: project's loops + latest runs (status/detail/started_at), auth-checked, never 500s on missing data
- Agent injects a compact **Canvas activity since last turn** block from those run details (which now carry ledger deltas and receipt rejections)
- Prompt rule: **at most one pointed question, only at a real fork** — rejected receipts ("I dropped two quotes I could not verify verbatim — relisten?"), a starving tab ("nothing has earned XL yet — loosen the rule or wait?"), repeated no_ops ("the loop has heard nothing for 40 minutes — recorder still on?"). Counterexamples pinned: never ask permission, never more than one question, silence when there is no fork
- Honesty: questions grounded only in injected details; inventing activity is forbidden (no-phantom-actions)

Gates: server ruff + 34 agentic API tests, agent 102 tests. Reports: `wave30-REPORT.md`, `wave30b-REPORT.md` (30b added the server endpoint the wave-30 client needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)