### PR TITLE
Canvas lens in extraction, Host guide tab, honest windowed backfill

### DIFF
--- a/echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py
+++ b/echo/directus/migrations/add_smart_loop_wave28_canvas_ledgers.py
@@ -41,6 +41,7 @@ def ensure_wave28_schema(dx: Directus) -> None:
             "canvas_crux",
             "canvas_host_items",
             "canvas_story_slides",
+            "canvas_host_guide",
         ),
         start=30,
     ):

--- a/echo/docs/plans/smart-loop-briefs/wave28d-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28d-REPORT.md
@@ -1,0 +1,76 @@
+# Wave 28d Report: Lens, Host Guide, Honest Backfill
+
+## Summary
+
+Implemented Wave 28d for the living canvas loop:
+
+- Connected the canvas report name and current brief to extraction prompts, including the explicit purpose/lens instruction and acceptance of zero quotes for off-topic conversations.
+- Added `Host guide` as the fourth fixed v1 tab after Story, persisted as `agent_loop.canvas_host_guide`, rendered from server ledger HTML, and replaced on each tick.
+- Made cold-start backfill honest and resilient by splitting long conversations into about 20k-character extraction windows and recording per-conversation/window outcomes in generation and run detail.
+
+## Changes
+
+### Lens in extraction
+
+- `_extract_living_canvas_update` now receives `report_name` and `brief`.
+- Extraction payload includes:
+  - report name,
+  - current brief,
+  - the exact purpose instruction that unrelated conversations may correctly return zero quotes,
+  - the guardrail against pre-populating static snippets from the brief.
+- Canvas preview now passes the same lens context.
+
+### Host guide tab
+
+- `CANVAS_TAB_SET_V1` is now fixed as:
+  - `crux`
+  - `concept_cloud`
+  - `story`
+  - `host_guide`
+- Added `canvas_host_guide` to fresh state, state patches, service reads, and the Wave 28 migration script.
+- Added a host-guide model prompt grounded only in:
+  - brief,
+  - current ledger summary,
+  - quote attribution counts,
+  - recent run activity.
+- Host guide shape:
+  - `where_the_room_is`
+  - `what_to_ask_next`
+  - `under_heard`
+  - `updated_at`
+- Rendering omits the under-heard block when no under-heard entries are present.
+
+### Honest backfill
+
+- Cold-start backfill now processes each conversation independently.
+- Long conversations are windowed into bounded extraction calls using `CANVAS_TRANSCRIPT_WINDOW_CHARS = 20_000`.
+- Model extraction errors are recorded per conversation/window and do not abort remaining conversations.
+- Generation/run detail now includes examples like:
+  - `backfill: 2 conversations`
+  - `backfill conv conv-1: 1 accepted / 0 rejected`
+  - `backfill conv conv-lon window 1: 1 accepted / 0 rejected`
+  - `backfill conv conv-fai: model error: context length`
+- The Wave 28c missing-marker gap was that `backfill: N conversations` was only assembled after a successful all-or-nothing extraction merge; an extraction exception exited before ledger detail existed.
+
+## Tests
+
+Passed with local dummy env values from `server/.env.sample`:
+
+```bash
+cd echo/server
+uv run ruff check .
+```
+
+Result: `All checks passed!`
+
+```bash
+cd echo/server
+uv run pytest -q tests/test_canvas_*.py tests/api/test_bff_canvases.py
+```
+
+Result: `46 passed, 2 warnings`.
+
+## Notes
+
+- `echo/agent` was not touched, so the agent pytest gate was not run.
+- Directus snapshot JSON was not hand-edited. The idempotent Wave 28 migration script now ensures `canvas_host_guide`.

