### PR TITLE
  ECHO-883 polish: past-tense monitor event names, swap funnel tooltip colors

### DIFF
--- a/echo/frontend/src/components/conversation/FunnelCanvas.tsx
+++ b/echo/frontend/src/components/conversation/FunnelCanvas.tsx
@@ -362,7 +362,7 @@ export const FunnelCanvas = ({
 			/>
 			{hover && (
 				<div
-					className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded bg-slate-800 px-2 py-1 text-xs text-white shadow"
+					className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded bg-graphite px-2 py-1 text-xs text-parchment shadow"
 					style={{ left: hover.x, top: hover.y - 6 }}
 				>
 					{hover.label}

--- a/echo/server/dembrane/api/participant.py
+++ b/echo/server/dembrane/api/participant.py
@@ -801,7 +801,7 @@ async def confirm_chunk_upload(
                     )
                     await capture_event(
                         conversation_id,
-                        "server_chunk_not_found_in_s3",
+                        "server_chunk_missing_in_s3",
                         {"chunk_id": body.chunk_id},
                     )
                     raise HTTPException(
@@ -844,7 +844,7 @@ async def confirm_chunk_upload(
             )
             await capture_event(
                 conversation_id,
-                "server_chunk_upload_bad",
+                "server_chunk_upload_rejected",
                 {"chunk_id": body.chunk_id, "file_size": file_size},
             )
             # Update the returned chunk to include the error

--- a/echo/server/tests/api/test_confirm_chunk_upload_analytics.py
+++ b/echo/server/tests/api/test_confirm_chunk_upload_analytics.py
@@ -1,4 +1,4 @@
-"""Tests for the server_chunk_upload_bad and server_chunk_not_found_in_s3
+"""Tests for the server_chunk_upload_rejected and server_chunk_missing_in_s3
 captures in confirm_chunk_upload."""
 
 from __future__ import annotations
@@ -44,7 +44,7 @@ async def test_confirm_upload_captures_bad_chunk_when_too_small() -> None:
 
     capture.assert_any_await(
         "conv-1",
-        "server_chunk_upload_bad",
+        "server_chunk_upload_rejected",
         {"chunk_id": "chunk-1", "file_size": 512},
     )
 
@@ -69,6 +69,6 @@ async def test_confirm_upload_captures_s3_not_found_after_retries() -> None:
     assert exc_info.value.status_code == 400
     capture.assert_any_await(
         "conv-1",
-        "server_chunk_not_found_in_s3",
+        "server_chunk_missing_in_s3",
         {"chunk_id": "chunk-1"},
     )


### PR DESCRIPTION
  Rename two server analytics events to match the snake_case past-tense
  convention: server_chunk_not_found_in_s3 -> server_chunk_missing_in_s3,
  server_chunk_upload_bad -> server_chunk_upload_rejected. Update the
  confirm_chunk_upload analytics test to match.

  Swap the funnel tooltip's hardcoded bg-slate-800/text-white for brand
  tokens (bg-graphite/text-parchment).