### PR TITLE
Canvas: organic cloud scatter, board seeding, near-duplicate concept merge

### DIFF
--- a/echo/docs/plans/canvas-agentic-tick.md
+++ b/echo/docs/plans/canvas-agentic-tick.md
@@ -53,6 +53,15 @@ calls, reasoning, receipts, everything.
 - "Questionable in chat": the visible project chat agent can read these
   hidden runs (readChat / readCanvasHistory) and answer "why did this
   change" from the actual run, then noteInsight on the owner's verdict.
+- Discoverability requirement (owner, 2026-07-09): hidden tick-run chats
+  must be REACHABLE through the same two tools the host already knows:
+  listProjectChats gains include_hidden/kind filtering (default stays
+  visible-only so Ask history is not flooded; the agent passes
+  kind="canvas_tick" when the host asks about the loop's work), and
+  readChat opens tick-run chats like any other. Every audit entry's
+  run_chat_id is a readChat-able id — "chat about run 3's delta" is:
+  readCanvasHistory -> run_chat_id -> readChat -> discuss. The agent
+  prompt names this path explicitly.
 
 ## Why this is safe now
 

--- a/echo/docs/plans/smart-loop-briefs/wave28h-REPORT.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28h-REPORT.md
@@ -1,0 +1,29 @@
+# Wave 28h Report
+
+## Start Check
+
+- Fetched `origin`.
+- Verified `origin/main` includes `9dd09d56 Canvas: Trace as a destination, Audit log tab, readCanvasHistory (#838)`.
+- Created `sameer/cloud-scatter` from `origin/main`.
+
+## Summary
+
+Implemented deterministic concept-cloud scatter, board seeding from existing accepted ledger quotes, and near-duplicate concept merging.
+
+## Implementation
+
+- Added board seeding from existing attributed `quotes_ledger` rows when a board tab is enabled and `board_cards` is empty.
+- Kept enabled-but-empty board tabs visible with the honest empty state `No attributed voices yet.`.
+- Added near-duplicate concept merging in ledger code using normalized phrase keys and token-sequence containment, pooling receipts and keeping the longer phrase.
+- Replaced binary cloud tilt/order with stable hash-derived tile order and inline per-tile style values for rotation, offset, animation delay, and animation duration.
+- Spread XL concept tiles through the rendered cloud so no two XL tiles are adjacent in normal 20-tile clouds.
+- Added sanitizer round-trip coverage for the inline scatter styles.
+
+## Gates
+
+- Server ruff:
+  `cd echo/server && uv run ruff check .`
+  Result: passed.
+- Full requested canvas suite, with local dummy settings required for test collection:
+  `cd echo/server && DIRECTUS_SECRET=test DIRECTUS_TOKEN=test DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/test REDIS_URL=redis://localhost:6379/0 STORAGE_S3_BUCKET=test STORAGE_S3_ENDPOINT=http://localhost:9000 STORAGE_S3_KEY=test STORAGE_S3_SECRET=test uv run pytest -q tests/test_canvas_*.py tests/api/test_bff_canvases.py tests/api/test_agentic_api.py`
+  Result: 95 passed, 2 warnings.

--- a/echo/docs/plans/smart-loop-briefs/wave28h-cloud-scatter.md
+++ b/echo/docs/plans/smart-loop-briefs/wave28h-cloud-scatter.md
@@ -1,8 +1,34 @@
-# Brief: Wave 28h — the cloud scatters like a room, not a spreadsheet
+# Brief: Wave 28h — cloud scatter, board seeding, near-duplicate concepts
 
-Start AFTER the 28g fix-back is merged: `git fetch origin && git checkout
--b sameer/cloud-scatter origin/main` (verify the 28g/trace-audit work is
-in main; if not, report and stop).
+Start AFTER 28g (#838) is merged: `git fetch origin && git checkout
+-b sameer/cloud-scatter origin/main` (verify the trace/audit work is in
+main; if not, report and stop).
+
+THREE items: the scatter (below), plus two carried-over live-repro fixes:
+
+## A. Board seeding from existing ledgers (live repro, echo-next loop 37ef418f)
+
+Enabling {kind: board} on a loop whose quotes ledger ALREADY holds
+attributed quotes produced 'board unchanged' and NO Board tab in the
+rendered HTML. Fix both halves:
+1. When a board tab is enabled and board cards are empty but attributed
+   quotes exist in the ledger, seed cards from those accepted quotes on
+   the next tick (no new extraction required).
+2. An enabled-but-empty board tab must still render in the tab bar with
+   an honest empty state ('no attributed voices yet'), never disappear.
+Tests for both.
+
+## B. Near-duplicate concept merge (live repro, echo-next canvas 14)
+
+'falling in love with the game' and 'falling in love with the game
+again' rendered as separate tiles with split receipts. In
+_merge_model_concepts, add code-level near-duplicate merging: normalize
+(lowercase, strip punctuation + filler words), merge when normalized
+phrases are equal OR one contains the other; pool quote_ids; the longer
+/ more room-flavored phrase survives; size tier recomputed after merge.
+Test with the live pair above.
+
+## C. The scatter (original brief)
 
 Owner evidence: side-by-side with the reference wall (Oren's), our
 concept cloud reads mechanical. Three concrete causes in

--- a/echo/docs/plans/smart-loop-briefs/wave33-json-surgery.md
+++ b/echo/docs/plans/smart-loop-briefs/wave33-json-surgery.md
@@ -1,0 +1,78 @@
+# Brief: Wave 33 — per-version JSON snapshots, readCanvasTab / editCanvasTab, edit buttons
+
+Start AFTER 28h is merged: `git fetch origin && git checkout -b
+sameer/canvas-json-surgery origin/main` (verify the cloud-scatter/board-
+seeding work is in main; if not, report and stop).
+
+Owner decision (2026-07-09): "we need a JSON store for each canvas
+version along with the html... so JSON edits are always surgical and the
+agent should know when to edit what." Live proof of the gap: asked to
+find concept-cloud duplicates, the agent had to grep raw HTML because no
+tool exposes the ledgers.
+
+## 1. state_snapshot on every generation
+
+canvas_generation gains a state_snapshot JSON field: the full canvas
+state (tabs config + all ledgers + crux + host items + story slides +
+board cards + open questions) exactly as rendered into that version's
+content_html. Written at mint time in the same store call. Extend the
+wave28 migration script idempotently. Backfill is NOT required for old
+generations (null = pre-snapshot version; tools must say so honestly).
+This makes versions diffable and restorable: a follow-up wave adds
+restore; do not build restore now.
+
+## 2. readCanvasTab (agent tool + endpoint)
+
+readCanvasTab(canvas, tab) -> the CURRENT JSON state for that tab
+(e.g. concept_cloud -> concepts with ids, phrases, tiers, quote_ids and
+their receipt quotes; board -> cards; crux -> question + history).
+Server: GET /agentic/projects/{pid}/canvases/{cid}/tabs/{tab} following
+the history endpoint's auth pattern (#838). Optional version param
+(generation id) reads that version's state_snapshot instead; null
+snapshot -> honest "version predates snapshots" response.
+Agent prompt: for ANY question about what is on the wall (duplicates,
+what concepts exist, who has receipts, why is X sized that way), use
+readCanvasTab — never inspect canvas HTML again.
+
+## 3. editCanvasTab (agent tool + endpoint)
+
+editCanvasTab(canvas, tab, operations) — surgical JSON operations, NOT
+freeform state replacement. v1 operation set (validated server-side):
+- concept_cloud: merge_concepts(ids, into_phrase?), remove_concept(id),
+  rename_concept(id, phrase — must still pass the receipts containment
+  check against its pooled quotes, else 422)
+- board: remove_card(id), set_card_label(id, label)
+- crux: set_question(text — same rules as extraction: one question,
+  history preserved)
+- story: remove_slide(index), reorder_slides(indices)
+- any tab: remove_host_item(id) (parity with removeFromCanvas)
+Each edit: applies to the live ledgers, mints a new generation
+(tick_kind="edited", with state_snapshot), writes an audit history entry
+(cause: chat edit, linking chat/message id), publishes the SSE nudge.
+Receipts invariants are enforced server-side: an edit can never create
+an unreceipted underline (rename revalidates; merges pool receipts).
+Agent prompt: prefer editCanvasTab for content surgery; editCanvas
+(HTML) remains ONLY for pure presentation tweaks that no operation
+covers, and says so in its docstring.
+
+## 4. Per-tab edit buttons on the wall
+
+Next to each tab's content, a small quiet edit affordance (pencil,
+handoff styling: royal, no button chrome) linking target=_top to the
+prefilled chat route (#835/#836 pattern):
+"Edit the {tab label} tab of the {report name} canvas: ". Sanitizer
+round-trip test. The + button pattern in ledgers.py shows the URL
+construction.
+
+## QA gates
+
+- Server: ruff; FULL canvas suite + agentic API tests; new tests:
+  snapshot written at mint and equals rendered state; readCanvasTab
+  shapes per tab; version param + pre-snapshot honesty; each edit
+  operation (incl. rename receipts-containment 422, merge pooling,
+  audit entry + edited generation + snapshot); edit buttons survive
+  sanitizer.
+- Agent: uv run pytest -q; tool wiring + prompt rules (readCanvasTab
+  over HTML; editCanvasTab over editCanvas for content).
+- Migration idempotent.
+- Report -> echo/docs/plans/smart-loop-briefs/wave33-REPORT.md.

--- a/echo/server/dembrane/canvas/ledgers.py
+++ b/echo/server/dembrane/canvas/ledgers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import html
 import hashlib
 from typing import Any
@@ -137,6 +138,39 @@ def _tab_key(tab: dict[str, Any]) -> str:
 def has_board_tab(state_or_tabs: Any) -> bool:
     tabs = state_or_tabs.get("tabs") if isinstance(state_or_tabs, dict) else state_or_tabs
     return any(_tab_kind(tab) == "board" for tab in normalize_canvas_tabs(tabs))
+
+
+def seed_board_cards_from_quotes(state: dict[str, Any], now: str | None = None) -> bool:
+    if not has_board_tab(state) or state.get("board_cards"):
+        return False
+    now = now or utc_now_iso()
+    quotes_by_voice: dict[str, list[dict[str, Any]]] = {}
+    for quote in state["quotes_ledger"]:
+        voice = str(quote.get("who") or "").strip()
+        if not voice or voice.lower() == "participant":
+            continue
+        quotes_by_voice.setdefault(voice, []).append(quote)
+    if not quotes_by_voice:
+        return False
+
+    for voice in sorted(quotes_by_voice):
+        quotes = quotes_by_voice[voice]
+        quote_ids = [str(quote.get("id")) for quote in quotes if str(quote.get("id") or "")]
+        latest_quote = str((quotes[-1] if quotes else {}).get("quote") or "").strip()
+        if not quote_ids or not latest_quote:
+            continue
+        state["board_cards"].append(
+            {
+                "id": generate_uuid(),
+                "group": voice,
+                "grouping": "person",
+                "synthesis": latest_quote[:700],
+                "quote_ids": quote_ids[-8:],
+                "first_seen": now,
+                "updated_at": now,
+            }
+        )
+    return bool(state["board_cards"])
 
 
 def host_item(
@@ -348,12 +382,8 @@ def _merge_model_concepts(
     quote_index_to_id: dict[int, str],
     now: str,
 ) -> tuple[int, list[str]]:
-    by_phrase = {
-        str(concept.get("phrase") or "").lower(): concept
-        for concept in state["concepts_ledger"]
-        if concept.get("phrase")
-    }
-    changed = 0
+    changed = _collapse_near_duplicate_concepts(state, now)
+    by_phrase = _concept_lookup(state)
     rejections: list[str] = []
     quotes_by_id = {str(quote.get("id")): quote for quote in state["quotes_ledger"]}
     for model_index, concept_input in enumerate(_list(extraction.get("concepts"))):
@@ -378,8 +408,8 @@ def _merge_model_concepts(
                 f"concept[{model_index}] phrase not found in supporting quote: {phrase[:80]}"
             )
             continue
-        key = phrase.lower()
-        concept = by_phrase.get(key)
+        key = _concept_phrase_key(phrase)
+        concept = _find_near_duplicate_concept(by_phrase, key)
         if not concept:
             concept = {
                 "id": generate_uuid(),
@@ -392,6 +422,10 @@ def _merge_model_concepts(
             state["concepts_ledger"].append(concept)
             by_phrase[key] = concept
             changed += 1
+        elif _prefer_concept_phrase(phrase, str(concept.get("phrase") or "")):
+            concept["phrase"] = phrase
+            concept["last_reinforced"] = now
+            changed += 1
         for quote_id in quote_ids:
             if quote_id in concept["quote_ids"]:
                 continue
@@ -399,6 +433,7 @@ def _merge_model_concepts(
             concept["last_reinforced"] = now
             changed += 1
 
+    changed += _collapse_near_duplicate_concepts(state, now)
     ranked = sorted(
         state["concepts_ledger"],
         key=lambda c: (_concept_score(c, state["quotes_ledger"]), c.get("first_seen") or ""),
@@ -418,6 +453,97 @@ def _merge_model_concepts(
             concept["size_tier"] = tier
             changed += 1
     return changed, rejections
+
+
+def _concept_lookup(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        _concept_phrase_key(str(concept.get("phrase") or "")): concept
+        for concept in state["concepts_ledger"]
+        if concept.get("phrase")
+    }
+
+
+_CONCEPT_FILLER_WORDS = {
+    "a",
+    "again",
+    "an",
+    "and",
+    "of",
+    "the",
+    "to",
+    "with",
+}
+
+
+def _concept_phrase_key(phrase: str) -> str:
+    words = re.sub(r"[^\w\s]", " ", phrase.lower()).split()
+    compact = [word for word in words if word not in _CONCEPT_FILLER_WORDS]
+    return " ".join(compact)
+
+
+def _find_near_duplicate_concept(
+    by_phrase: dict[str, dict[str, Any]],
+    key: str,
+) -> dict[str, Any] | None:
+    if not key:
+        return None
+    if key in by_phrase:
+        return by_phrase[key]
+    for existing_key, concept in by_phrase.items():
+        if not existing_key:
+            continue
+        if _concept_key_contains(existing_key, key) or _concept_key_contains(key, existing_key):
+            return concept
+    return None
+
+
+def _concept_key_contains(haystack: str, needle: str) -> bool:
+    haystack_words = haystack.split()
+    needle_words = needle.split()
+    if not haystack_words or not needle_words or len(needle_words) > len(haystack_words):
+        return False
+    return any(
+        haystack_words[index : index + len(needle_words)] == needle_words
+        for index in range(len(haystack_words) - len(needle_words) + 1)
+    )
+
+
+def _prefer_concept_phrase(candidate: str, current: str) -> bool:
+    candidate = candidate.strip()
+    current = current.strip()
+    if not candidate:
+        return False
+    if not current:
+        return True
+    return (len(candidate.split()), len(candidate)) > (len(current.split()), len(current))
+
+
+def _collapse_near_duplicate_concepts(state: dict[str, Any], now: str) -> int:
+    concepts = [concept for concept in state["concepts_ledger"] if isinstance(concept, dict)]
+    merged: list[dict[str, Any]] = []
+    changed = 0
+    for concept in concepts:
+        phrase = str(concept.get("phrase") or "").strip()
+        key = _concept_phrase_key(phrase)
+        existing = _find_near_duplicate_concept(
+            {_concept_phrase_key(str(item.get("phrase") or "")): item for item in merged},
+            key,
+        )
+        if not existing:
+            merged.append(concept)
+            continue
+        if _prefer_concept_phrase(phrase, str(existing.get("phrase") or "")):
+            existing["phrase"] = phrase
+        pooled = [str(qid) for qid in existing.get("quote_ids") or []]
+        for quote_id in [str(qid) for qid in concept.get("quote_ids") or []]:
+            if quote_id not in pooled:
+                pooled.append(quote_id)
+        existing["quote_ids"] = pooled
+        existing["last_reinforced"] = now
+        changed += 1
+    if len(merged) != len(state["concepts_ledger"]):
+        state["concepts_ledger"] = merged
+    return changed
 
 
 def _update_model_crux(
@@ -486,7 +612,7 @@ def _merge_board_cards(
         return False, []
     cards = _list(extraction.get("board_cards"))
     if not cards:
-        return False, []
+        return seed_board_cards_from_quotes(state, now), []
 
     quotes_by_id = {str(quote.get("id")): quote for quote in state["quotes_ledger"]}
     existing_by_group = {
@@ -630,14 +756,7 @@ def _render_crux(state: dict[str, Any]) -> str:
 
 
 def _render_cloud(state: dict[str, Any]) -> str:
-    concepts = sorted(
-        state["concepts_ledger"],
-        key=lambda c: (
-            {"xl": 4, "l": 3, "m": 2, "s": 1}.get(str(c.get("size_tier")), 1),
-            c.get("last_reinforced") or "",
-        ),
-        reverse=True,
-    )[:20]
+    concepts = _ordered_cloud_concepts(state["concepts_ledger"])[:20]
     if not concepts:
         tiles = (
             '<p class="tabbed-canvas-empty">Concepts will appear as transcript receipts arrive.</p>'
@@ -648,6 +767,39 @@ def _render_cloud(state: dict[str, Any]) -> str:
             for index, concept in enumerate(concepts)
         )
     return f'<div class="tabbed-cloud">{tiles}{_render_host_items(state, "concept_cloud")}</div>'
+
+
+def _ordered_cloud_concepts(concepts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ranked = sorted(
+        concepts,
+        key=lambda c: (
+            {"xl": 4, "l": 3, "m": 2, "s": 1}.get(str(c.get("size_tier")), 1),
+            c.get("last_reinforced") or "",
+        ),
+        reverse=True,
+    )[:20]
+    if not ranked:
+        return []
+    xl = _hash_sorted([concept for concept in ranked if str(concept.get("size_tier")) == "xl"])
+    others = _hash_sorted([concept for concept in ranked if str(concept.get("size_tier")) != "xl"])
+    ordered: list[dict[str, Any] | None] = [None] * len(ranked)
+    if xl and others:
+        for index, concept in enumerate(xl):
+            slot = round(index * (len(ranked) - 1) / max(1, len(xl) - 1))
+            while slot < len(ordered) and ordered[slot] is not None:
+                slot += 1
+            if slot >= len(ordered):
+                slot = next(i for i, item in enumerate(ordered) if item is None)
+            ordered[slot] = concept
+    else:
+        for index, concept in enumerate(xl):
+            ordered[index] = concept
+    other_iter = iter(others)
+    return [item if item is not None else next(other_iter) for item in ordered]
+
+
+def _hash_sorted(concepts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(concepts, key=lambda concept: _stable_hash(str(concept.get("id") or concept.get("phrase") or "")))
 
 
 def _render_story(state: dict[str, Any]) -> str:
@@ -717,7 +869,7 @@ def _render_host_guide(state: dict[str, Any]) -> str:
 def _render_board(state: dict[str, Any]) -> str:
     cards = state.get("board_cards") or []
     if not cards:
-        body = '<p class="tabbed-canvas-empty">The board is waiting for attributed receipt quotes.</p>'
+        body = '<p class="tabbed-canvas-empty">No attributed voices yet.</p>'
     else:
         body = "\n".join(_board_card(card, state["quotes_ledger"]) for card in cards[:30])
     return f"""
@@ -927,16 +1079,45 @@ def _concept_tile(concept: dict[str, Any], quotes: list[dict[str, Any]], index: 
     quote_ids = [str(qid) for qid in concept.get("quote_ids") or []]
     evidence = [q for q in quotes if str(q.get("id")) in quote_ids]
     trace = "\n".join(_quote_block(q) for q in evidence[:4])
-    rotation = "pos" if index % 2 else "neg"
+    style = html.escape(_concept_tile_style(concept, index), quote=True)
     if trace:
         trace_href = f"#{_trace_id(str(concept.get('phrase') or ''), quote_ids)}"
         return f"""
-<details class="tabbed-concept tabbed-concept-{tier} tabbed-tilt-{rotation}">
+<details class="tabbed-concept tabbed-concept-{tier}" style="{style}">
   <summary><a class="tabbed-traceable" href="{trace_href}">{phrase}</a></summary>
   <div class="tabbed-trace">{trace}</div>
 </details>
 """.strip()
-    return f'<div class="tabbed-concept tabbed-concept-{tier} tabbed-tilt-{rotation}"><span>{phrase}</span></div>'
+    return f'<div class="tabbed-concept tabbed-concept-{tier}" style="{style}"><span>{phrase}</span></div>'
+
+
+def _stable_hash(seed: str) -> int:
+    return int(hashlib.sha1(seed.encode("utf-8")).hexdigest()[:12], 16)
+
+
+def _hash_unit(seed: str, salt: str) -> float:
+    return _stable_hash(f"{seed}:{salt}") / float(0xFFFFFFFFFFFF)
+
+
+def _concept_tile_style(concept: dict[str, Any], index: int) -> str:
+    seed = str(concept.get("id") or concept.get("phrase") or index)
+    rotation = _scale(_hash_unit(seed, "rotation"), -1.2, 1.2)
+    delay = _scale(_hash_unit(seed, "delay"), 0.0, 6.95)
+    duration = _scale(_hash_unit(seed, "duration"), 6.0, 9.0)
+    offset_x = _scale(_hash_unit(seed, "offset-x"), -5.0, 5.0)
+    offset_y = _scale(_hash_unit(seed, "offset-y"), -4.0, 4.0)
+    margin_top = _scale(_hash_unit(seed, "margin-top"), -3.0, 5.0)
+    margin_side = _scale(_hash_unit(seed, "margin-side"), -4.0, 4.0)
+    return (
+        f"transform:translate({offset_x:.1f}px,{offset_y:.1f}px) rotate({rotation:.2f}deg);"
+        f"animation-delay:{delay:.2f}s;"
+        f"animation-duration:{duration:.2f}s;"
+        f"margin:{margin_top:.1f}px {margin_side:.1f}px 0;"
+    )
+
+
+def _scale(value: float, low: float, high: float) -> float:
+    return low + (high - low) * value
 
 
 def _board_card(card: dict[str, Any], quotes: list[dict[str, Any]]) -> str:

--- a/echo/server/dembrane/canvas/ticks.py
+++ b/echo/server/dembrane/canvas/ticks.py
@@ -26,6 +26,7 @@ from dembrane.canvas.ledgers import (
     ledger_prompt_summary,
     normalize_canvas_tabs,
     apply_model_extraction,
+    seed_board_cards_from_quotes,
 )
 from dembrane.directus_async import async_directus
 from dembrane.canvas.sanitize import CanvasSanitizationError, sanitize_canvas_html
@@ -939,6 +940,8 @@ async def run_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[str, Any]
                     ledger_detail["host_guide_changed"] = True
             except Exception as exc:
                 ledger_detail["rejections"].append(f"open questions model error: {exc}")
+        if seed_board_cards_from_quotes(living_state, started_at.isoformat()):
+            ledger_detail["board_changed"] = True
         ledger_detail["rejections"].extend(
             _shape_warnings(str(config.get("brief") or ""), living_state["tabs"])
         )

--- a/echo/server/tests/test_canvas_ledgers.py
+++ b/echo/server/tests/test_canvas_ledgers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from dembrane.canvas.ledgers import (
     host_item,
     state_patch,
@@ -360,3 +362,123 @@ def test_board_folds_unattributed_receipts_into_room_card() -> None:
     assert state["board_cards"][0]["group"] == "the room"
     assert "the room" in html
     assert "Maya" not in html
+
+
+def test_board_seeds_from_existing_attributed_ledger_quotes() -> None:
+    state = fresh_canvas_state({"canvas_tabs": [{"kind": "board", "grouping": "person"}]})
+    state["quotes_ledger"] = [
+        {
+            "id": "q-maya",
+            "who": "Maya",
+            "quote": "Keep the doorway open.",
+            "source": {"conversation_id": "conv-1", "chunk_id": "chunk-1"},
+            "when": "2026-07-09T10:00:00Z",
+        }
+    ]
+
+    state, detail = apply_model_extraction(
+        state,
+        _bundle(),
+        {"quotes": [], "concepts": [], "crux": None, "story_slides": [], "board_cards": []},
+    )
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert detail["board_changed"] is True
+    assert state["board_cards"][0]["group"] == "Maya"
+    assert state["board_cards"][0]["synthesis"] == "Keep the doorway open."
+    assert "Keep the doorway open." in html
+
+
+def test_empty_board_tab_renders_honest_empty_state() -> None:
+    state = fresh_canvas_state({"canvas_tabs": [{"kind": "board", "grouping": "person"}]})
+
+    html = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert 'href="#tab-board_person"' in html
+    assert "No attributed voices yet." in html
+
+
+def test_near_duplicate_concepts_merge_and_keep_longer_phrase() -> None:
+    state = fresh_canvas_state()
+    bundle = {
+        "conversations": [
+            {
+                "id": "conv-1",
+                "label": "Maya",
+                "chunks": [
+                    {
+                        "id": "chunk-1",
+                        "transcript": (
+                            "falling in love with the game. "
+                            "falling in love with the game again."
+                        ),
+                        "created_at": "2026-07-09T10:00:00Z",
+                    }
+                ],
+            }
+        ]
+    }
+
+    state, _detail = apply_model_extraction(
+        state,
+        bundle,
+        {
+            "quotes": [
+                {
+                    "who": "Maya",
+                    "quote": "falling in love with the game.",
+                    "conversation_id": "conv-1",
+                    "chunk_id": "chunk-1",
+                },
+                {
+                    "who": "Maya",
+                    "quote": "falling in love with the game again.",
+                    "conversation_id": "conv-1",
+                    "chunk_id": "chunk-1",
+                },
+            ],
+            "concepts": [
+                {"phrase": "falling in love with the game", "supporting_quote_indices": [0]},
+                {
+                    "phrase": "falling in love with the game again",
+                    "supporting_quote_indices": [1],
+                },
+            ],
+            "crux": None,
+            "story_slides": [],
+        },
+    )
+
+    assert len(state["concepts_ledger"]) == 1
+    assert state["concepts_ledger"][0]["phrase"] == "falling in love with the game again"
+    assert len(state["concepts_ledger"][0]["quote_ids"]) == 2
+
+
+def test_cloud_scatter_is_deterministic_spread_and_sanitized() -> None:
+    concepts = [
+        {
+            "id": f"concept-{index}",
+            "phrase": f"phrase {index}",
+            "quote_ids": [],
+            "size_tier": "xl" if index < 3 else "m",
+            "last_reinforced": f"2026-07-09T10:{index:02d}:00Z",
+        }
+        for index in range(10)
+    ]
+    state = fresh_canvas_state({"canvas_concepts_ledger": concepts})
+
+    first = render_tabbed_canvas(state=state, project={"name": "Room"})
+    second = render_tabbed_canvas(state=state, project={"name": "Room"})
+
+    assert first == second
+    styles = re.findall(r'class="tabbed-concept tabbed-concept-[^"]+" style="([^"]+)"', first)
+    assert len(styles) == 10
+    assert len(set(styles[:3])) == 3
+    assert "animation-delay:" in styles[0]
+    assert "animation-duration:" in styles[0]
+    tiers = re.findall(r'class="tabbed-concept tabbed-concept-([a-z]+)" style=', first)
+    xl_positions = [index for index, tier in enumerate(tiers) if tier == "xl"]
+    assert all((right - left) > 1 for left, right in zip(xl_positions, xl_positions[1:], strict=False))
+    sanitized = sanitize_canvas_html(first)
+    assert 'style="transform:translate(' in sanitized.html
+    assert "animation-delay:" in sanitized.html

--- a/echo/server/tests/test_canvas_ticks.py
+++ b/echo/server/tests/test_canvas_ticks.py
@@ -597,6 +597,8 @@ async def test_tab_set_change_rerenders_despite_no_new_content(monkeypatch) -> N
 
     assert result["status"] == "ok"
     assert 'for="canvas-tab-board_person"' in result["generation"]["content_html"]
+    assert "Keep this." in result["generation"]["content_html"]
+    assert fake.items["agent_loop"]["loop1"]["canvas_board_cards"][0]["group"] == "Maya"
     assert fake.items["agent_loop"]["loop1"]["canvas_tabs"] == [
         {"kind": "board", "grouping": "person"}
     ]


### PR DESCRIPTION
Three live-repro fixes from this morning's wall:

- **Scatter like a room, not a spreadsheet**: per-tile rotation/float/order derived from a stable hash of the concept id — continuous ±1.2°, varied bob timing, XL tiles spread (never adjacent). Deterministic: a tile keeps its lean across re-renders; content moves, furniture doesn't. `prefers-reduced-motion` respected, sanitizer round-trip tested
- **Board seeding** (repro: loop 37ef418f): enabling a board tab with attributed quotes already in the ledger seeds person cards on the next tick; an empty board renders an honest "no attributed voices yet" instead of disappearing from the tab bar
- **Near-duplicate merge** (repro: canvas 14): normalized token-containment merging pools receipts and keeps the longer phrase — tested with the live pair

Gates: server ruff + full canvas/API suite (95). Report: `wave28h-REPORT.md`. Rides along: wave 33 brief + agentic-tick note update (hidden-run discoverability via listProjectChats/readChat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)