--- a/echo/docs/plans/smart-loop-briefs/wave28d-lens-hostguide.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28d-lens-hostguide.md
@@ -1,0 +1,71 @@
+# Brief: Wave 28d — the lens, the host guide, and honest backfill
+
+Start: `git fetch origin && git checkout -b sameer/canvas-lens origin/main`
+(main includes #831). No other git write commands.
+
+## Live evidence (echo-next, report 12 "13th Week Retrospective Wall")
+
+Owner created a canvas with brief "13th Week Retrospective Wall" over a
+project holding 5 conversations (a 92k-char team retrospective + two
+product-design talks + two short ones). The generated wall (generation
+609701ad) is entirely about the product-design talks: crux "How should we
+design the user-friendly interface for resolving zero-sum merge
+conflicts...", concepts "playbook", "merge conflict", "mainline of code".
+Ledger state: 5 quotes total, ALL from one conversation (e7c27eb8, the
+lunch design talk); the retrospective itself contributed ZERO quotes,
+silently. Owner's verdict: "it should have been clear that it is about the
+13th week rather than building the canvas. Also I don't see the host
+guide."
+
+Three defects:
+
+## 1. The extraction never sees the brief (the lens is disconnected)
+
+The loop brief (canvas_config_revision.brief — shape + lens, the host's
+instructions) must be part of the extraction call. Add to the extraction
+system/user prompt: the report name and the current brief, with the
+instruction: "This wall exists for the purpose described in the brief.
+Extract ONLY material that serves it. Conversations unrelated to this
+purpose may legitimately yield zero quotes — returning nothing for them is
+correct, not a failure. At most one small tile of off-topic room flavor is
+allowed." Also honor the brief's guardrails (e.g. this brief forbids
+pre-populating static transcript snippets into structure).
+
+## 2. Host guide is a missing v1 tab
+
+The owners' chosen starter trio (2026-07-08 talk) was Crux, Concept cloud,
+Host guide; add Host guide as the fourth fixed tab (order: Crux, Concept
+cloud, Story, Host guide). Shape (fixed, per the handoff design language):
+a short model-written section grounded ONLY in the brief + current ledgers
++ recent run activity:
+- "where the room is" (2-3 sentences, no invented facts),
+- "what to ask next" (2-3 concrete questions the host can say out loud),
+- "under-heard" (voices/threads with few or no receipts yet, from ledger
+  attribution — omit the block entirely rather than guess).
+Persist it like the other per-tab state (e.g. canvas_host_guide JSON on
+the loop; extend the wave28 migration script idempotently). It updates on
+ticks like the crux (replace, not append).
+
+## 3. Backfill is silently partial
+
+The retro conversation produced zero quotes with no trace of why. Fix:
+- per-conversation extraction outcomes recorded in run/generation detail:
+  "backfill conv <shortid>: N accepted / M rejected" or "model error:
+  <reason>" — a failed conversation must be visible, never skipped
+  silently (also verify why the live detail carries no "backfill: N
+  conversations" marker even though 28c added it — find and fix the gap).
+- long transcripts must be windowed: split a conversation's transcript
+  into ~20k-char windows, one extraction call each, so a 92k-char retro
+  actually fits the model call instead of failing or truncating.
+- a model error on one conversation/window must not abort the others.
+
+## QA gates
+
+- Tests: brief text lands in the extraction prompt; off-topic-yields-zero
+  is accepted behavior (no retry storm); host guide renders in the tab bar
+  + persists + replaces; long-transcript windowing produces multiple
+  extraction calls; per-conversation failure recorded and non-fatal.
+- cd echo/server && uv run ruff check . ; focused canvas pytest suite.
+- cd echo/agent && uv run pytest -q if agent touched (should not be).
+- Migration change stays idempotent.
+- Report -> echo/docs/plans/smart-loop-briefs/wave28d-REPORT.md.

--- a/echo/docs/plans/smart-loop-briefs/wave28e-board-primitive.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28e-board-primitive.md
@@ -1,0 +1,68 @@
+# Brief: Wave 28e — the Board primitive + applied briefs must visibly matter
+
+Start: `git fetch origin && git checkout -b sameer/canvas-board origin/main`
+(main will include 28d by the time you start; verify with
+`git log --oneline -3 origin/main` and if 28d ("lens") is NOT merged yet,
+say so in the report and branch from origin/main anyway, rebasing later is
+the coordinator's problem — do not wait).
+
+## Live evidence (echo-next chat e59c0720, canvas 12)
+
+Host asked in chat for "a good summary person by person" like an earlier
+canvas version had. The agent proposed a brief update promising the loop
+would "rebuild the board, presenting a clear person-by-person summary".
+Host applied TWICE. Both post-apply generations: "0 quote(s), 0 concept
+change(s), crux unchanged, story unchanged" — identical wall. Two gaps:
+
+1. There is no tab shape that can express person-by-person.
+2. An applied brief cannot change which tabs exist, so shape requests are
+   dead on arrival — and nothing tells the host that.
+
+## What to build
+
+1. **Board primitive** (new tab kind `board`): a dense grid of white cards
+   (per the handoff "Canvas" row: 5-col grid at desktop, 9px gaps,
+   `12px 13px` blocks) keyed by a grouping the config declares — v1
+   grouping: `person`. Each card: the person/label as header, a short
+   model-written synthesis of THAT voice grounded in accepted quotes
+   attributed to them (attribution perfect or absent: voices without
+   attributed quotes render under one "the room" card rather than guessed
+   names), plus 1-2 receipt quotes (traceable, same details/summary
+   mechanism). Board state persists like the other ledgers and updates
+   additively per tick (synthesis rewritten, receipts appended). The
+   extraction call gains a `board_cards` output section only when a board
+   tab is enabled.
+
+2. **Tabs become config** (they already live on `canvas_tabs`): the
+   applied brief maps to tab config. Extend the config revision/apply path
+   so a proposal can declare tabs (e.g. add `board` with grouping person,
+   drop `story`), defaulting to the current set when unspecified. The
+   agent-side proposal tool schema gains an optional `tabs` field —
+   proposeCanvas passes it through. v1 tab kinds: crux, cloud, story,
+   host_guide (28d), board.
+
+3. **Apply must visibly matter**: after an applied revision, the manual
+   tick re-renders with the new tab set immediately (even with zero new
+   transcript — tab-set changes bypass the empty-over-full guard because
+   the STRUCTURE changed, content did not). If an applied brief requests
+   something no primitive can express, the run detail must say so
+   plainly ("brief asks for X; no tab primitive supports it") so the
+   agent (canvas-activity block, #832) can surface it instead of promising
+   a rebuild that cannot happen.
+
+4. **Agent prompt** (echo/agent/agent.py): when the host asks for a
+   structural view that maps to a primitive (per-person, per-table board),
+   the proposal declares the tab change. When it maps to NO primitive, say
+   that honestly in chat and record an insight — never promise the loop
+   will "rebuild" into a shape that does not exist.
+
+## QA gates
+
+- Server: ruff + focused canvas pytest; tests: board render from
+  attributed quotes; unattributed voices fold into "the room"; tab-set
+  change re-renders on apply despite no new content; unsupported-shape
+  detail recorded.
+- Agent: uv run pytest -q; tests for the tabs field passthrough + honest
+  no-primitive reply rule.
+- Migration: extend idempotently if new fields are needed.
+- Report -> echo/docs/plans/smart-loop-briefs/wave28e-REPORT.md.

--- a/echo/server/dembrane/api/v2/bff/canvases.py
+++ b/echo/server/dembrane/api/v2/bff/canvases.py
@@ -15,6 +15,7 @@ from dembrane.redis_async import get_redis_client
 from dembrane.canvas.ticks import (
     run_tick,
     _generate_html,
+    _generate_host_guide,
     _gather_has_transcript,
     _extract_living_canvas_update,
 )
@@ -282,10 +283,21 @@ async def preview_canvas(
             extraction = await _extract_living_canvas_update(
                 gather_bundle=gather_bundle,
                 current_state=living_state,
+                report_name=body.name,
+                brief=body.brief,
             )
         except Exception as exc:
             raise HTTPException(status_code=502, detail=f"Canvas extraction failed: {exc}") from exc
         living_state, _detail = apply_model_extraction(living_state, gather_bundle, extraction)
+        try:
+            living_state["host_guide"] = await _generate_host_guide(
+                report_name=body.name,
+                brief=body.brief,
+                current_state=living_state,
+                recent_activity=_detail,
+            )
+        except Exception:
+            pass
 
     raw_html = await _generate_html(
         brief=body.brief,

--- a/echo/server/dembrane/canvas/ledgers.py
+++ b/echo/server/dembrane/canvas/ledgers.py
@@ -8,13 +8,14 @@ from datetime import datetime, timezone
 
 from dembrane.utils import generate_uuid
 
-CANVAS_TAB_SET_V1 = ("crux", "concept_cloud", "story")
+CANVAS_TAB_SET_V1 = ("crux", "concept_cloud", "story", "host_guide")
 CANVAS_TAB_LABELS = {
     "crux": "Crux",
     "concept_cloud": "Concept cloud",
     "story": "Story",
+    "host_guide": "Host guide",
 }
-HOST_TARGET_TABS = set(CANVAS_TAB_SET_V1)
+HOST_TARGET_TABS = set(CANVAS_TAB_SET_V1) - {"host_guide"}
 
 
 def utc_now_iso() -> str:
@@ -32,6 +33,7 @@ def fresh_canvas_state(loop: dict[str, Any] | None = None) -> dict[str, Any]:
         or {"question": "", "history": []},
         "host_items": _list(loop.get("host_items") or loop.get("canvas_host_items")),
         "story_slides": _list(loop.get("story_slides") or loop.get("canvas_story_slides")),
+        "host_guide": _dict(loop.get("host_guide") or loop.get("canvas_host_guide")),
     }
 
 
@@ -43,6 +45,7 @@ def state_patch(state: dict[str, Any]) -> dict[str, Any]:
         "canvas_crux": state.get("crux") or {"question": "", "history": []},
         "canvas_host_items": state.get("host_items") or [],
         "canvas_story_slides": state.get("story_slides") or [],
+        "canvas_host_guide": state.get("host_guide") or {},
     }
 
 
@@ -418,6 +421,8 @@ def _panel(tab: str, state: dict[str, Any]) -> str:
         body = _render_crux(state)
     elif tab == "concept_cloud":
         body = _render_cloud(state)
+    elif tab == "host_guide":
+        body = _render_host_guide(state)
     else:
         body = _render_story(state)
     return f'<section class="tabbed-canvas-panel tabbed-canvas-panel-{tab}" data-tab-panel="{tab}" aria-label="{label}">{body}</section>'
@@ -476,6 +481,44 @@ def _render_story(state: dict[str, Any]) -> str:
   <h2>{heading}</h2>
   <div class="tabbed-story-quotes">{slide_html}</div>
   {_render_host_items(state, "story")}
+</div>
+""".strip()
+
+
+def _render_host_guide(state: dict[str, Any]) -> str:
+    guide = state.get("host_guide") if isinstance(state.get("host_guide"), dict) else {}
+    where = str(guide.get("where_the_room_is") or "").strip()
+    questions = [
+        str(item).strip() for item in guide.get("what_to_ask_next") or [] if str(item).strip()
+    ][:3]
+    under_heard = [
+        str(item).strip() for item in guide.get("under_heard") or [] if str(item).strip()
+    ][:5]
+    if not where and not questions and not under_heard:
+        body = '<p class="tabbed-canvas-empty">The host guide is waiting for usable room receipts.</p>'
+    else:
+        where_html = (
+            f'<section class="tabbed-guide-block"><h3>Where the room is</h3><p>{html.escape(where)}</p></section>'
+            if where
+            else ""
+        )
+        questions_html = ""
+        if questions:
+            rows = "".join(f"<li>{html.escape(question)}</li>" for question in questions)
+            questions_html = (
+                f'<section class="tabbed-guide-block"><h3>What to ask next</h3><ol>{rows}</ol></section>'
+            )
+        under_heard_html = ""
+        if under_heard:
+            rows = "".join(f"<li>{html.escape(item)}</li>" for item in under_heard)
+            under_heard_html = (
+                f'<section class="tabbed-guide-block"><h3>Under-heard</h3><ul>{rows}</ul></section>'
+            )
+        body = where_html + questions_html + under_heard_html
+    return f"""
+<div class="tabbed-host-guide">
+  <p class="tabbed-canvas-kicker">Host guide</p>
+  {body}
 </div>
 """.strip()
 
@@ -619,11 +662,14 @@ _CSS = """
 .tabbed-canvas-panel{display:none}
 #canvas-tab-crux:checked~.tabbed-canvas-tabbar label[for=canvas-tab-crux],
 #canvas-tab-concept_cloud:checked~.tabbed-canvas-tabbar label[for=canvas-tab-concept_cloud],
-#canvas-tab-story:checked~.tabbed-canvas-tabbar label[for=canvas-tab-story]{color:var(--ink);border-bottom-color:var(--royal)}
+#canvas-tab-story:checked~.tabbed-canvas-tabbar label[for=canvas-tab-story],
+#canvas-tab-host_guide:checked~.tabbed-canvas-tabbar label[for=canvas-tab-host_guide]{color:var(--ink);border-bottom-color:var(--royal)}
 #canvas-tab-crux:checked~[data-tab-panel=crux],
 #canvas-tab-concept_cloud:checked~[data-tab-panel=concept_cloud],
-#canvas-tab-story:checked~[data-tab-panel=story]{display:block}
+#canvas-tab-story:checked~[data-tab-panel=story],
+#canvas-tab-host_guide:checked~[data-tab-panel=host_guide]{display:block}
 .tabbed-crux,.tabbed-story{max-width:1000px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center}
+.tabbed-host-guide{max-width:840px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center;gap:16px}
 .tabbed-crux h1,.tabbed-story h2{max-width:900px;margin:0;font-weight:500;line-height:1.14;text-wrap:balance}
 .tabbed-crux h1{font-size:clamp(32px,4.6vw,48px)}
 .tabbed-story h2{font-size:clamp(24px,3.4vw,36px)}
@@ -646,8 +692,13 @@ _CSS = """
 .tabbed-host-items{margin-top:22px;display:grid;gap:12px}
 .tabbed-host-item{border:1px solid var(--hairline);border-left:3px solid var(--royal);background:var(--card);padding:15px 18px}
 .tabbed-host-item p{margin:0;white-space:pre-wrap}
+.tabbed-guide-block{border:1px solid var(--hairline);background:var(--card);padding:16px 18px}
+.tabbed-guide-block h3{margin:0 0 10px;font-size:16px;font-weight:600}
+.tabbed-guide-block p{margin:0;color:var(--ink-soft);line-height:1.45}
+.tabbed-guide-block ol,.tabbed-guide-block ul{margin:0;padding-left:20px;color:var(--ink-soft);line-height:1.45}
+.tabbed-guide-block li+li{margin-top:8px}
 .tabbed-canvas-empty{color:var(--ink-soft)}
 @keyframes tabbedFloat{0%,100%{translate:0 0}50%{translate:0 -5px}}
 @media (prefers-reduced-motion:reduce){.tabbed-concept{animation:none}}
-@media (max-width:720px){.tabbed-canvas-frame{padding:14px 14px 60px}.tabbed-canvas-tabbar{gap:16px}.tabbed-crux,.tabbed-story{min-height:58vh}}
+@media (max-width:720px){.tabbed-canvas-frame{padding:14px 14px 60px}.tabbed-canvas-tabbar{gap:16px}.tabbed-crux,.tabbed-story,.tabbed-host-guide{min-height:58vh}}
 """

--- a/echo/server/dembrane/canvas/service.py
+++ b/echo/server/dembrane/canvas/service.py
@@ -312,6 +312,7 @@ async def get_loop_for_report(report_id: str) -> dict[str, Any] | None:
                     "canvas_crux",
                     "canvas_host_items",
                     "canvas_story_slides",
+                    "canvas_host_guide",
                     "created_at",
                     "updated_at",
                 ],

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -35,6 +35,7 @@ _BANNED_VISIBLE_COPY: tuple[tuple[str, str], ...] = (
     ("successfully", "successfully"),
     ("\u2014", "em dash"),
 )
+CANVAS_TRANSCRIPT_WINDOW_CHARS = 20_000
 
 
 class _VisibleTextParser(HTMLParser):
@@ -133,12 +134,16 @@ def _generation_detail(
     if ledger_detail:
         if ledger_detail.get("backfill_conversations") is not None:
             details.append(f"backfill: {ledger_detail.get('backfill_conversations')} conversations")
+        outcomes = ledger_detail.get("conversation_outcomes") or []
+        if outcomes:
+            details.extend(str(outcome) for outcome in outcomes[:40])
         details.append(
             "ledger update: "
             f"{ledger_detail.get('quotes_added', 0)} quote(s), "
             f"{ledger_detail.get('concepts_changed', 0)} concept change(s), "
             f"crux {'changed' if ledger_detail.get('crux_changed') else 'unchanged'}, "
-            f"story {'changed' if ledger_detail.get('story_changed') else 'unchanged'}"
+            f"story {'changed' if ledger_detail.get('story_changed') else 'unchanged'}, "
+            f"host guide {'changed' if ledger_detail.get('host_guide_changed') else 'unchanged'}"
         )
         removed = ledger_detail.get("concepts_removed") or []
         if removed:
@@ -187,6 +192,15 @@ Crux rules:
 - A newcomer can answer it out loud: no internal references, jargon, or hidden numbers.
 - Phrase as an invitation with a concrete first move.
 
+Purpose rules:
+- This wall exists for the purpose described in the brief.
+- Extract ONLY material that serves it.
+- Conversations unrelated to this purpose may legitimately yield zero quotes;
+  returning nothing for them is correct, not a failure.
+- At most one small tile of off-topic room flavor is allowed.
+- Honor the brief's guardrails, including instructions not to pre-populate
+  static transcript snippets into structure.
+
 Return exactly:
 {
   "quotes": [{"who": string|null, "quote": string, "conversation_id": string, "chunk_id": string|null}],
@@ -195,6 +209,25 @@ Return exactly:
   "story_slides": [{"eyebrow": string|null, "heading": string, "lede": string, "quote_indices": [0]}]
 }
 Quote and slide indices are zero-based into your returned quotes array.
+"""
+
+HOST_GUIDE_SYSTEM_PROMPT = """
+You write the Host guide tab for a dembrane living canvas. Return JSON only.
+
+Grounding rules:
+- Use ONLY the brief, current ledgers, and recent run activity provided by the user.
+- Do not invent facts, names, conflict, consensus, or absent voices.
+- Keep "where_the_room_is" to 2-3 sentences.
+- Give 2-3 concrete questions the host can say out loud.
+- Use "under_heard" only for voices or threads with few or no receipts in the
+  ledger attribution. If there is not enough evidence, return an empty array.
+
+Return exactly:
+{
+  "where_the_room_is": string,
+  "what_to_ask_next": [string],
+  "under_heard": [string]
+}
 """
 
 
@@ -418,6 +451,82 @@ def _single_conversation_bundle(
     }
 
 
+def _short_id(value: Any) -> str:
+    text = str(value or "unknown")
+    return text[:8] if len(text) > 8 else text
+
+
+def _copy_conversation_with_chunks(
+    conversation: dict[str, Any],
+    chunks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    transcript = "\n".join(str(chunk.get("transcript") or "") for chunk in chunks if chunk)
+    return {
+        **conversation,
+        "chunks": chunks,
+        "latest_transcript": transcript,
+    }
+
+
+def _conversation_chunks(conversation: dict[str, Any]) -> list[dict[str, Any]]:
+    chunks = conversation.get("chunks") if isinstance(conversation.get("chunks"), list) else []
+    if chunks:
+        return [chunk for chunk in chunks if isinstance(chunk, dict)]
+    return [
+        {
+            "id": None,
+            "transcript": conversation.get("latest_transcript") or "",
+            "created_at": conversation.get("created_at"),
+        }
+    ]
+
+
+def _windowed_conversation_bundles(
+    gather_bundle: dict[str, Any],
+    conversation: dict[str, Any],
+    *,
+    window_chars: int = CANVAS_TRANSCRIPT_WINDOW_CHARS,
+) -> list[dict[str, Any]]:
+    window_chars = max(1000, window_chars)
+    bundles: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] = []
+    current_size = 0
+
+    def flush() -> None:
+        nonlocal current, current_size
+        if not current:
+            return
+        bundles.append(
+            _single_conversation_bundle(
+                gather_bundle,
+                _copy_conversation_with_chunks(conversation, current),
+            )
+        )
+        current = []
+        current_size = 0
+
+    for chunk in _conversation_chunks(conversation):
+        transcript = str(chunk.get("transcript") or "")
+        if not transcript.strip():
+            continue
+        start = 0
+        while start < len(transcript):
+            remaining = window_chars - current_size
+            if remaining <= 0:
+                flush()
+                remaining = window_chars
+            piece = transcript[start : start + remaining]
+            start += len(piece)
+            if not piece:
+                break
+            current.append({**chunk, "transcript": piece})
+            current_size += len(piece)
+            if current_size >= window_chars:
+                flush()
+    flush()
+    return bundles
+
+
 def _transcript_payload_for_model(gather_bundle: dict[str, Any]) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     remaining = max(12000, get_settings().canvas.max_total_transcript_chars)
@@ -464,9 +573,19 @@ async def _extract_living_canvas_update(
     *,
     gather_bundle: dict[str, Any],
     current_state: dict[str, Any],
+    report_name: str,
+    brief: str,
 ) -> dict[str, Any]:
     project = gather_bundle.get("project") or {}
     user_payload = {
+        "report": {"name": report_name},
+        "brief": brief,
+        "purpose_instruction": (
+            "This wall exists for the purpose described in the brief. Extract ONLY material "
+            "that serves it. Conversations unrelated to this purpose may legitimately yield "
+            "zero quotes -- returning nothing for them is correct, not a failure. At most one "
+            "small tile of off-topic room flavor is allowed."
+        ),
         "project": {
             "name": project.get("name"),
             "language": project.get("language") or "en",
@@ -488,11 +607,66 @@ async def _extract_living_canvas_update(
     return _json_from_model_text(_choice_text(response))
 
 
+def _ledger_attribution(state: dict[str, Any]) -> dict[str, Any]:
+    normalized = fresh_canvas_state(state)
+    by_conversation: dict[str, int] = {}
+    by_voice: dict[str, int] = {}
+    for quote in normalized["quotes_ledger"]:
+        source = quote.get("source") if isinstance(quote.get("source"), dict) else {}
+        conv_id = str(source.get("conversation_id") or "unknown")
+        by_conversation[conv_id] = by_conversation.get(conv_id, 0) + 1
+        voice = str(quote.get("who") or "participant")
+        by_voice[voice] = by_voice.get(voice, 0) + 1
+    return {"by_conversation": by_conversation, "by_voice": by_voice}
+
+
+async def _generate_host_guide(
+    *,
+    report_name: str,
+    brief: str,
+    current_state: dict[str, Any],
+    recent_activity: dict[str, Any],
+) -> dict[str, Any]:
+    user_payload = {
+        "report": {"name": report_name},
+        "brief": brief,
+        "current_ledgers": ledger_prompt_summary(current_state),
+        "ledger_attribution": _ledger_attribution(current_state),
+        "recent_run_activity": recent_activity,
+    }
+    response = await arouter_completion(
+        MODELS.MULTI_MODAL_FAST,
+        messages=[
+            {"role": "system", "content": HOST_GUIDE_SYSTEM_PROMPT},
+            {"role": "user", "content": json.dumps(user_payload, ensure_ascii=False, indent=2)},
+        ],
+        temperature=0.2,
+        max_tokens=1400,
+    )
+    parsed = _json_from_model_text(_choice_text(response))
+    questions = [
+        str(item).strip()[:220]
+        for item in parsed.get("what_to_ask_next") or []
+        if str(item).strip()
+    ][:3]
+    under_heard = [
+        str(item).strip()[:220] for item in parsed.get("under_heard") or [] if str(item).strip()
+    ][:5]
+    return {
+        "where_the_room_is": str(parsed.get("where_the_room_is") or "").strip()[:900],
+        "what_to_ask_next": questions,
+        "under_heard": under_heard,
+        "updated_at": _now().isoformat(),
+    }
+
+
 async def _merge_extraction_for_tick(
     *,
     gather_bundle: dict[str, Any],
     current_state: dict[str, Any],
     backfill: bool,
+    report_name: str,
+    brief: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     living_state = fresh_canvas_state(current_state)
     combined_detail: dict[str, Any] = {
@@ -500,8 +674,10 @@ async def _merge_extraction_for_tick(
         "concepts_changed": 0,
         "crux_changed": False,
         "story_changed": False,
+        "host_guide_changed": False,
         "concepts_removed": [],
         "rejections": [],
+        "conversation_outcomes": [],
     }
     conversations = [
         conv
@@ -513,20 +689,53 @@ async def _merge_extraction_for_tick(
     if not conversations:
         return living_state, combined_detail
 
-    bundles = (
-        [_single_conversation_bundle(gather_bundle, conv) for conv in conversations]
-        if backfill
-        else [gather_bundle]
-    )
-    for bundle in bundles:
-        extraction = await _extract_living_canvas_update(
-            gather_bundle=bundle,
-            current_state=living_state,
+    bundles: list[tuple[dict[str, Any], str, int | None, int]] = []
+    if backfill:
+        for conv in conversations:
+            windows = _windowed_conversation_bundles(gather_bundle, conv)
+            for window_index, bundle in enumerate(windows, start=1):
+                bundles.append((bundle, str(conv.get("id") or "unknown"), window_index, len(windows)))
+    else:
+        oversized = any(
+            sum(len(str(chunk.get("transcript") or "")) for chunk in _conversation_chunks(conv))
+            > CANVAS_TRANSCRIPT_WINDOW_CHARS
+            for conv in conversations
         )
+        if oversized:
+            for conv in conversations:
+                windows = _windowed_conversation_bundles(gather_bundle, conv)
+                for window_index, bundle in enumerate(windows, start=1):
+                    bundles.append(
+                        (bundle, str(conv.get("id") or "unknown"), window_index, len(windows))
+                    )
+        else:
+            bundles = [(gather_bundle, "recent", None, 1)]
+
+    for bundle, conv_id, window_index, window_count in bundles:
+        try:
+            extraction = await _extract_living_canvas_update(
+                gather_bundle=bundle,
+                current_state=living_state,
+                report_name=report_name,
+                brief=brief,
+            )
+        except Exception as exc:
+            label = f"backfill conv {_short_id(conv_id)}" if backfill else f"conv {_short_id(conv_id)}"
+            if window_index is not None and window_count > 1:
+                label += f" window {window_index}"
+            combined_detail["conversation_outcomes"].append(f"{label}: model error: {exc}")
+            continue
         living_state, detail = apply_model_extraction(
             living_state,
             bundle,
             extraction,
+        )
+        rejected = len(detail.get("rejections") or [])
+        label = f"backfill conv {_short_id(conv_id)}" if backfill else f"conv {_short_id(conv_id)}"
+        if window_index is not None and window_count > 1:
+            label += f" window {window_index}"
+        combined_detail["conversation_outcomes"].append(
+            f"{label}: {int(detail.get('quotes_added') or 0)} accepted / {rejected} rejected"
         )
         combined_detail["quotes_added"] += int(detail.get("quotes_added") or 0)
         combined_detail["concepts_changed"] += int(detail.get("concepts_changed") or 0)
@@ -538,6 +747,18 @@ async def _merge_extraction_for_tick(
         )
         combined_detail["concepts_removed"].extend(detail.get("concepts_removed") or [])
         combined_detail["rejections"].extend(detail.get("rejections") or [])
+    try:
+        host_guide = await _generate_host_guide(
+            report_name=report_name,
+            brief=brief,
+            current_state=living_state,
+            recent_activity=combined_detail,
+        )
+        if host_guide != living_state.get("host_guide"):
+            living_state["host_guide"] = host_guide
+            combined_detail["host_guide_changed"] = True
+    except Exception as exc:
+        combined_detail["rejections"].append(f"host guide model error: {exc}")
     return living_state, combined_detail
 
 
@@ -622,6 +843,8 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
                     gather_bundle=gather_bundle,
                     current_state=living_state,
                     backfill=cold_start_backfill,
+                    report_name=str(loop.get("name") or config.get("name") or config.get("brief") or "Canvas"),
+                    brief=str(config.get("brief") or ""),
                 )
             except Exception as exc:
                 run = await _create_run(
@@ -638,11 +861,25 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
                 "concepts_changed": 0,
                 "crux_changed": False,
                 "story_changed": False,
+                "host_guide_changed": False,
                 "concepts_removed": [],
                 "rejections": [],
+                "conversation_outcomes": [],
             }
             if cold_start_backfill:
                 ledger_detail["backfill_conversations"] = 0
+            try:
+                host_guide = await _generate_host_guide(
+                    report_name=str(loop.get("name") or config.get("name") or "Canvas"),
+                    brief=str(config.get("brief") or ""),
+                    current_state=living_state,
+                    recent_activity=ledger_detail,
+                )
+                if host_guide != living_state.get("host_guide"):
+                    living_state["host_guide"] = host_guide
+                    ledger_detail["host_guide_changed"] = True
+            except Exception as exc:
+                ledger_detail["rejections"].append(f"host guide model error: {exc}")
 
         if _state_is_empty_wall(living_state) and _contentful_generation(latest_ok):
             run = await _create_run(

--- a/echo/server/tests/test_canvas_ledgers.py
+++ b/echo/server/tests/test_canvas_ledgers.py
@@ -61,7 +61,7 @@ def test_apply_model_extraction_accepts_verbatim_receipts_and_updates_crux() -> 
     assert state["concepts_ledger"][0]["phrase"] == "doorway open"
     assert state["crux"]["question"] == "What first move keeps the doorway open?"
     assert state["story_slides"][0]["quote_ids"] == [state["quotes_ledger"][0]["id"]]
-    assert state_patch(state)["canvas_tabs"] == ["crux", "concept_cloud", "story"]
+    assert state_patch(state)["canvas_tabs"] == ["crux", "concept_cloud", "story", "host_guide"]
     assert state_patch(state)["canvas_story_slides"]
 
 
@@ -181,5 +181,26 @@ def test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items() ->
 
     assert 'type="radio"' in html
     assert 'for="canvas-tab-crux"' in html
+    assert 'for="canvas-tab-host_guide"' in html
     assert "tabbed-traceable" in html
     assert "Host says: hold this exact reflection." in html
+
+
+def test_render_tabbed_canvas_includes_persisted_host_guide() -> None:
+    state = fresh_canvas_state(
+        {
+            "canvas_host_guide": {
+                "where_the_room_is": "The room is circling one concrete next step.",
+                "what_to_ask_next": ["What would make this safe to try tomorrow?"],
+                "under_heard": ["No receipts yet from operations."],
+            }
+        }
+    )
+
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert "Host guide" in html
+    assert "Where the room is" in html
+    assert "What would make this safe to try tomorrow?" in html
+    assert "No receipts yet from operations." in html
+    assert state_patch(state)["canvas_host_guide"]["where_the_room_is"].startswith("The room")

--- a/echo/server/tests/test_canvas_ticks.py
+++ b/echo/server/tests/test_canvas_ticks.py
@@ -74,6 +74,16 @@ def _claim_tick_window(monkeypatch) -> None:
 
     monkeypatch.setattr(ticks, "_claim_scheduled_tick_window", _claim)
 
+    async def _host_guide(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "where_the_room_is": "The room is forming around receipts already accepted.",
+            "what_to_ask_next": ["What should we test next?"],
+            "under_heard": [],
+            "updated_at": "2026-07-08T10:00:00+00:00",
+        }
+
+    monkeypatch.setattr(ticks, "_generate_host_guide", _host_guide)
+
 
 @pytest.mark.asyncio
 async def test_tick_no_op_when_no_new_content(monkeypatch) -> None:
@@ -167,7 +177,7 @@ async def test_tick_error_stores_error_generation_and_pauses_after_three(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_tick_model_failure_noops_without_touching_loop_state(monkeypatch) -> None:
+async def test_tick_model_failure_records_nonfatal_conversation_outcome(monkeypatch) -> None:
     fake = _FakeDirectus()
     fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"] = [
         {"id": "q-old", "quote": "Keep this.", "source": {}}
@@ -203,13 +213,10 @@ async def test_tick_model_failure_noops_without_touching_loop_state(monkeypatch)
 
     result = await ticks.run_tick("loop1", "scheduled")
 
-    assert result["status"] == "no_op"
-    assert fake.created["agent_loop_run"][0]["status"] == "no_op"
-    assert (
-        "Model extraction failed: model unavailable" in fake.created["agent_loop_run"][0]["detail"]
-    )
-    assert "canvas_generation" not in fake.created
-    assert fake.updated == []
+    assert result["status"] == "ok"
+    assert fake.created["agent_loop_run"][0]["status"] == "ok"
+    assert "conv recent: model error: model unavailable" in result["generation"]["detail"]
+    assert fake.created["canvas_generation"][0]["status"] == "ok"
     assert fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"] == [
         {"id": "q-old", "quote": "Keep this.", "source": {}}
     ]
@@ -296,6 +303,48 @@ async def test_tick_uses_model_extraction_and_records_receipt_rejections(monkeyp
     assert "Keep the doorway open." in generation["content_html"]
     assert "not found verbatim" in generation["detail"]
     assert "no accepted supporting quote" in generation["detail"]
+    assert "Host guide" in generation["content_html"]
+    assert fake.items["agent_loop"]["loop1"]["canvas_host_guide"]["where_the_room_is"]
+
+
+@pytest.mark.asyncio
+async def test_extraction_prompt_includes_report_brief_and_zero_quote_instruction(
+    monkeypatch,
+) -> None:
+    messages_seen: list[list[dict[str, str]]] = []
+
+    async def _completion(model, messages, **kwargs):  # noqa: ANN001, ARG001
+        messages_seen.append(messages)
+
+        class _Message:
+            content = '{"quotes":[],"concepts":[],"crux":null,"story_slides":[]}'
+
+        class _Choice:
+            message = _Message()
+
+        class _Response:
+            choices = [_Choice()]
+
+        return _Response()
+
+    monkeypatch.setattr(ticks, "arouter_completion", _completion)
+
+    result = await ticks._extract_living_canvas_update(
+        gather_bundle={
+            "project": {"name": "Room"},
+            "conversations": [{"id": "conv-1", "latest_transcript": "Off-topic room flavor."}],
+        },
+        current_state={},
+        report_name="13th Week Retrospective Wall",
+        brief="Focus on the 13th week. Do not pre-populate static transcript snippets.",
+    )
+
+    payload = messages_seen[0][1]["content"]
+    assert result["quotes"] == []
+    assert "13th Week Retrospective Wall" in payload
+    assert "Focus on the 13th week" in payload
+    assert "Extract ONLY material that serves it" in payload
+    assert "returning nothing for them is correct" in payload
 
 
 @pytest.mark.asyncio
@@ -358,6 +407,7 @@ async def test_cold_start_backfill_uses_full_history_then_delta(monkeypatch) -> 
     assert extraction_calls[2] == ["conv-1", "conv-2"]
     assert "backfill: 2 conversations" in first["generation"]["detail"]
     assert "backfill: 2 conversations" in first["run"]["detail"]
+    assert "backfill conv conv-1: 1 accepted / 0 rejected" in first["generation"]["detail"]
 
 
 @pytest.mark.asyncio
@@ -399,6 +449,120 @@ async def test_empty_extraction_with_prior_generation_noops_without_storing_skel
     assert "canvas_generation" not in fake.created
     assert fake.updated == []
     assert fake.latest_generation["id"] == "g-old"
+
+
+@pytest.mark.asyncio
+async def test_backfill_long_transcript_is_windowed(monkeypatch) -> None:
+    fake = _FakeDirectus()
+    extraction_lengths: list[int] = []
+    long_transcript = "A relevant retrospective receipt. " * 1800
+
+    async def _config(report_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"id": "cfg1", "brief": "retro brief", "gather_spec": {}, "cadence_minutes": 5}
+
+    async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "latest_content_at": "2026-07-07T10:20:00+00:00",
+            "project": {"name": "Room"},
+            "conversations": [
+                {"id": "conv-long", "label": "Retro", "latest_transcript": long_transcript}
+            ],
+        }
+
+    async def _extract(**kwargs) -> dict[str, Any]:
+        transcript = kwargs["gather_bundle"]["conversations"][0]["chunks"][0]["transcript"]
+        extraction_lengths.append(len(transcript))
+        quote = transcript.strip()[:120].strip()
+        return {
+            "quotes": [
+                {"who": "Retro", "quote": quote, "conversation_id": "conv-long", "chunk_id": None}
+            ],
+            "concepts": [],
+            "crux": None,
+            "story_slides": [],
+        }
+
+    async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
+        return None
+
+    async def _publish(report_id: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(ticks, "async_directus", fake)
+    monkeypatch.setattr(ticks, "_latest_config", _config)
+    monkeypatch.setattr(ticks, "execute_gather_spec", _gather)
+    monkeypatch.setattr(ticks, "_extract_living_canvas_update", _extract)
+    monkeypatch.setattr(ticks, "_enqueue_next_if_due", _enqueue)
+    monkeypatch.setattr(ticks, "publish_generation_nudge", _publish)
+
+    result = await ticks.run_tick("loop1", "manual")
+
+    assert result["status"] == "ok"
+    assert len(extraction_lengths) > 1
+    assert max(extraction_lengths) <= ticks.CANVAS_TRANSCRIPT_WINDOW_CHARS
+    assert "backfill conv conv-lon window 1:" in result["generation"]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_conversation_model_error_is_recorded_and_nonfatal(monkeypatch) -> None:
+    fake = _FakeDirectus()
+
+    async def _config(report_id: str) -> dict[str, Any]:  # noqa: ARG001
+        return {"id": "cfg1", "brief": "retro brief", "gather_spec": {}, "cadence_minutes": 5}
+
+    async def _gather(**kwargs) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "latest_content_at": "2026-07-07T10:20:00+00:00",
+            "project": {"name": "Room"},
+            "conversations": [
+                {"id": "conv-fail", "label": "Retro", "latest_transcript": "This one errors."},
+                {"id": "conv-ok", "label": "Design", "latest_transcript": "Keep this receipt."},
+            ],
+        }
+
+    async def _extract(**kwargs) -> dict[str, Any]:
+        conv = kwargs["gather_bundle"]["conversations"][0]
+        if conv["id"] == "conv-fail":
+            raise RuntimeError("context length")
+        return {
+            "quotes": [
+                {
+                    "who": "Design",
+                    "quote": "Keep this receipt.",
+                    "conversation_id": "conv-ok",
+                    "chunk_id": None,
+                }
+            ],
+            "concepts": [{"phrase": "this receipt", "supporting_quote_indices": [0]}],
+            "crux": None,
+            "story_slides": [],
+        }
+
+    async def _enqueue(loop: dict[str, Any]) -> None:  # noqa: ARG001
+        return None
+
+    async def _publish(report_id: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(ticks, "async_directus", fake)
+    monkeypatch.setattr(ticks, "_latest_config", _config)
+    monkeypatch.setattr(ticks, "execute_gather_spec", _gather)
+    monkeypatch.setattr(ticks, "_extract_living_canvas_update", _extract)
+    monkeypatch.setattr(ticks, "_enqueue_next_if_due", _enqueue)
+    monkeypatch.setattr(ticks, "publish_generation_nudge", _publish)
+
+    result = await ticks.run_tick("loop1", "manual")
+
+    assert result["status"] == "ok"
+    assert "backfill conv conv-fai: model error: context length" in result[
+        "generation"
+    ]["detail"]
+    assert "backfill conv conv-ok: 1 accepted / 0 rejected" in result["generation"][
+        "detail"
+    ]
+    assert fake.items["agent_loop"]["loop1"]["canvas_quotes_ledger"][0]["quote"] == (
+        "Keep this receipt."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the live canvas-12 failure: a "13th Week Retrospective Wall" whose entire ledger came from one unrelated design conversation while the 92k-char retrospective silently contributed zero.

- **Lens connected**: report name + brief enter the extraction prompt with the purpose rule (unrelated conversations may legitimately yield zero; brief guardrails honored). Preview passes the same context
- **Host guide** as the fourth fixed tab (`canvas_host_guide`): where the room is / what to ask next / under-heard from receipt attribution — omitted rather than guessed; replaced per tick like the crux
- **Honest backfill**: 20k-char windowed extraction per conversation, per-conversation/window accounting in run+generation detail (`backfill conv X: N accepted / M rejected`, `model error: ...`), failures isolated. Root cause of the missing 28c marker: extraction exceptions exited before detail assembly
- Migration extended idempotently

Gates: server ruff + 44 canvas tests (agent untouched). Report: `wave28d-REPORT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)