### PR TITLE
Canvas: Trace as a destination, Audit log tab, readCanvasHistory

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -295,6 +295,10 @@ tabs=[{"kind":"crux"},{"kind":"concept_cloud"},{"kind":"board","grouping":"perso
 If the host asks for a structural view no primitive supports, say that plainly,
 quietly call recordInsight with category capability_gap, and do not promise the
 loop will rebuild into that shape.
+When the host asks why a canvas changed, what it heard, what it left out, or
+who/what caused a canvas update, call readCanvasHistory and answer only from
+that history. If you make a review judgment about confusing history, missing
+receipts, or a weak canvas audit trail, quietly call recordInsight.
 After proposing a canvas, do not ask the host to tell you when it is applied.
 The chat records that automatically.
 When you propose a canvas or an update, the proposal card appears RIGHT HERE in
@@ -1556,6 +1560,30 @@ def create_agent_graph(
         return {"canvases": canvases}
 
     @tool
+    async def readCanvasHistory(canvas: str, limit: int = 30) -> dict[str, Any]:
+        """Read a canvas audit history by id or unique canvas name/reference.
+
+        Use this before answering why a canvas changed, what it heard, what it
+        kept out, or which chat/run caused a canvas update. Answer from the
+        returned history only.
+        """
+        resolved_canvas_id, resolved_name = await _resolve_canvas_id(canvas)
+        client = _create_echo_client()
+        try:
+            payload = await client.get_canvas_history(
+                project_id,
+                resolved_canvas_id,
+                limit=max(1, min(limit, 100)),
+            )
+        finally:
+            await client.close()
+        return {
+            "canvas_id": resolved_canvas_id,
+            "canvas_name": resolved_name or payload.get("name"),
+            "history": payload.get("history") if isinstance(payload.get("history"), list) else [],
+        }
+
+    @tool
     async def editCanvas(canvas: str, instruction: str, edited_html: str = "") -> dict[str, Any]:
         """Directly edit the latest generated HTML for a small canvas presentation
         or wording change. `canvas` may be an id or unique canvas name/reference.
@@ -1804,6 +1832,7 @@ def create_agent_graph(
         proposeGoal,
         listMethodologies,
         listCanvases,
+        readCanvasHistory,
         editCanvas,
         addToCanvas,
         removeFromCanvas,

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -196,6 +196,20 @@ class EchoClient:
         payload = await self.get(f"/agentic/projects/{project_id}/canvases/{canvas_id}")
         return payload if isinstance(payload, dict) else {}
 
+    async def get_canvas_history(
+        self,
+        project_id: str,
+        canvas_id: str,
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        response = await self._client.get(
+            f"/agentic/projects/{project_id}/canvases/{canvas_id}/history",
+            params={"limit": max(1, min(limit, 100))},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
     async def edit_canvas(
         self,
         project_id: str,

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -36,6 +36,7 @@ class _FakeEchoClient:
         methodologies_payload: dict | None = None,
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
+        canvas_history_response: dict | None = None,
         canvas_loop_response: dict | None = None,
         canvas_host_item_response: dict | None = None,
         canvas_remove_item_response: dict | None = None,
@@ -65,6 +66,7 @@ class _FakeEchoClient:
         self.methodologies_payload = methodologies_payload or {}
         self.project_tags_payload = project_tags_payload or []
         self.canvases_payload = canvases_payload or []
+        self.canvas_history_response = canvas_history_response or {"history": []}
         self.canvas_loop_response = canvas_loop_response or {}
         self.canvas_host_item_response = canvas_host_item_response or {"status": "added"}
         self.canvas_remove_item_response = canvas_remove_item_response or {"status": "removed"}
@@ -77,6 +79,7 @@ class _FakeEchoClient:
         self.list_methodologies_calls: list[str] = []
         self.list_project_tags_calls: list[str] = []
         self.list_canvases_calls: list[str] = []
+        self.canvas_history_calls: list[dict[str, object]] = []
         self.canvas_loop_calls: list[dict[str, str]] = []
         self.canvas_host_item_calls: list[dict[str, object]] = []
         self.canvas_remove_item_calls: list[dict[str, object]] = []
@@ -205,6 +208,12 @@ class _FakeEchoClient:
         self.list_canvases_calls.append(project_id)
         return self.canvases_payload
 
+    async def get_canvas_history(self, project_id: str, canvas_id: str, limit: int = 30) -> dict:
+        self.canvas_history_calls.append(
+            {"project_id": project_id, "canvas_id": canvas_id, "limit": limit}
+        )
+        return self.canvas_history_response
+
     async def update_canvas_loop(
         self,
         project_id: str,
@@ -298,6 +307,7 @@ class _FakeEchoClientFactory:
         methodologies_payload: dict | None = None,
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
+        canvas_history_response: dict | None = None,
         canvas_loop_response: dict | None = None,
         canvas_host_item_response: dict | None = None,
         canvas_remove_item_response: dict | None = None,
@@ -319,6 +329,7 @@ class _FakeEchoClientFactory:
         self.methodologies_payload = methodologies_payload
         self.project_tags_payload = project_tags_payload
         self.canvases_payload = canvases_payload
+        self.canvas_history_response = canvas_history_response
         self.canvas_loop_response = canvas_loop_response
         self.canvas_host_item_response = canvas_host_item_response
         self.canvas_remove_item_response = canvas_remove_item_response
@@ -342,6 +353,7 @@ class _FakeEchoClientFactory:
             methodologies_payload=self.methodologies_payload,
             project_tags_payload=self.project_tags_payload,
             canvases_payload=self.canvases_payload,
+            canvas_history_response=self.canvas_history_response,
             canvas_loop_response=self.canvas_loop_response,
             canvas_host_item_response=self.canvas_host_item_response,
             canvas_remove_item_response=self.canvas_remove_item_response,
@@ -1590,6 +1602,45 @@ async def test_list_canvases_returns_project_canvases():
     assert result["canvases"][0]["id"] == "canvas-1"
     assert factory.instances[0].list_canvases_calls == ["project-1"]
     assert factory.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_read_canvas_history_resolves_canvas_and_returns_entries():
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        canvases_payload=[{"id": "canvas-1", "name": "Pulse wall", "kind": "canvas"}],
+        canvas_history_response={
+            "id": "canvas-1",
+            "name": "Pulse wall",
+            "history": [
+                {
+                    "at": "2026-07-09T12:00:00Z",
+                    "kind": "run",
+                    "changes": ["added doorway open"],
+                }
+            ],
+        },
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["readCanvasHistory"].ainvoke({"canvas": "pulse", "limit": 7})
+
+    assert result["canvas_id"] == "canvas-1"
+    assert result["canvas_name"] == "Pulse wall"
+    assert result["history"][0]["changes"] == ["added doorway open"]
+    assert factory.instances[0].list_canvases_calls == ["project-1"]
+    assert factory.instances[1].canvas_history_calls == [
+        {"project_id": "project-1", "canvas_id": "canvas-1", "limit": 7}
+    ]
 
 
 @pytest.mark.asyncio

--- a/echo/agent/tests/test_echo_client.py
+++ b/echo/agent/tests/test_echo_client.py
@@ -137,6 +137,16 @@ class _FakeAsyncClient:
                     ],
                 },
             )
+        if path == "/agentic/projects/project-1/canvases/canvas-1/history":
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                json={
+                    "id": "canvas-1",
+                    "name": "Pulse wall",
+                    "history": [{"kind": "run", "changes": ["added doorway open"]}],
+                },
+            )
         if path.startswith("/agentic/projects/") and path.endswith("/canvases"):
             return httpx.Response(
                 status_code=200,
@@ -294,6 +304,21 @@ async def test_list_chat_canvas_activity_uses_expected_path_and_limit(monkeypatc
         == "/agentic/projects/project-1/chats/chat-1/canvas-activity"
     )
     assert client._client.calls[0]["params"] == {"limit": 5}
+
+
+@pytest.mark.asyncio
+async def test_get_canvas_history_uses_expected_path_and_limit(monkeypatch):
+    monkeypatch.setattr("echo_client.httpx.AsyncClient", _FakeAsyncClient)
+
+    client = EchoClient(bearer_token="token-1")
+    payload = await client.get_canvas_history("project-1", "canvas-1", limit=9)
+
+    assert payload["history"][0]["changes"] == ["added doorway open"]
+    assert (
+        client._client.calls[0]["path"]
+        == "/agentic/projects/project-1/canvases/canvas-1/history"
+    )
+    assert client._client.calls[0]["params"] == {"limit": 9}
 
 
 @pytest.mark.asyncio

--- a/echo/docs/plans/smart-loop-briefs/wave28g-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28g-REPORT.md
@@ -1,0 +1,35 @@
+# Wave 28g Report
+
+## Summary
+
+Implemented Trace as an anchor-addressable canvas destination, added an Audit log tab backed by shared canvas history objects, and exposed the same history through the agent-facing `readCanvasHistory` tool.
+
+## Implementation
+
+- Added `trace` and `audit` canvas tab kinds and default tabs.
+- Kept radio-tab fallback markup while adding CSS `:has()` / `:target` routing for `#tab-*` tabs and `#trace-*` claim anchors.
+- Built Trace entries from concept, story, and board claims with stable claim/quote-id hashes.
+- Kept inline `<details>` receipt fallbacks while making traceable claim labels link to the Trace destination.
+- Added Audit log accordions with the refined `HH:MM · outcome — cause · links` summary grammar and expanded heard / added-updated / kept-out / cause / view-version sections.
+- Added `echo/server/dembrane/canvas/history.py` so stored canvas HTML and the agent endpoint read the same normalized `{at, kind, version, cause, heard, changes, kept_out}` history objects.
+- Populated Audit entries during living canvas HTML generation.
+- Fix-back: made `build_canvas_history` accept an injected Directus client and made tick rendering pass `ticks.async_directus`, preserving the existing tick test contract and preventing non-test tick rendering from bypassing the active Directus seam.
+- Added `GET /agentic/projects/{project_id}/canvases/{canvas_id}/history` with the same agent token, project access, and canvas ownership checks as the existing canvas endpoints.
+- Added `EchoClient.get_canvas_history` and the `readCanvasHistory` agent tool with canvas id/name resolution.
+- Updated the agent prompt to require `readCanvasHistory` for canvas history/change/cause questions and `recordInsight` for review judgments.
+
+## Gates
+
+- Server ruff:
+  `cd echo/server && uv run ruff check dembrane/canvas/ledgers.py dembrane/canvas/history.py dembrane/canvas/ticks.py dembrane/api/agentic.py tests/test_canvas_ledgers.py tests/test_canvas_history.py tests/test_canvas_ticks.py tests/test_canvas_sanitize.py tests/test_canvas_gather.py tests/test_canvas_service.py tests/api/test_bff_canvases.py tests/api/test_agentic_api.py`
+- Full requested canvas pytest, with local dummy settings required for test collection:
+  `cd echo/server && DIRECTUS_SECRET=test DIRECTUS_TOKEN=test DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/test REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=test STORAGE_S3_ENDPOINT=http://localhost:9000 STORAGE_S3_KEY=test STORAGE_S3_SECRET=test uv run pytest -q tests/test_canvas_ledgers.py tests/test_canvas_history.py tests/test_canvas_ticks.py tests/test_canvas_sanitize.py tests/test_canvas_gather.py tests/test_canvas_service.py tests/api/test_bff_canvases.py tests/api/test_agentic_api.py`
+  Result: 88 passed, 2 warnings.
+- Fix-back reproduction before the Directus seam fix produced the 8 expected `tests/test_canvas_ticks.py` failures; the targeted rerun of those 8 tests passed after the fix.
+- Sanitizer round-trip coverage is in `tests/test_canvas_ledgers.py::test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items`.
+- Endpoint shape/auth coverage is in `tests/api/test_agentic_api.py::test_agentic_canvas_history_returns_shared_history`.
+- Agent:
+  `cd echo/agent && uv run pytest -q`
+  Result: 105 passed, 4 warnings.
+
+All listed gates passed. Frontend was untouched per the brief.

--- a/echo/docs/plans/smart-loop-briefs/wave28h-cloud-scatter.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28h-cloud-scatter.md
@@ -1,0 +1,47 @@
+# Brief: Wave 28h — the cloud scatters like a room, not a spreadsheet
+
+Start AFTER the 28g fix-back is merged: `git fetch origin && git checkout
+-b sameer/cloud-scatter origin/main` (verify the 28g/trace-audit work is
+in main; if not, report and stop).
+
+Owner evidence: side-by-side with the reference wall (Oren's), our
+concept cloud reads mechanical. Three concrete causes in
+_render_cloud/_concept_tile CSS:
+
+1. Rotation is binary: exactly -1.2deg or +1.2deg alternating by index.
+2. Float is in unison: one shared `tabbedFloat 7s` with no per-tile
+   delay or duration variance ("off phase AND different velocity per
+   tile" is the owners' explicit ask from 2026-07-08).
+3. Order is strictly size-sorted, so XL tiles clump at the top instead
+   of being distributed through the flow.
+
+## The fix: deterministic per-tile randomness
+
+Derive per-tile values from a STABLE hash of the concept id (never
+random(), never time-based — a tile must keep its personality across
+re-renders and ticks):
+
+- rotation: continuous in [-1.2, +1.2] deg
+- float delay: [0, 7)s; float duration: [6, 9]s
+- tiny translate offsets / margin variance within handoff spacing tiers
+- ordering: deterministic hash-shuffle of the ~20 tiles with a
+  constraint that the 3 XL tiles are spread (no two XL adjacent);
+  size tiers keep their font-size classes (12px -> clamp(24px, 2.8vw,
+  34px) per the handoff)
+
+Implementation: inline per-tile style attributes (or generated CSS
+classes) computed in Python at render time. Must survive the sanitizer
+(round-trip test — style attributes with transform/animation-delay may
+need the sanitizer allowlist extended narrowly; keep it to the exact
+properties needed). `prefers-reduced-motion: reduce` still kills all
+animation.
+
+## QA gates
+
+- Unit tests: same ledger state renders IDENTICAL html across two calls
+  (determinism); different concept ids get different rotations/delays;
+  no two XL adjacent in the rendered order; sanitizer round-trip keeps
+  the style attributes.
+- cd echo/server && uv run ruff check . ; FULL canvas pytest suite (all
+  test_canvas_*.py + bff + agentic api).
+- Report -> echo/docs/plans/smart-loop-briefs/wave28h-REPORT.md.

--- a/echo/docs/plans/smart-loop-briefs/wave34-voice-floor.md
+++ b/echo/docs/plans/smart-loop-briefs/wave34-voice-floor.md
@@ -1,0 +1,53 @@
+# Brief: Wave 34 — the voice floor: selectivity applies to material, never to voices
+
+Start AFTER 28h is merged: `git fetch origin && git checkout -b
+sameer/voice-floor origin/main` (verify the cloud-scatter work is in
+main; if not, report and stop).
+
+## The invariant (owner decision, 2026-07-09)
+
+Live failure it prevents: the first backfill of the 13th-week wall
+extracted 5 quotes, ALL from one conversation; Usama (remote, quieter
+audio, distinct accent) contributed zero receipts and vanished from the
+wall silently. The extraction rule "only what does real work" is right
+for content and wrong for people.
+
+The invariant, enforced in CODE after extraction, never left to the
+model: every voice with words in the gathered transcript ends the tick
+either (a) with at least one accepted receipt, or (b) named in the
+under-heard block of the Open questions tab, with the honest reason.
+No third state. A voice is never silently absent.
+
+## Implementation (echo/server/dembrane/canvas/)
+
+1. Voice inventory at gather time: per conversation, the set of speaker
+   labels present (attribution data already flows for board cards; where
+   the transcript has no speaker attribution, the conversation itself is
+   the "voice" — its participant_name/label).
+2. Post-extraction coverage check in the tick: voices with material in
+   THIS tick's gathered window but zero accepted receipts overall ->
+   ONE targeted second extraction pass, scoped to only that voice's
+   passages (filter chunks/segments by speaker where attribution exists,
+   else the whole conversation), with a prompt that says: this voice has
+   no receipts on the wall yet; extract their strongest 1-3 verbatim
+   passages if ANY passes the receipts bar. Budget: one extra model call
+   per uncovered voice per tick, max 3 per tick (record when the cap
+   truncates).
+3. Still nothing? The voice lands in under-heard (Open questions tab)
+   with the reason: "no receipt-quality passage yet" — and the run
+   detail records it ("voice floor: Usama -> under-heard").
+4. Board grouping "person": a voice with receipts but no board card gets
+   its card on the next render (verify this already holds; test it).
+5. Run/generation detail gains a voices line:
+   "voices: 6 heard, 1 under-heard (Usama)".
+
+## QA gates
+
+- Tests: uncovered voice triggers exactly one targeted pass; covered
+  voices trigger none; still-uncovered voice renders in under-heard AND
+  run detail; cap at 3 targeted passes recorded honestly; no-attribution
+  conversations use the conversation label as the voice.
+- cd echo/server && uv run ruff check . ; FULL canvas pytest suite (all
+  test_canvas_*.py + tests/api/test_bff_canvases.py +
+  tests/api/test_agentic_api.py).
+- Report -> echo/docs/plans/smart-loop-briefs/wave34-REPORT.md.

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -26,6 +26,7 @@ from dembrane.agentic_worker import (
     AGENT_CANCELLED_ERROR_CODE,
     process_agentic_run,
 )
+from dembrane.canvas.history import build_canvas_history
 from dembrane.canvas.service import (
     apply_loop_action,
     get_latest_config,
@@ -1507,6 +1508,25 @@ async def get_project_canvas(
         "loop": _loop_payload(loop) if loop else None,
         "latest_config": config,
         "latest_generation": generation,
+    }
+
+
+@AgenticRouter.get("/projects/{project_id}/canvases/{canvas_id}/history")
+async def get_project_canvas_history(
+    project_id: str,
+    canvas_id: str,
+    auth: DependencyDirectusSession,
+    limit: int = Query(default=30, ge=1),
+) -> dict[str, Any]:
+    _require_agent_token(auth)
+    await _assert_project_access(project_id, auth)
+    report = await _get_project_canvas_or_404(project_id, canvas_id)
+    entries = await build_canvas_history(canvas_id, limit=min(limit, 100))
+    loop = await get_loop_for_report(canvas_id)
+    return {
+        "id": canvas_id,
+        "name": (loop or {}).get("name") or report.get("user_instructions") or "Canvas",
+        "history": entries,
     }
 
 

--- a/echo/server/dembrane/canvas/history.py
+++ b/echo/server/dembrane/canvas/history.py
@@ -1,0 +1,212 @@
+"""Canvas history objects shared by the Audit tab and agent tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dembrane.canvas.ledgers import fresh_canvas_state
+from dembrane.directus_async import async_directus
+
+
+def _as_id(value: Any) -> str | None:
+    if isinstance(value, dict):
+        value = value.get("id")
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _rows(value: Any) -> list[dict[str, Any]]:
+    return [row for row in value if isinstance(row, dict)] if isinstance(value, list) else []
+
+
+async def _get_rows(
+    collection: str,
+    query: dict[str, Any],
+    *,
+    directus_client: Any,
+) -> list[dict[str, Any]]:
+    rows = await directus_client.get_items(collection, {"query": query})
+    return _rows(rows)
+
+
+def _cause(
+    *,
+    cause_type: str,
+    chat_id: Any = None,
+    message_id: Any = None,
+    run_chat_id: Any = None,
+) -> dict[str, str | None]:
+    return {
+        "type": cause_type,
+        "chat_id": _as_id(chat_id),
+        "message_id": _as_id(message_id),
+        "run_chat_id": _as_id(run_chat_id),
+    }
+
+
+def _detail_items(detail: Any) -> list[str]:
+    text = str(detail or "").strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(";") if part.strip()] or [text]
+
+
+def _version_map(generations: list[dict[str, Any]]) -> dict[str, int]:
+    ok_generations = sorted(
+        [row for row in generations if str(row.get("status") or "") == "ok"],
+        key=lambda row: str(row.get("created_at") or ""),
+    )
+    return {
+        str(row["id"]): index + 1
+        for index, row in enumerate(ok_generations)
+        if str(row.get("id") or "").strip()
+    }
+
+
+async def build_canvas_history(
+    report_id: str,
+    *,
+    limit: int = 30,
+    directus_client: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Return normalized audit entries for a canvas report.
+
+    The object shape is intentionally renderer-friendly and agent-friendly:
+    {at, kind, version, cause, heard, changes, kept_out}. Rows are newest first.
+    """
+    capped_limit = max(1, min(limit, 100))
+    client = directus_client or async_directus
+    loop_rows = await _get_rows(
+        "agent_loop",
+        {
+            "filter": {"report_id": {"_eq": report_id}},
+            "fields": ["*"],
+            "sort": ["-created_at"],
+            "limit": 1,
+        },
+        directus_client=client,
+    )
+    loop = loop_rows[0] if loop_rows else {}
+    loop_id = _as_id(loop.get("id"))
+    run_chat_id = _as_id(loop.get("created_from_chat_id"))
+
+    generations = await _get_rows(
+        "canvas_generation",
+        {
+            "filter": {"report_id": {"_eq": report_id}},
+            "fields": ["*"],
+            "sort": ["-created_at"],
+            "limit": capped_limit,
+        },
+        directus_client=client,
+    )
+    generation_versions = _version_map(generations)
+    generation_by_id = {str(row.get("id")): row for row in generations if row.get("id")}
+
+    runs: list[dict[str, Any]] = []
+    if loop_id:
+        runs = await _get_rows(
+            "agent_loop_run",
+            {
+                "filter": {"loop_id": {"_eq": loop_id}},
+                "fields": ["*"],
+                "sort": ["-started_at"],
+                "limit": capped_limit,
+            },
+            directus_client=client,
+        )
+
+    config_revisions = await _get_rows(
+        "canvas_config_revision",
+        {
+            "filter": {"report_id": {"_eq": report_id}},
+            "fields": ["*"],
+            "sort": ["-created_at"],
+            "limit": min(capped_limit, 20),
+        },
+        directus_client=client,
+    )
+
+    entries: list[dict[str, Any]] = []
+    seen_generation_ids: set[str] = set()
+    for run in runs:
+        generation_id = _as_id(run.get("generation_id"))
+        generation = generation_by_id.get(generation_id or "")
+        if generation_id:
+            seen_generation_ids.add(generation_id)
+        status = str(run.get("status") or "").strip()
+        no_change = status == "no_op" or not generation_id
+        kind = "no change" if no_change else "run"
+        detail_items = _detail_items(run.get("detail"))
+        changes = ["no change — nothing new heard"] if no_change else detail_items
+        entries.append(
+            {
+                "at": run.get("started_at") or run.get("created_at"),
+                "kind": kind,
+                "version": generation_versions.get(generation_id or ""),
+                "cause": _cause(cause_type=str(generation.get("tick_kind") or "canvas_loop") if generation else "canvas_loop", run_chat_id=run_chat_id),
+                "heard": detail_items if not no_change else [],
+                "changes": changes,
+                "kept_out": [item for item in detail_items if "rejected" in item.lower() or "kept out" in item.lower()],
+            }
+        )
+
+    for generation in generations:
+        generation_id = _as_id(generation.get("id"))
+        if not generation_id or generation_id in seen_generation_ids:
+            continue
+        detail_items = _detail_items(generation.get("detail"))
+        entries.append(
+            {
+                "at": generation.get("created_at"),
+                "kind": "generation",
+                "version": generation_versions.get(generation_id),
+                "cause": _cause(cause_type=str(generation.get("tick_kind") or "generation"), run_chat_id=run_chat_id),
+                "heard": detail_items,
+                "changes": detail_items,
+                "kept_out": [item for item in detail_items if "rejected" in item.lower() or "kept out" in item.lower()],
+            }
+        )
+
+    for revision in config_revisions:
+        entries.append(
+            {
+                "at": revision.get("created_at"),
+                "kind": "config revision",
+                "version": None,
+                "cause": _cause(
+                    cause_type=str(revision.get("note") or "brief update"),
+                    chat_id=revision.get("chat_id") or revision.get("applied_from_chat_id"),
+                    run_chat_id=run_chat_id,
+                ),
+                "heard": [],
+                "changes": [str(revision.get("brief") or "").strip()[:220]]
+                if str(revision.get("brief") or "").strip()
+                else [],
+                "kept_out": [],
+            }
+        )
+
+    state = fresh_canvas_state(loop)
+    for item in state.get("host_items") or []:
+        if not isinstance(item, dict):
+            continue
+        removed = bool(item.get("removed_at"))
+        entries.append(
+            {
+                "at": item.get("removed_at") or item.get("added_at"),
+                "kind": "host item removed" if removed else "host item added",
+                "version": None,
+                "cause": _cause(
+                    cause_type="host",
+                    chat_id=item.get("chat_id"),
+                    message_id=item.get("message_id"),
+                    run_chat_id=run_chat_id,
+                ),
+                "heard": [str(item.get("text") or "").strip()] if not removed else [],
+                "changes": [str(item.get("text") or "").strip()],
+                "kept_out": [str(item.get("text") or "").strip()] if removed else [],
+            }
+        )
+
+    return sorted(entries, key=lambda entry: str(entry.get("at") or ""), reverse=True)[:capped_limit]

--- a/echo/server/dembrane/canvas/ledgers.py
+++ b/echo/server/dembrane/canvas/ledgers.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import html
+import hashlib
 from typing import Any
 from datetime import datetime, timezone
 from urllib.parse import quote as url_quote
 
 from dembrane.utils import generate_uuid
 
-CANVAS_TAB_SET_V1 = ("crux", "concept_cloud", "story", "host_guide")
-CANVAS_SUPPORTED_TAB_KINDS = ("crux", "concept_cloud", "story", "host_guide", "board")
+CANVAS_TAB_SET_V1 = ("crux", "concept_cloud", "story", "host_guide", "trace", "audit")
+CANVAS_SUPPORTED_TAB_KINDS = (
+    "crux",
+    "concept_cloud",
+    "story",
+    "host_guide",
+    "board",
+    "trace",
+    "audit",
+)
 CANVAS_TAB_LABELS = {
     "crux": "Crux",
     "concept_cloud": "Concept cloud",
@@ -19,6 +28,8 @@ CANVAS_TAB_LABELS = {
     # the host-visible tab label is renamed.
     "host_guide": "Open questions",
     "board": "Board",
+    "trace": "Trace",
+    "audit": "Audit log",
 }
 HOST_TARGET_TABS = {"crux", "concept_cloud", "story"}
 
@@ -40,6 +51,7 @@ def fresh_canvas_state(loop: dict[str, Any] | None = None) -> dict[str, Any]:
         "story_slides": _list(loop.get("story_slides") or loop.get("canvas_story_slides")),
         "host_guide": _dict(loop.get("host_guide") or loop.get("canvas_host_guide")),
         "board_cards": _list(loop.get("board_cards") or loop.get("canvas_board_cards")),
+        "audit_entries": _list(loop.get("audit_entries") or loop.get("canvas_audit_entries")),
     }
 
 
@@ -99,6 +111,9 @@ def _normalize_tab_kind(value: Any) -> str | None:
         "concepts_cloud": "concept_cloud",
         "host": "host_guide",
         "guide": "host_guide",
+        "history": "audit",
+        "audit_log": "audit",
+        "log": "audit",
         "person_board": "board",
         "people": "board",
         "per_person": "board",
@@ -552,7 +567,8 @@ def render_tabbed_canvas(
         for index, tab in enumerate(tabs)
     )
     labels = "\n".join(
-        f'<label class="tabbed-canvas-tab" for="canvas-tab-{_tab_dom_id(tab)}">{html.escape(CANVAS_TAB_LABELS[_tab_kind(tab)])}</label>'
+        f'<label class="tabbed-canvas-tab tabbed-canvas-tab-fallback" for="canvas-tab-{_tab_dom_id(tab)}">{html.escape(CANVAS_TAB_LABELS[_tab_kind(tab)])}</label>'
+        f'<a class="tabbed-canvas-tab tabbed-canvas-tab-link" href="#tab-{_tab_dom_id(tab)}">{html.escape(CANVAS_TAB_LABELS[_tab_kind(tab)])}</a>'
         for tab in tabs
     )
     panels = "\n".join(_panel(tab, state) for tab in tabs)
@@ -588,10 +604,14 @@ def _panel(tab: Any, state: dict[str, Any]) -> str:
         body = _render_host_guide(state)
     elif kind == "board":
         body = _render_board(state)
+    elif kind == "trace":
+        body = _render_trace(state)
+    elif kind == "audit":
+        body = _render_audit(state)
     else:
         body = _render_story(state)
     dom_id = _tab_dom_id(tab_config)
-    return f'<section class="tabbed-canvas-panel tabbed-canvas-panel-{dom_id}" data-tab-panel="{dom_id}" aria-label="{label}">{body}</section>'
+    return f'<section class="tabbed-canvas-panel tabbed-canvas-panel-{dom_id}" id="tab-{dom_id}" data-tab-panel="{dom_id}" aria-label="{label}">{body}</section>'
 
 
 def _render_crux(state: dict[str, Any]) -> str:
@@ -707,15 +727,178 @@ def _render_board(state: dict[str, Any]) -> str:
 """.strip()
 
 
+def _render_trace(state: dict[str, Any]) -> str:
+    entries = _trace_entries(state)
+    quotes_by_id = {str(quote.get("id")): quote for quote in state["quotes_ledger"]}
+    if not entries:
+        body = '<p class="tabbed-canvas-empty">Trace cards appear when a visible claim has receipt quotes.</p>'
+    else:
+        body = "\n".join(_trace_entry(entry, quotes_by_id) for entry in entries)
+    return f"""
+<div class="tabbed-trace-room">
+  {body}
+</div>
+""".strip()
+
+
+def _render_audit(state: dict[str, Any]) -> str:
+    entries = sorted(
+        [entry for entry in state.get("audit_entries") or [] if isinstance(entry, dict)],
+        key=lambda entry: str(entry.get("at") or ""),
+        reverse=True,
+    )
+    if not entries:
+        body = '<p class="tabbed-canvas-empty">Audit log entries appear after the canvas runs or the host changes it.</p>'
+    else:
+        body = "\n".join(_audit_entry(entry) for entry in entries[:30])
+    return f"""
+<div class="tabbed-audit">
+  {body}
+</div>
+""".strip()
+
+
+def _trace_entries(state: dict[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for concept in sorted(
+        state["concepts_ledger"],
+        key=lambda item: str(item.get("last_reinforced") or ""),
+        reverse=True,
+    ):
+        claim = str(concept.get("phrase") or "").strip()
+        quote_ids = [str(qid) for qid in concept.get("quote_ids") or [] if str(qid).strip()]
+        _append_trace_entry(entries, seen, "Concept", claim, quote_ids)
+    for slide in state.get("story_slides") or []:
+        claim = str(slide.get("lede") or slide.get("heading") or "").strip()
+        quote_ids = [str(qid) for qid in slide.get("quote_ids") or [] if str(qid).strip()]
+        _append_trace_entry(entries, seen, "Story", claim, quote_ids)
+    for card in state.get("board_cards") or []:
+        claim = str(card.get("synthesis") or card.get("group") or "").strip()
+        quote_ids = [str(qid) for qid in card.get("quote_ids") or [] if str(qid).strip()]
+        _append_trace_entry(entries, seen, "Board", claim, quote_ids)
+    return entries
+
+
+def _append_trace_entry(
+    entries: list[dict[str, Any]],
+    seen: set[str],
+    label: str,
+    claim: str,
+    quote_ids: list[str],
+) -> None:
+    quote_ids = [qid for index, qid in enumerate(quote_ids) if qid and qid not in quote_ids[:index]]
+    if not claim or not quote_ids:
+        return
+    entry_id = _trace_id(claim, quote_ids)
+    if entry_id in seen:
+        return
+    seen.add(entry_id)
+    entries.append({"id": entry_id, "label": label, "claim": claim, "quote_ids": quote_ids})
+
+
+def _trace_id(claim: str, quote_ids: list[str]) -> str:
+    payload = "|".join([_normalize_ws(claim), *quote_ids])
+    return f"trace-{hashlib.sha1(payload.encode('utf-8')).hexdigest()[:10]}"
+
+
+def _trace_entry(entry: dict[str, Any], quotes_by_id: dict[str, dict[str, Any]]) -> str:
+    quote_rows = [
+        _quote_block(quotes_by_id[qid])
+        for qid in entry.get("quote_ids") or []
+        if qid in quotes_by_id
+    ]
+    quotes_html = "\n".join(quote_rows) or (
+        '<p class="tabbed-canvas-empty">The receipt quotes for this claim are no longer available.</p>'
+    )
+    return f"""
+<article class="tabbed-trace-entry" id="{html.escape(str(entry.get("id") or ""))}">
+  <p class="tabbed-canvas-kicker">{html.escape(str(entry.get("label") or "Trace"))}</p>
+  <h2>{html.escape(str(entry.get("claim") or ""))}</h2>
+  <div class="tabbed-trace-cards">{quotes_html}</div>
+</article>
+""".strip()
+
+
+def _audit_entry(entry: dict[str, Any]) -> str:
+    at = html.escape(_format_audit_time(entry.get("at")))
+    outcome = html.escape(str(entry.get("kind") or "run").replace("_", " "))
+    cause = _format_audit_cause(entry.get("cause"))
+    links = _format_audit_links(entry)
+    summary = f"{at} · {outcome} — {html.escape(cause)}"
+    if links:
+        summary = f"{summary} · {links}"
+    heard = _audit_list("Heard", entry.get("heard"))
+    changes = _audit_list("Added / updated", entry.get("changes"))
+    kept_out = _audit_list("Kept out", entry.get("kept_out"))
+    version = html.escape(str(entry.get("version") or "unversioned"))
+    return f"""
+<details class="tabbed-audit-entry">
+  <summary>{summary}</summary>
+  <div class="tabbed-audit-body">
+    {heard}
+    {changes}
+    {kept_out}
+    <p><b>Cause</b> {html.escape(cause)}</p>
+    <p><b>View version</b> {version}</p>
+  </div>
+</details>
+""".strip()
+
+
+def _audit_list(label: str, value: Any) -> str:
+    items = [str(item).strip() for item in value if str(item).strip()] if isinstance(value, list) else []
+    if not items:
+        return f"<p><b>{html.escape(label)}</b> none</p>"
+    rows = "".join(f"<li>{html.escape(item)}</li>" for item in items[:8])
+    return f"<section><b>{html.escape(label)}</b><ul>{rows}</ul></section>"
+
+
+def _format_audit_time(value: Any) -> str:
+    raw = str(value or "").strip()
+    if "T" in raw:
+        return raw.split("T", 1)[1][:5]
+    if len(raw) >= 5 and raw[2] == ":":
+        return raw[:5]
+    return raw or "--:--"
+
+
+def _format_audit_cause(value: Any) -> str:
+    if not isinstance(value, dict):
+        return "canvas loop"
+    cause_type = str(value.get("type") or "canvas loop").replace("_", " ")
+    chat_id = str(value.get("chat_id") or value.get("run_chat_id") or "").strip()
+    message_id = str(value.get("message_id") or "").strip()
+    if chat_id and message_id:
+        return f"{cause_type} from chat {chat_id} message {message_id}"
+    if chat_id:
+        return f"{cause_type} from chat {chat_id}"
+    return cause_type
+
+
+def _format_audit_links(entry: dict[str, Any]) -> str:
+    cause = entry.get("cause") if isinstance(entry.get("cause"), dict) else {}
+    links: list[str] = []
+    chat_id = str(cause.get("chat_id") or "").strip()
+    run_chat_id = str(cause.get("run_chat_id") or "").strip()
+    if chat_id:
+        links.append(f'<span class="tabbed-audit-link">chat {html.escape(chat_id)}</span>')
+    if run_chat_id and run_chat_id != chat_id:
+        links.append(f'<span class="tabbed-audit-link">run chat {html.escape(run_chat_id)}</span>')
+    return " ".join(links)
+
+
 def _story_slide(slide: dict[str, Any], quotes: list[dict[str, Any]]) -> str:
     eyebrow = str(slide.get("eyebrow") or "").strip()
     eyebrow_html = f'<p class="tabbed-canvas-kicker">{html.escape(eyebrow)}</p>' if eyebrow else ""
-    quote_ids = {str(qid) for qid in slide.get("quote_ids") or []}
-    evidence = [quote for quote in quotes if str(quote.get("id")) in quote_ids]
+    quote_ids = [str(qid) for qid in slide.get("quote_ids") or []]
+    quote_id_set = set(quote_ids)
+    evidence = [quote for quote in quotes if str(quote.get("id")) in quote_id_set]
     trace = "\n".join(_quote_block(q) for q in evidence[:3])
     lede = html.escape(str(slide.get("lede") or ""))
     if lede and evidence:
-        lede_html = f'<details class="tabbed-slide-trace"><summary><span class="tabbed-traceable">{lede}</span></summary><div class="tabbed-trace">{trace}</div></details>'
+        trace_href = f"#{_trace_id(str(slide.get('lede') or slide.get('heading') or ''), quote_ids)}"
+        lede_html = f'<details class="tabbed-slide-trace"><summary><a class="tabbed-traceable" href="{trace_href}">{lede}</a></summary><div class="tabbed-trace">{trace}</div></details>'
     elif lede:
         lede_html = f'<p class="tabbed-canvas-lede">{lede}</p>'
     else:
@@ -746,9 +929,10 @@ def _concept_tile(concept: dict[str, Any], quotes: list[dict[str, Any]], index: 
     trace = "\n".join(_quote_block(q) for q in evidence[:4])
     rotation = "pos" if index % 2 else "neg"
     if trace:
+        trace_href = f"#{_trace_id(str(concept.get('phrase') or ''), quote_ids)}"
         return f"""
 <details class="tabbed-concept tabbed-concept-{tier} tabbed-tilt-{rotation}">
-  <summary><span class="tabbed-traceable">{phrase}</span></summary>
+  <summary><a class="tabbed-traceable" href="{trace_href}">{phrase}</a></summary>
   <div class="tabbed-trace">{trace}</div>
 </details>
 """.strip()
@@ -758,14 +942,16 @@ def _concept_tile(concept: dict[str, Any], quotes: list[dict[str, Any]], index: 
 def _board_card(card: dict[str, Any], quotes: list[dict[str, Any]]) -> str:
     group = html.escape(str(card.get("group") or "the room"))
     synthesis = html.escape(str(card.get("synthesis") or ""))
-    quote_ids = {str(qid) for qid in card.get("quote_ids") or []}
-    evidence = [quote for quote in quotes if str(quote.get("id")) in quote_ids]
+    quote_ids = [str(qid) for qid in card.get("quote_ids") or []]
+    quote_id_set = set(quote_ids)
+    evidence = [quote for quote in quotes if str(quote.get("id")) in quote_id_set]
     trace = "\n".join(_quote_block(q) for q in evidence[:2])
     receipt_html = ""
     if trace:
+        trace_href = f"#{_trace_id(str(card.get('synthesis') or card.get('group') or ''), quote_ids)}"
         receipt_html = (
             '<details class="tabbed-board-trace">'
-            '<summary><span class="tabbed-traceable">Receipts</span></summary>'
+            f'<summary><a class="tabbed-traceable" href="{trace_href}">Receipts</a></summary>'
             f'<div class="tabbed-trace">{trace}</div></details>'
         )
     return f"""
@@ -905,19 +1091,40 @@ _CSS = """
 .tabbed-canvas-notice{border:1px solid var(--amber);background:rgba(255,209,102,.35);padding:12px 13px;margin:0 0 14px}
 .tabbed-canvas-radio{position:absolute;opacity:0;pointer-events:none}
 .tabbed-canvas-tabbar{display:flex;align-items:end;border-bottom:1px solid var(--hairline);gap:26px;margin:0 0 26px}
-.tabbed-canvas-tab{font-size:14.5px;font-weight:500;color:var(--ink-soft);border-bottom:2px solid transparent;padding:10px 2px;cursor:pointer}
+.tabbed-canvas-tab{font-size:14.5px;font-weight:500;color:var(--ink-soft);border-bottom:2px solid transparent;padding:10px 2px;cursor:pointer;text-decoration:none}
+.tabbed-canvas-tab-link{display:none}
 .tabbed-canvas-add{margin-left:auto;color:var(--royal);font-size:22px;line-height:1.6;text-decoration:none}
 .tabbed-canvas-panel{display:none}
 #canvas-tab-crux:checked~.tabbed-canvas-tabbar label[for=canvas-tab-crux],
 #canvas-tab-concept_cloud:checked~.tabbed-canvas-tabbar label[for=canvas-tab-concept_cloud],
 #canvas-tab-story:checked~.tabbed-canvas-tabbar label[for=canvas-tab-story],
 #canvas-tab-host_guide:checked~.tabbed-canvas-tabbar label[for=canvas-tab-host_guide],
+#canvas-tab-trace:checked~.tabbed-canvas-tabbar label[for=canvas-tab-trace],
+#canvas-tab-audit:checked~.tabbed-canvas-tabbar label[for=canvas-tab-audit],
 #canvas-tab-board_person:checked~.tabbed-canvas-tabbar label[for=canvas-tab-board_person]{color:var(--ink);border-bottom-color:var(--royal)}
 #canvas-tab-crux:checked~[data-tab-panel=crux],
 #canvas-tab-concept_cloud:checked~[data-tab-panel=concept_cloud],
 #canvas-tab-story:checked~[data-tab-panel=story],
 #canvas-tab-host_guide:checked~[data-tab-panel=host_guide],
+#canvas-tab-trace:checked~[data-tab-panel=trace],
+#canvas-tab-audit:checked~[data-tab-panel=audit],
 #canvas-tab-board_person:checked~[data-tab-panel=board_person]{display:block}
+@supports selector(:has(*)){
+.tabbed-canvas-tab-fallback{display:none}
+.tabbed-canvas-tab-link{display:inline-block}
+.tabbed-canvas:has(.tabbed-canvas-panel:target) .tabbed-canvas-panel{display:none}
+.tabbed-canvas:has(.tabbed-trace-entry:target) .tabbed-canvas-panel{display:none}
+.tabbed-canvas .tabbed-canvas-panel:target{display:block}
+.tabbed-canvas:has(.tabbed-trace-entry:target) [data-tab-panel=trace]{display:block}
+.tabbed-canvas:has(#tab-crux:target) .tabbed-canvas-tab-link[href="#tab-crux"],
+.tabbed-canvas:has(#tab-concept_cloud:target) .tabbed-canvas-tab-link[href="#tab-concept_cloud"],
+.tabbed-canvas:has(#tab-story:target) .tabbed-canvas-tab-link[href="#tab-story"],
+.tabbed-canvas:has(#tab-host_guide:target) .tabbed-canvas-tab-link[href="#tab-host_guide"],
+.tabbed-canvas:has(#tab-trace:target) .tabbed-canvas-tab-link[href="#tab-trace"],
+.tabbed-canvas:has(.tabbed-trace-entry:target) .tabbed-canvas-tab-link[href="#tab-trace"],
+.tabbed-canvas:has(#tab-audit:target) .tabbed-canvas-tab-link[href="#tab-audit"],
+.tabbed-canvas:has(#tab-board_person:target) .tabbed-canvas-tab-link[href="#tab-board_person"]{color:var(--ink);border-bottom-color:var(--royal)}
+}
 .tabbed-crux{max-width:1000px;min-height:70vh;margin:0 auto;display:flex;flex-direction:column;justify-content:center}
 .tabbed-story{max-width:1000px;margin:0 auto}
 .tabbed-story-stack{display:grid;gap:30px}
@@ -961,6 +1168,19 @@ _CSS = """
 .tabbed-board-trace{margin-top:auto}
 .tabbed-board-trace summary{list-style:none;cursor:pointer;font-size:12px}
 .tabbed-board-trace summary::-webkit-details-marker{display:none}
+.tabbed-trace-room{max-width:780px;margin:0 auto;display:grid;gap:24px}
+.tabbed-trace-entry{scroll-margin-top:24px}
+.tabbed-trace-entry:target{outline:2px solid var(--royal);outline-offset:12px}
+.tabbed-trace-entry h2{margin:0;font-size:clamp(28px,4vw,44px);font-weight:500;line-height:1.12;text-wrap:balance}
+.tabbed-trace-cards{margin-top:18px}
+.tabbed-audit{max-width:900px;margin:0 auto;display:grid;gap:12px}
+.tabbed-audit-entry{background:var(--card);border:1px solid var(--hairline);padding:13px 15px}
+.tabbed-audit-entry[open]{border-color:var(--royal)}
+.tabbed-audit-entry summary{cursor:pointer;font-variant-numeric:tabular-nums;color:var(--ink)}
+.tabbed-audit-body{margin-top:12px;color:var(--ink-soft);line-height:1.45}
+.tabbed-audit-body p{margin:8px 0}
+.tabbed-audit-body ul{margin:6px 0 0;padding-left:20px}
+.tabbed-audit-link{color:var(--royal)}
 .tabbed-canvas-empty{color:var(--ink-soft)}
 @keyframes tabbedFloat{0%,100%{translate:0 0}50%{translate:0 -5px}}
 @media (prefers-reduced-motion:reduce){.tabbed-concept{animation:none}}

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -17,6 +17,7 @@ from dembrane.redis_async import get_redis_client
 from dembrane.canvas.access import CanvasReaderAccessDenied
 from dembrane.canvas.events import publish_generation_nudge
 from dembrane.canvas.gather import execute_gather_spec
+from dembrane.canvas.history import build_canvas_history
 from dembrane.canvas.ledgers import (
     state_patch,
     has_board_tab,
@@ -360,8 +361,18 @@ async def _generate_html(
     gather_bundle: dict[str, Any],
     living_state: dict[str, Any] | None = None,
     report_name: str | None = None,
+    report_id: str | None = None,
 ) -> str:
     if living_state is not None:
+        if report_id:
+            living_state = {
+                **living_state,
+                "audit_entries": await build_canvas_history(
+                    report_id,
+                    limit=30,
+                    directus_client=async_directus,
+                ),
+            }
         return render_tabbed_canvas(
             state=living_state,
             project=gather_bundle.get("project") or {},
@@ -961,6 +972,7 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
             gather_bundle=gather_bundle,
             living_state=living_state,
             report_name=str(loop.get("name") or config.get("name") or "Canvas"),
+            report_id=report_id,
         )
         sanitized = sanitize_canvas_html(raw_html, max_bytes=get_settings().canvas.max_html_bytes)
         banned_copy = _banned_visible_copy(sanitized.html)

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -1212,6 +1212,52 @@ async def test_agentic_canvas_lifecycle_delegates_to_shared_service(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_agentic_canvas_history_returns_shared_history(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+    session = _make_session(user_id="user-1")
+
+    class _AsyncDirectus:
+        async def get_item(self, collection: str, item_id: str) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "id": "canvas-1",
+                "kind": "canvas",
+                "project_id": {"id": "project-1"},
+                "deleted_at": None,
+                "user_instructions": "Pulse wall",
+            }
+
+    async def _loop(report_id: str) -> dict[str, Any]:
+        assert report_id == "canvas-1"
+        return {"id": "loop-1", "name": "Pulse wall"}
+
+    async def _history(report_id: str, *, limit: int) -> list[dict[str, Any]]:
+        assert report_id == "canvas-1"
+        assert limit == 9
+        return [{"at": "2026-07-09T12:00:00Z", "kind": "run", "changes": ["added"]}]
+
+    monkeypatch.setattr(agentic_api, "async_directus", _AsyncDirectus())
+    monkeypatch.setattr(agentic_api, "get_loop_for_report", _loop)
+    monkeypatch.setattr(agentic_api, "build_canvas_history", _history)
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=session,
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+    ) as client:
+        response = await client.get(
+            "/api/agentic/projects/project-1/canvases/canvas-1/history?limit=9"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "canvas-1",
+        "name": "Pulse wall",
+        "history": [{"at": "2026-07-09T12:00:00Z", "kind": "run", "changes": ["added"]}],
+    }
+
+
+@pytest.mark.asyncio
 async def test_agentic_canvas_edit_delegates_to_direct_edit_service(monkeypatch) -> None:
     run_service = AgenticRunService(directus_client=InMemoryDirectus())
     session = _make_session(user_id="user-1")

--- a/echo/server/tests/test_canvas_history.py
+++ b/echo/server/tests/test_canvas_history.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dembrane.canvas import history
+
+
+class _FakeDirectus:
+    async def get_items(self, collection: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        query = params["query"]
+        if collection == "agent_loop":
+            assert query["filter"] == {"report_id": {"_eq": "canvas-1"}}
+            return [
+                {
+                    "id": "loop-1",
+                    "report_id": "canvas-1",
+                    "created_from_chat_id": "chat-run",
+                    "canvas_host_items": [
+                        {
+                            "text": "Keep the doorway open.",
+                            "target_tab": "story",
+                            "chat_id": "chat-1",
+                            "message_id": "msg-1",
+                            "added_at": "2026-07-09T12:05:00Z",
+                        }
+                    ],
+                }
+            ]
+        if collection == "canvas_generation":
+            return [
+                {
+                    "id": "gen-1",
+                    "report_id": "canvas-1",
+                    "status": "ok",
+                    "tick_kind": "scheduled",
+                    "detail": "added one quote",
+                    "created_at": "2026-07-09T12:10:00Z",
+                }
+            ]
+        if collection == "agent_loop_run":
+            assert query["filter"] == {"loop_id": {"_eq": "loop-1"}}
+            return [
+                {
+                    "id": "run-2",
+                    "loop_id": "loop-1",
+                    "status": "no_op",
+                    "detail": "nothing fresh",
+                    "generation_id": None,
+                    "started_at": "2026-07-09T12:15:00Z",
+                },
+                {
+                    "id": "run-1",
+                    "loop_id": "loop-1",
+                    "status": "ok",
+                    "detail": "added one quote",
+                    "generation_id": "gen-1",
+                    "started_at": "2026-07-09T12:10:00Z",
+                },
+            ]
+        if collection == "canvas_config_revision":
+            return []
+        raise AssertionError(f"unexpected collection {collection}")
+
+
+@pytest.mark.asyncio
+async def test_build_canvas_history_includes_no_op_and_host_causes(monkeypatch) -> None:
+    monkeypatch.setattr(history, "async_directus", _FakeDirectus())
+
+    entries = await history.build_canvas_history("canvas-1", limit=10)
+
+    assert entries[0]["kind"] == "no change"
+    assert entries[0]["changes"] == ["no change — nothing new heard"]
+    assert entries[0]["cause"]["run_chat_id"] == "chat-run"
+    assert entries[1]["kind"] == "run"
+    assert entries[1]["version"] == 1
+    assert entries[2]["kind"] == "host item added"
+    assert entries[2]["cause"]["chat_id"] == "chat-1"

--- a/echo/server/tests/test_canvas_ledgers.py
+++ b/echo/server/tests/test_canvas_ledgers.py
@@ -8,6 +8,7 @@ from dembrane.canvas.ledgers import (
     render_tabbed_canvas,
     apply_model_extraction,
 )
+from dembrane.canvas.sanitize import sanitize_canvas_html
 
 
 def _bundle() -> dict:
@@ -66,6 +67,8 @@ def test_apply_model_extraction_accepts_verbatim_receipts_and_updates_crux() -> 
         {"kind": "concept_cloud"},
         {"kind": "story"},
         {"kind": "host_guide"},
+        {"kind": "trace"},
+        {"kind": "audit"},
     ]
     assert state_patch(state)["canvas_story_slides"]
 
@@ -191,6 +194,8 @@ def test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items() ->
     assert 'type="radio"' in html
     assert 'for="canvas-tab-crux"' in html
     assert 'for="canvas-tab-host_guide"' in html
+    assert 'href="#tab-trace"' in html
+    assert 'href="#tab-audit"' in html
     assert ">Open questions</label>" in html
     assert (
         'href="/en-US/w/workspace-1/projects/project-1/chats/new?prefill='
@@ -198,7 +203,42 @@ def test_render_tabbed_canvas_includes_tabs_traceable_quotes_and_host_items() ->
         '" target="_top"'
     ) in html
     assert "tabbed-traceable" in html
+    assert 'href="#trace-' in html
+    assert 'class="tabbed-trace-entry" id="trace-' in html
     assert "Host says: hold this exact reflection." in html
+    sanitized = sanitize_canvas_html(html)
+    assert 'href="#trace-' in sanitized.html
+
+
+def test_render_tabbed_canvas_includes_audit_log_entries() -> None:
+    state = fresh_canvas_state(
+        {
+            "audit_entries": [
+                {
+                    "at": "2026-07-09T12:34:00Z",
+                    "kind": "run",
+                    "version": 2,
+                    "cause": {
+                        "type": "scheduled",
+                        "chat_id": "chat-1",
+                        "message_id": "msg-1",
+                        "run_chat_id": "chat-run",
+                    },
+                    "heard": ["doorway open"],
+                    "changes": ["added doorway open"],
+                    "kept_out": ["quote was not exact"],
+                }
+            ]
+        }
+    )
+
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert "Audit log" in html
+    assert "12:34 · run — scheduled from chat chat-1 message msg-1" in html
+    assert "run chat chat-run" in html
+    assert "added doorway open" in html
+    assert "quote was not exact" in html
 
 
 def test_render_tabbed_canvas_includes_persisted_host_guide() -> None:


### PR DESCRIPTION
The trace/audit architecture from the owners' 2026-07-08 conversations, landing as tabs:

- **Trace is where clicks land**: any dotted-underline claim in Story/Cloud/Crux/Board routes to the Trace tab anchored at that claim (CSS `:target` + `:has()` with the radio mechanism as fallback; sanitizer round-trip tested). Claim big, one card per quote — exact words · speaker · when · source — never a composite
- **Audit log tab**: `HH:MM · outcome — cause · links` grammar (owner-refined); one entry per event with expanded heard / added / kept-out / cause sections; mints link their version, applies and host items link the exact chat message; rejections and judgment-omissions render honestly
- **One source of truth**: `canvas/history.py` normalizes the history objects consumed by both the rendered tab and the new `GET /agentic/projects/{pid}/canvases/{cid}/history` endpoint + `readCanvasHistory` agent tool — "why did this change?" in chat is answered from receipts, and review verdicts get noted as insights
- Fix-back included: history rendering accepts an injected Directus client so the 8 owner-approved tick-test contracts hold

Gates: server ruff + 88 tests (full canvas suite + agentic API), agent 105. Report: `wave28g-REPORT.md`. Deferred to 28h (same files, briefs staged): board seeding from existing ledgers, near-duplicate concept merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)