### PR TITLE
Canvas: Open questions tab, story spacing, + button opens a prefilled chat

### DIFF
--- a/echo/docs/plans/canvas-agentic-tick.md
+++ b/echo/docs/plans/canvas-agentic-tick.md
@@ -1,0 +1,71 @@
+# Design: the agentic tick — every canvas update is a headless run
+
+Owner decision, 2026-07-09 (morning of the 13th-week retro day 2).
+
+## The shape
+
+The canvas tick stops being a fixed 1-2-3-4-5 pipeline and becomes a
+HEADLESS AGENTIC RUN: the same harness as the project chat agent (same
+model, memory injection, tool budget discipline, honesty rules), executed
+without a human on the other side, stored as a project chat that is HIDDEN
+from the Ask list (chat kind: "canvas_tick" or hidden flag). Every tick is
+therefore fully replayable and readable in the existing chat UI — tool
+calls, reasoning, receipts, everything.
+
+## What the tick agent gets
+
+- Read tools shared with chat: grepConversationSnippets,
+  listConversationSummary, listConversationFullTranscript, readMemory,
+  readGoal, getProjectSettings (post-rename names).
+- Canvas tools: readCanvasTab, editCanvasTab (surgical JSON edits to a
+  tab's state), plus the pipeline steps AS TOOLS: gatherNewTranscript,
+  extractReceipts (returns validated quotes only), mintVersion (render +
+  store generation).
+- A per-tick tool budget (~6-8 calls) and the tab skills (per-tab
+  contract files: crux/cloud/story/board/open-questions rules distilled
+  from the canvas-ux-handoff) injected as skill context.
+
+## What stays below the agent's reach (non-negotiable)
+
+1. RECEIPT VALIDATION is tool-layer code: every quote returned by
+   extractReceipts has passed the verbatim-substring check; the agent
+   cannot forge or bypass evidence. No receipt, no underline — by
+   construction, not by prompt.
+2. RENDER is deterministic: mintVersion turns JSON state into HTML with
+   zero model involvement. The agent decides WHAT to update, never how it
+   is drawn.
+3. VOICE FLOOR (wave 34 invariant): per-speaker coverage is checked in
+   code after extraction; selectivity applies to material, never to
+   voices; uncovered voices trigger a targeted pass or land in
+   under-heard honestly.
+
+## Versions and audit
+
+- Each generation stores state_snapshot (full JSON: tabs + ledgers) next
+  to content_html — versions are diffable, restorable, surgically
+  editable (wave 33).
+- The Audit log tab renders the run ledger. Entry grammar (refined with
+  owner): `HH:MM · outcome — cause · links`; a mint and its run are one
+  entry with `run ↗` (hidden chat) and `view version ↗` suffix links;
+  no_ops render honestly ("no change — nothing new heard"); kept-out
+  counts surface in the collapsed line. Full spec lives in
+  wave28g-trace-audit.md. Applies/host items keep chat/message links.
+- "Questionable in chat": the visible project chat agent can read these
+  hidden runs (readChat / readCanvasHistory) and answer "why did this
+  change" from the actual run, then noteInsight on the owner's verdict.
+
+## Why this is safe now
+
+The night's fences carry over unchanged: per-turn/run tool budgets,
+no-phantom-actions, mechanical receipts, empty-over-full guard, cadence
+window locks, banned-copy checks. The agentic layer only replaces the
+PLAN of a tick (which tabs need work, what to look at), which was the
+part hardcoded 1-5 could never do well.
+
+## Sequencing
+
+28f (rename/spacing/+button) -> 34 (voice floor) -> 28g (trace + audit
+tab, schema already includes optional run-chat links) -> 32 (tool renames
++ noteInsight visibility + editProjectTags) -> 33 (state_snapshot +
+readCanvasTab/editCanvasTab + per-tab edit buttons) -> 35 (this note:
+headless run migration of the tick).

--- a/echo/docs/plans/smart-loop-briefs/wave28f-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28f-REPORT.md
@@ -1,0 +1,44 @@
+# Wave 28f Report: Render Polish
+
+## Start Check
+
+- `origin/main` includes Wave 28e #834 at `a903e626`, so the brief's wait condition was satisfied before implementation.
+- The current worktree already had unrelated docs edits in `echo/docs/plans/smart-loop-briefs/wave28g-trace-audit.md`, untracked `echo/docs/plans/canvas-agentic-tick.md`, and untracked `wave18-shots/`; these were left untouched.
+
+## What Shipped
+
+- Renamed the visible `host_guide` tab label and rendered copy to `Open questions` while keeping internal `canvas_host_guide` field names unchanged.
+- Added a code comment documenting the label/internal-field split to avoid migration churn.
+- Updated the Open questions prompt so `where_the_room_is` is one short orienting line and the tab leans into parked or next questions.
+- Reworked deterministic Story rendering so each structured slide is its own `80vh` centered screen with one kicker, display heading sizing, balanced text, and handoff spacing tiers.
+- Kept the other tab spacing sweep scoped to existing renderer tokens: cloud measure, trace cards, dense board blocks, tab gaps, and mobile minima remain in handoff ranges.
+- Converted the tab-bar `+` from inert text to a `_top` chat link with a URL-encoded prefill: `I need a new tab in the {report name} canvas: `.
+- Added `workspace_id` to gathered project context so real renders can build `/{lang}/w/{workspace_id}/projects/{project_id}/chats/new?prefill=...`.
+- Verified sanitizer round-trips the relative prefill anchor and preserves `target="_top"`.
+
+## Files Modified
+
+- `echo/server/dembrane/api/v2/bff/canvases.py`
+- `echo/server/dembrane/canvas/gather.py`
+- `echo/server/dembrane/canvas/ledgers.py`
+- `echo/server/dembrane/canvas/ticks.py`
+- `echo/server/tests/test_canvas_gather.py`
+- `echo/server/tests/test_canvas_ledgers.py`
+- `echo/server/tests/test_canvas_sanitize.py`
+- `echo/server/tests/test_canvas_ticks.py`
+- `echo/docs/plans/smart-loop-briefs/wave28f-REPORT.md`
+
+## QA Gates
+
+- `cd echo/server && uv run ruff check .` passed.
+- `cd echo/server && DIRECTUS_SECRET=test DIRECTUS_TOKEN=test DATABASE_URL=postgresql://test:test@localhost:5432/test REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=test STORAGE_S3_ENDPOINT=http://localhost:9000 STORAGE_S3_KEY=test STORAGE_S3_SECRET=test uv run pytest -q tests/test_canvas_ledgers.py tests/test_canvas_ticks.py tests/test_canvas_sanitize.py tests/test_canvas_gather.py tests/test_canvas_service.py tests/api/test_bff_canvases.py` passed: 51 passed, 2 warnings.
+- `cd echo/agent && rg -n "host guide|Host guide" agent.py tests skills -g '*.py' -g '*.md'` found agent copy references, so the agent gate was run.
+- `cd echo/agent && uv run pytest -q` passed: 103 passed, 4 warnings.
+
+## Coverage Added
+
+- Rendered fragment assertions now expect `Open questions`, not `Host guide`.
+- Story render assertions check for full-screen slide hooks and display heading CSS.
+- The tab-bar `+` assertion covers the language segment, workspace/project route, `_top` target, and report-name prefill.
+- Gather tests assert `workspace_id` is present in project context.
+- Sanitizer tests assert relative chat-prefill anchors keep `href` and `target="_top"` without being counted as stripped external references.

--- a/echo/docs/plans/smart-loop-briefs/wave28g-trace-audit.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28g-trace-audit.md
@@ -39,6 +39,27 @@ details + config revisions + host items:
   the wall on judgment" belongs here)
 - cap the rendered tail (~30 entries) with a link to the dashboard
   version history (wave 31 ships see-all versions) for the rest.
+- entry format (owner-approved): collapsed line grammar is
+  `HH:MM · outcome — cause · links`, newest first, tabular-nums times:
+    09:42 · v14 minted — 2 quotes added, crux updated          run ↗
+    09:37 · no change — nothing new heard (12 min quiet)       run ↗
+    09:31 · v13 minted — Board tab added by you in chat ↗ — all tabs redrawn
+    09:24 · pinned to Board — "Cesare's reflection" by you in chat ↗
+    09:20 · v12 minted — 9 quotes in, 2 kept out ⚠             run ↗
+  Rules: a mint and its run are ONE entry (run link as suffix, never a
+  separate line); mint lines always carry a one-phrase diff; no_op
+  entries render as honest "no change — nothing new heard"; `kept out`
+  (rejections + judgment omissions) is promoted into the collapsed line
+  whenever nonzero; human causes are named and link the exact chat
+  message; cadence causes get no link. Expanded accordion sections:
+  heard / added / updated / kept out / cause, plus `view version`.
+  Versions display as small per-canvas ordinals (v12), not uuids.
+- entries are backed by a JSON object {at, kind, version, cause{type,
+  chat_id, message_id, run_chat_id}, heard, changes, kept_out} — the
+  same object the agent reads via readCanvasHistory, so the tab and the
+  chat answer from one source. Runs will later carry run_chat_id
+  (headless tick runs, echo/docs/plans/canvas-agentic-tick.md) — include
+  the field NOW, render the run ↗ link when present.
 
 ## 3. The history is readable and questionable in chat
 

--- a/echo/server/dembrane/api/v2/bff/canvases.py
+++ b/echo/server/dembrane/api/v2/bff/canvases.py
@@ -311,6 +311,7 @@ async def preview_canvas(
         previous_html=None,
         gather_bundle=gather_bundle,
         living_state=living_state,
+        report_name=str((gather_bundle.get("project") or {}).get("name") or "Canvas"),
     )
     sanitized = sanitize_canvas_html(raw_html)
     return {"content_html": sanitized.html}

--- a/echo/server/dembrane/canvas/gather.py
+++ b/echo/server/dembrane/canvas/gather.py
@@ -94,6 +94,7 @@ async def execute_gather_spec(
     project = await async_directus.get_item("project", project_id)
     project_context = {
         "id": project_id,
+        "workspace_id": (project or {}).get("workspace_id"),
         "name": (project or {}).get("name"),
         "context": (project or {}).get("context"),
         "goal": await get_current_project_goal_content(project_id),

--- a/echo/server/dembrane/canvas/ledgers.py
+++ b/echo/server/dembrane/canvas/ledgers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import html
 from typing import Any
 from datetime import datetime, timezone
+from urllib.parse import quote as url_quote
 
 from dembrane.utils import generate_uuid
 
@@ -14,7 +15,9 @@ CANVAS_TAB_LABELS = {
     "crux": "Crux",
     "concept_cloud": "Concept cloud",
     "story": "Story",
-    "host_guide": "Host guide",
+    # Internal state remains canvas_host_guide for migration stability; only
+    # the host-visible tab label is renamed.
+    "host_guide": "Open questions",
     "board": "Board",
 }
 HOST_TARGET_TABS = {"crux", "concept_cloud", "story"}
@@ -534,6 +537,7 @@ def render_tabbed_canvas(
     state: dict[str, Any],
     project: dict[str, Any],
     sample_notice: str | None = None,
+    report_name: str | None = None,
 ) -> str:
     state = fresh_canvas_state(state)
     tabs = normalize_canvas_tabs(state["tabs"])
@@ -552,6 +556,7 @@ def render_tabbed_canvas(
         for tab in tabs
     )
     panels = "\n".join(_panel(tab, state) for tab in tabs)
+    new_tab_href = _new_tab_chat_href(project, report_name=report_name)
     return f"""
 <div class="canvas-shell tabbed-canvas" data-canvas-schema="tabbed-v1">
   <style>{_CSS}</style>
@@ -561,7 +566,7 @@ def render_tabbed_canvas(
     {controls}
     <nav class="tabbed-canvas-tabbar" aria-label="Canvas tabs">
       {labels}
-      <span class="tabbed-canvas-add" aria-hidden="true">+</span>
+      <a class="tabbed-canvas-add" href="{new_tab_href}" target="_top" aria-label="Open a chat to request a new tab">+</a>
     </nav>
     {panels}
   </div>
@@ -635,12 +640,17 @@ def _render_story(state: dict[str, Any]) -> str:
             slide_html = "\n".join(_quote_block(q) for q in quotes)
         else:
             slide_html = '<p class="tabbed-canvas-empty">The story is waiting for the first usable room quotes.</p>'
-    heading = html.escape(str((state.get("crux") or {}).get("question") or "What is emerging?"))
+        heading = html.escape(str((state.get("crux") or {}).get("question") or "What is emerging?"))
+        slide_html = f"""
+<article class="tabbed-story-slide">
+  <p class="tabbed-canvas-kicker">Story</p>
+  <h3>{heading}</h3>
+  <div class="tabbed-story-evidence">{slide_html}</div>
+</article>
+""".strip()
     return f"""
 <div class="tabbed-story">
-  <p class="tabbed-canvas-kicker">Story</p>
-  <h2>{heading}</h2>
-  <div class="tabbed-story-quotes">{slide_html}</div>
+  <div class="tabbed-story-stack">{slide_html}</div>
   {_render_host_items(state, "story")}
 </div>
 """.strip()
@@ -656,10 +666,10 @@ def _render_host_guide(state: dict[str, Any]) -> str:
         str(item).strip() for item in guide.get("under_heard") or [] if str(item).strip()
     ][:5]
     if not where and not questions and not under_heard:
-        body = '<p class="tabbed-canvas-empty">The host guide is waiting for usable room receipts.</p>'
+        body = '<p class="tabbed-canvas-empty">Open questions are waiting for usable room receipts.</p>'
     else:
         where_html = (
-            f'<section class="tabbed-guide-block"><h3>Where the room is</h3><p>{html.escape(where)}</p></section>'
+            f'<p class="tabbed-open-orient">{html.escape(where)}</p>'
             if where
             else ""
         )
@@ -678,7 +688,7 @@ def _render_host_guide(state: dict[str, Any]) -> str:
         body = where_html + questions_html + under_heard_html
     return f"""
 <div class="tabbed-host-guide">
-  <p class="tabbed-canvas-kicker">Host guide</p>
+  <p class="tabbed-canvas-kicker">Open questions</p>
   {body}
 </div>
 """.strip()
@@ -796,6 +806,41 @@ def _tab_dom_id(tab: Any) -> str:
     return kind
 
 
+def _language_segment(language: Any) -> str:
+    mapping = {
+        "cs": "cs-CZ",
+        "cs-CZ": "cs-CZ",
+        "de": "de-DE",
+        "de-DE": "de-DE",
+        "en": "en-US",
+        "en-US": "en-US",
+        "es": "es-ES",
+        "es-ES": "es-ES",
+        "fr": "fr-FR",
+        "fr-FR": "fr-FR",
+        "it": "it-IT",
+        "it-IT": "it-IT",
+        "nl": "nl-NL",
+        "nl-NL": "nl-NL",
+        "uk": "uk-UA",
+        "uk-UA": "uk-UA",
+    }
+    return mapping.get(str(language or "").strip(), "en-US")
+
+
+def _new_tab_chat_href(project: dict[str, Any], *, report_name: str | None = None) -> str:
+    workspace_id = str(project.get("workspace_id") or "").strip()
+    project_id = str(project.get("id") or "").strip()
+    if not workspace_id or not project_id:
+        return "#"
+    canvas_name = str(report_name or project.get("report_name") or project.get("name") or "this").strip()
+    prefill = url_quote(f"I need a new tab in the {canvas_name} canvas: ", safe="")
+    lang = url_quote(_language_segment(project.get("language")), safe="")
+    workspace = url_quote(workspace_id, safe="")
+    project_path_id = url_quote(project_id, safe="")
+    return f"/{lang}/w/{workspace}/projects/{project_path_id}/chats/new?prefill={prefill}"
+
+
 def _normalize_ws(value: str) -> str:
     return " ".join(value.split())
 
@@ -861,7 +906,7 @@ _CSS = """
 .tabbed-canvas-radio{position:absolute;opacity:0;pointer-events:none}
 .tabbed-canvas-tabbar{display:flex;align-items:end;border-bottom:1px solid var(--hairline);gap:26px;margin:0 0 26px}
 .tabbed-canvas-tab{font-size:14.5px;font-weight:500;color:var(--ink-soft);border-bottom:2px solid transparent;padding:10px 2px;cursor:pointer}
-.tabbed-canvas-add{margin-left:auto;color:var(--royal);font-size:22px;line-height:1.6}
+.tabbed-canvas-add{margin-left:auto;color:var(--royal);font-size:22px;line-height:1.6;text-decoration:none}
 .tabbed-canvas-panel{display:none}
 #canvas-tab-crux:checked~.tabbed-canvas-tabbar label[for=canvas-tab-crux],
 #canvas-tab-concept_cloud:checked~.tabbed-canvas-tabbar label[for=canvas-tab-concept_cloud],
@@ -873,12 +918,18 @@ _CSS = """
 #canvas-tab-story:checked~[data-tab-panel=story],
 #canvas-tab-host_guide:checked~[data-tab-panel=host_guide],
 #canvas-tab-board_person:checked~[data-tab-panel=board_person]{display:block}
-.tabbed-crux,.tabbed-story{max-width:1000px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center}
+.tabbed-crux{max-width:1000px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center}
+.tabbed-story{max-width:1000px;margin:0 auto}
+.tabbed-story-stack{display:grid;gap:30px}
+.tabbed-story-slide{min-height:80vh;display:flex;flex-direction:column;justify-content:center;gap:24px}
+.tabbed-story-slide h3{max-width:900px;margin:0;font-size:clamp(32px,4.6vw,48px);font-weight:500;letter-spacing:-.015em;line-height:1.12;text-wrap:balance}
+.tabbed-story-evidence,.tabbed-story-slide .tabbed-slide-trace{max-width:620px}
 .tabbed-host-guide{max-width:840px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center;gap:16px}
 .tabbed-crux h1,.tabbed-story h2{max-width:900px;margin:0;font-weight:500;line-height:1.14;text-wrap:balance}
 .tabbed-crux h1{font-size:clamp(32px,4.6vw,48px)}
-.tabbed-story h2{font-size:clamp(24px,3.4vw,36px)}
+.tabbed-story h2{font-size:clamp(24px,3.4vw,36px);letter-spacing:-.01em}
 .tabbed-canvas-lede{max-width:620px;font-size:16px;line-height:1.45;color:var(--ink-soft)}
+.tabbed-canvas-lede b{color:var(--ink);font-weight:500}
 .tabbed-cloud{max-width:1060px;margin:0 auto;display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:center;padding:30px 0}
 .tabbed-concept{background:var(--card);border:1px solid var(--hairline);padding:12px 13px;animation:tabbedFloat 7s ease-in-out infinite}
 .tabbed-concept summary{list-style:none;cursor:pointer}
@@ -902,6 +953,7 @@ _CSS = """
 .tabbed-guide-block p{margin:0;color:var(--ink-soft);line-height:1.45}
 .tabbed-guide-block ol,.tabbed-guide-block ul{margin:0;padding-left:20px;color:var(--ink-soft);line-height:1.45}
 .tabbed-guide-block li+li{margin-top:8px}
+.tabbed-open-orient{margin:0;color:var(--ink-soft);font-size:16px;line-height:1.45;max-width:620px}
 .tabbed-board{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:9px;align-items:stretch}
 .tabbed-board-card{background:var(--card);border:1px solid var(--hairline);padding:12px 13px;min-height:150px;display:flex;flex-direction:column;gap:8px}
 .tabbed-board-card h3{margin:0;font-size:14px;font-weight:700;line-height:1.2;color:var(--ink)}
@@ -913,5 +965,5 @@ _CSS = """
 @keyframes tabbedFloat{0%,100%{translate:0 0}50%{translate:0 -5px}}
 @media (prefers-reduced-motion:reduce){.tabbed-concept{animation:none}}
 @media (max-width:1100px){.tabbed-board{grid-template-columns:repeat(3,minmax(0,1fr))}}
-@media (max-width:720px){.tabbed-canvas-frame{padding:14px 14px 60px}.tabbed-canvas-tabbar{gap:16px}.tabbed-crux,.tabbed-story,.tabbed-host-guide{min-height:58vh}.tabbed-board{grid-template-columns:1fr}}
+@media (max-width:720px){.tabbed-canvas-frame{padding:14px 14px 60px}.tabbed-canvas-tabbar{gap:16px}.tabbed-crux,.tabbed-story-slide,.tabbed-host-guide{min-height:58vh}.tabbed-board{grid-template-columns:1fr}}
 """

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -145,7 +145,7 @@ def _generation_detail(
             f"{ledger_detail.get('concepts_changed', 0)} concept change(s), "
             f"crux {'changed' if ledger_detail.get('crux_changed') else 'unchanged'}, "
             f"story {'changed' if ledger_detail.get('story_changed') else 'unchanged'}, "
-            f"host guide {'changed' if ledger_detail.get('host_guide_changed') else 'unchanged'}, "
+            f"open questions {'changed' if ledger_detail.get('host_guide_changed') else 'unchanged'}, "
             f"board {'changed' if ledger_detail.get('board_changed') else 'unchanged'}"
         )
         removed = ledger_detail.get("concepts_removed") or []
@@ -220,13 +220,13 @@ If enabled_tabs does not include a board tab, omit board_cards.
 """
 
 HOST_GUIDE_SYSTEM_PROMPT = """
-You write the Host guide tab for a dembrane living canvas. Return JSON only.
+You write the Open questions tab for a dembrane living canvas. Return JSON only.
 
 Grounding rules:
 - Use ONLY the brief, current ledgers, and recent run activity provided by the user.
 - Do not invent facts, names, conflict, consensus, or absent voices.
-- Keep "where_the_room_is" to 2-3 sentences.
-- Give 2-3 concrete questions the host can say out loud.
+- Keep "where_the_room_is" to one short orienting line.
+- Give 2-3 concrete parked questions or next questions the host can say out loud.
 - Use "under_heard" only for voices or threads with few or no receipts in the
   ledger attribution. If there is not enough evidence, return an empty array.
 
@@ -359,12 +359,14 @@ async def _generate_html(
     previous_html: str | None,
     gather_bundle: dict[str, Any],
     living_state: dict[str, Any] | None = None,
+    report_name: str | None = None,
 ) -> str:
     if living_state is not None:
         return render_tabbed_canvas(
             state=living_state,
             project=gather_bundle.get("project") or {},
             sample_notice=gather_bundle.get("sample_notice"),
+            report_name=report_name,
         )
 
     project = gather_bundle.get("project") or {}
@@ -799,7 +801,7 @@ async def _merge_extraction_for_tick(
             living_state["host_guide"] = host_guide
             combined_detail["host_guide_changed"] = True
     except Exception as exc:
-        combined_detail["rejections"].append(f"host guide model error: {exc}")
+        combined_detail["rejections"].append(f"open questions model error: {exc}")
     return living_state, combined_detail
 
 
@@ -925,7 +927,7 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
                     living_state["host_guide"] = host_guide
                     ledger_detail["host_guide_changed"] = True
             except Exception as exc:
-                ledger_detail["rejections"].append(f"host guide model error: {exc}")
+                ledger_detail["rejections"].append(f"open questions model error: {exc}")
         ledger_detail["rejections"].extend(
             _shape_warnings(str(config.get("brief") or ""), living_state["tabs"])
         )
@@ -958,6 +960,7 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
             previous_html=(latest_ok or {}).get("content_html"),
             gather_bundle=gather_bundle,
             living_state=living_state,
+            report_name=str(loop.get("name") or config.get("name") or "Canvas"),
         )
         sanitized = sanitize_canvas_html(raw_html, max_bytes=get_settings().canvas.max_html_bytes)
         banned_copy = _banned_visible_copy(sanitized.html)

--- a/echo/server/tests/test_canvas_gather.py
+++ b/echo/server/tests/test_canvas_gather.py
@@ -12,6 +12,7 @@ class _FakeDirectus:
         return {
             "id": item_id,
             "name": "Panel day",
+            "workspace_id": "workspace-1",
             "context": "Testing context",
             "language": "en",
             "anonymize_transcripts": True,
@@ -41,6 +42,7 @@ class _EmptyDirectus:
         return {
             "id": item_id,
             "name": "Panel day",
+            "workspace_id": "workspace-1",
             "context": "Testing context",
             "language": "en",
             "anonymize_transcripts": False,
@@ -84,6 +86,7 @@ async def test_gather_verifies_reader_and_caps_transcript(monkeypatch) -> None:
 
     assert calls == [{"acting_directus_user_id": "du1", "project_id": "p1"}]
     assert bundle["project"]["name"] == "Panel day"
+    assert bundle["project"]["workspace_id"] == "workspace-1"
     assert bundle["project"]["goal"] == "Surface practical concerns."
     assert bundle["conversations"][0]["latest_transcript"] == "aaaaaaaaaa\n[truncated]"
     assert bundle["counts"]["truncated_conversations"] == 1

--- a/echo/server/tests/test_canvas_ledgers.py
+++ b/echo/server/tests/test_canvas_ledgers.py
@@ -182,11 +182,21 @@ def test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items() ->
     )
     state = append_host_item(state, item)
 
-    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+    html = render_tabbed_canvas(
+        state=state,
+        project={"id": "project-1", "workspace_id": "workspace-1", "name": "Room", "language": "en"},
+        report_name="13th Week Retrospective Wall",
+    )
 
     assert 'type="radio"' in html
     assert 'for="canvas-tab-crux"' in html
     assert 'for="canvas-tab-host_guide"' in html
+    assert ">Open questions</label>" in html
+    assert (
+        'href="/en-US/w/workspace-1/projects/project-1/chats/new?prefill='
+        "I%20need%20a%20new%20tab%20in%20the%2013th%20Week%20Retrospective%20Wall%20canvas%3A%20"
+        '" target="_top"'
+    ) in html
     assert "tabbed-traceable" in html
     assert "Host says: hold this exact reflection." in html
 
@@ -204,11 +214,34 @@ def test_render_tabbed_canvas_includes_persisted_host_guide() -> None:
 
     html = render_tabbed_canvas(state=state, project={"name": "Room"})
 
-    assert "Host guide" in html
-    assert "Where the room is" in html
+    assert "Open questions" in html
+    assert "Host guide" not in html
+    assert "Where the room is" not in html
     assert "What would make this safe to try tomorrow?" in html
     assert "No receipts yet from operations." in html
     assert state_patch(state)["canvas_host_guide"]["where_the_room_is"].startswith("The room")
+
+
+def test_story_slides_use_full_screen_spacing_hooks() -> None:
+    state = fresh_canvas_state(
+        {
+            "canvas_story_slides": [
+                {
+                    "eyebrow": "Signal",
+                    "heading": "The doorway matters",
+                    "lede": "People want the doorway open.",
+                    "quote_ids": [],
+                }
+            ]
+        }
+    )
+
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert 'class="tabbed-story-stack"' in html
+    assert 'class="tabbed-story-slide"' in html
+    assert "min-height:80vh" in html
+    assert "font-size:clamp(32px,4.6vw,48px)" in html
 
 
 def test_board_renders_from_attributed_quotes() -> None:

--- a/echo/server/tests/test_canvas_sanitize.py
+++ b/echo/server/tests/test_canvas_sanitize.py
@@ -85,3 +85,20 @@ def test_sanitize_preserves_css_only_tabs_and_trace_expansion() -> None:
     assert "<details" in result.html
     assert "<summary>" in result.html
     assert "tabbed-traceable" in result.html
+
+
+def test_sanitize_preserves_relative_chat_prefill_anchor_target() -> None:
+    result = sanitize_canvas_html(
+        """
+        <div class="canvas-shell tabbed-canvas">
+          <a class="tabbed-canvas-add"
+             href="/en-US/w/workspace-1/projects/project-1/chats/new?prefill=I%20need%20a%20new%20tab%3A%20"
+             target="_top">+</a>
+        </div>
+        """,
+        max_bytes=2000,
+    )
+
+    assert "/en-US/w/workspace-1/projects/project-1/chats/new?prefill=" in result.html
+    assert 'target="_top"' in result.html
+    assert result.stripped_references == 0

--- a/echo/server/tests/test_canvas_ticks.py
+++ b/echo/server/tests/test_canvas_ticks.py
@@ -303,7 +303,7 @@ async def test_tick_uses_model_extraction_and_records_receipt_rejections(monkeyp
     assert "Keep the doorway open." in generation["content_html"]
     assert "not found verbatim" in generation["detail"]
     assert "no accepted supporting quote" in generation["detail"]
-    assert "Host guide" in generation["content_html"]
+    assert "Open questions" in generation["content_html"]
     assert fake.items["agent_loop"]["loop1"]["canvas_host_guide"]["where_the_room_is"]
 
 


### PR DESCRIPTION
Owner feedback from the live wall this morning:

- **Host guide → Open questions**: visible label + copy renamed (the content was open questions; the internal `canvas_host_guide` field stays to avoid migration churn, split documented). Prompt now leans into parked questions + what to ask next
- **Story spacing per the handoff**: each slide a centered 80vh screen, one kicker max, display heading `clamp(32px, 4.6vw, 48px)`, 620px lede, handoff spacing tiers swept across tabs
- **The + becomes a door**: tab-bar + links (`target=_top`) to `/chats/new?prefill="I need a new tab in the {report} canvas: "` — pairs with the `?prefill=` route from #835; sanitizer round-trip tested
- Rides along: the agentic-tick design note (`docs/plans/canvas-agentic-tick.md`) and the refined audit-entry grammar in the 28g brief

Gates: server ruff + 51 canvas tests, agent 103. Report: `wave28f-REPORT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)