### PR TITLE
  fix(dev): point devcontainer agent build at repo root

### DIFF
--- a/echo/.devcontainer/docker-compose.yml
+++ b/echo/.devcontainer/docker-compose.yml
@@ -66,8 +66,8 @@ services:
 
   agent:
     build:
-      context: ../agent
-      dockerfile: Dockerfile
+      context: ../../
+      dockerfile: echo/agent/Dockerfile
     ports:
       - 8001:8001
     environment:


### PR DESCRIPTION
  The agent image was rewritten in #753 to build from the git repo root
  (it bakes docs/ as its knowledge FS, so it needs both echo/agent/ and
  docs/ in context). CI was updated to match; the devcontainer compose was
  not, so it still built with context ../agent and failed on
  `COPY docs/ ./knowledge/docs/` with "/docs": not found.

  Set context ../../ + dockerfile echo/agent/Dockerfile, matching
  .github/workflows/ci.yml.