### PR TITLE
ECHO-878 feat(canvas): gate Project Library behind ENABLE_CANVAS, off in production

### DIFF
--- a/echo/frontend/src/Router.tsx
+++ b/echo/frontend/src/Router.tsx
@@ -20,7 +20,7 @@ import { Verify } from "./components/participant/verify/Verify";
 import { VerifyArtefact } from "./components/participant/verify/VerifyArtefact";
 import { VerifySelection } from "./components/participant/verify/VerifySelection";
 import { ProjectAccessGuard } from "./components/project/ProjectAccessGuard";
-import { ENABLE_MONITOR } from "./config";
+import { ENABLE_CANVAS, ENABLE_MONITOR } from "./config";
 import {
 	ParticipantConversationAudioRoute,
 	ParticipantConversationTextRoute,
@@ -255,32 +255,40 @@ const projectRouteChildren = [
 						],
 						path: "conversations/:conversationId",
 					},
-					{
-						children: [
-							{
-								element: <ProjectLibraryAspect />,
-								path: "views/:viewId/aspects/:aspectId",
-							},
-							{
-								element: <ProjectLibraryView />,
-								path: "views/:viewId",
-							},
-							{
-								element: <LibraryRoute />,
-								index: true,
-							},
-						],
-						element: <ProjectLibraryLayout />,
-						path: "library",
-					},
+					...(ENABLE_CANVAS
+						? [
+								{
+									children: [
+										{
+											element: <ProjectLibraryAspect />,
+											path: "views/:viewId/aspects/:aspectId",
+										},
+										{
+											element: <ProjectLibraryView />,
+											path: "views/:viewId",
+										},
+										{
+											element: <LibraryRoute />,
+											index: true,
+										},
+									],
+									element: <ProjectLibraryLayout />,
+									path: "library",
+								},
+							]
+						: []),
 					{
 						element: <ProjectReportRoute />,
 						path: "report",
 					},
-					{
-						element: <CanvasRoute />,
-						path: "canvases/:canvasId",
-					},
+					...(ENABLE_CANVAS
+						? [
+								{
+									element: <CanvasRoute />,
+									path: "canvases/:canvasId",
+								},
+							]
+						: []),
 					{
 						element: <ProjectConversationsRoute />,
 						path: "conversations",

--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -188,6 +188,8 @@ export const ENABLE_AGENTATION = byEnv({ next: true }, false);
 // Host live-monitor (page, sidebar item, project-home block) and the portal
 // beacons that feed it. Kill switch: flip to false / byEnv to disable a env.
 export const ENABLE_MONITOR = true;
+// Project Library / dynamic canvases. Off in production this release; on elsewhere.
+export const ENABLE_CANVAS = byEnv({ production: false }, true);
 
 export const getProductFeedbackUrl = (locale = "en-US") =>
 	`https://portal.dembrane.com/${locale}/a2b7fbeb-af8d-41c8-b70b-9ff1f3c6d51a/start?theme=dm-sans`;

--- a/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
@@ -16,7 +16,7 @@ import { useLocation, useParams } from "react-router";
 import { useProjectChatsCountQuery } from "@/components/chat/hooks";
 import { useConversationsCountByProjectId } from "@/components/conversation/hooks";
 import { useProjectById } from "@/components/project/hooks";
-import { ENABLE_MONITOR } from "@/config";
+import { ENABLE_CANVAS, ENABLE_MONITOR } from "@/config";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { isReadOnlyRole } from "@/lib/roles";
 import { BackButton } from "../../primitives/BackButton";
@@ -88,12 +88,14 @@ export const ProjectHomeView = () => {
 					icon={BroadcastIcon}
 				/>
 			)}
-			<NavItem
-				to={`${base}/library`}
-				label={<Trans>Library</Trans>}
-				icon={BooksIcon}
-				active={libraryActive}
-			/>
+			{ENABLE_CANVAS && (
+				<NavItem
+					to={`${base}/library`}
+					label={<Trans>Library</Trans>}
+					icon={BooksIcon}
+					active={libraryActive}
+				/>
+			)}
 			<NavItem
 				to={`${base}/host-guide`}
 				label={<Trans>Host guide</Trans>}

--- a/echo/server/.env.sample
+++ b/echo/server/.env.sample
@@ -30,6 +30,7 @@ DISABLE_CHAT_TITLE_GENERATION=0
 SERVE_API_DOCS=0
 DISABLE_SENTRY=0
 ENABLE_MONITOR=1
+ENABLE_CANVAS=1
 
 ############################################################
 # Transcription providers

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -10,7 +10,7 @@ from logging import getLogger
 from datetime import datetime, timezone
 from contextlib import suppress
 
-from fastapi import Query, Request, APIRouter, HTTPException
+from fastapi import Query, Depends, Request, APIRouter, HTTPException
 from pydantic import Field, BaseModel
 from fastapi.responses import JSONResponse, StreamingResponse
 
@@ -48,6 +48,7 @@ from dembrane.agentic_runtime import (
     subscribe_live_events,
 )
 from dembrane.service.agentic import TERMINAL_RUN_STATUSES, AgenticRunNotFoundException
+from dembrane.api.feature_flags import require_canvas_enabled
 from dembrane.api.dependency_auth import DirectusSession, DependencyDirectusSession
 
 AgenticRouter = APIRouter(tags=["agentic"])
@@ -1585,7 +1586,10 @@ async def _get_project_chat_or_404(
     return chat
 
 
-@AgenticRouter.get("/projects/{project_id}/canvases")
+@AgenticRouter.get(
+    "/projects/{project_id}/canvases",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def list_project_canvases(
     project_id: str,
     auth: DependencyDirectusSession,
@@ -1654,7 +1658,10 @@ async def _recent_loop_runs(loop_id: str, limit: int) -> list[dict[str, Any]]:
     ]
 
 
-@AgenticRouter.get("/projects/{project_id}/chats/{chat_id}/canvas-activity")
+@AgenticRouter.get(
+    "/projects/{project_id}/chats/{chat_id}/canvas-activity",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def list_chat_canvas_activity(
     project_id: str,
     chat_id: str,
@@ -1709,7 +1716,10 @@ async def list_chat_canvas_activity(
     return {"canvases": canvases}
 
 
-@AgenticRouter.get("/projects/{project_id}/canvases/{canvas_id}")
+@AgenticRouter.get(
+    "/projects/{project_id}/canvases/{canvas_id}",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def get_project_canvas(
     project_id: str,
     canvas_id: str,
@@ -1731,7 +1741,10 @@ async def get_project_canvas(
     }
 
 
-@AgenticRouter.get("/projects/{project_id}/canvases/{canvas_id}/history")
+@AgenticRouter.get(
+    "/projects/{project_id}/canvases/{canvas_id}/history",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def get_project_canvas_history(
     project_id: str,
     canvas_id: str,
@@ -1750,7 +1763,10 @@ async def get_project_canvas_history(
     }
 
 
-@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/edit")
+@AgenticRouter.post(
+    "/projects/{project_id}/canvases/{canvas_id}/edit",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def edit_project_canvas(
     project_id: str,
     canvas_id: str,
@@ -1778,7 +1794,10 @@ async def edit_project_canvas(
     }
 
 
-@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/host-items")
+@AgenticRouter.post(
+    "/projects/{project_id}/canvases/{canvas_id}/host-items",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def add_project_canvas_host_item(
     project_id: str,
     canvas_id: str,
@@ -1801,7 +1820,10 @@ async def add_project_canvas_host_item(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/host-items/remove")
+@AgenticRouter.post(
+    "/projects/{project_id}/canvases/{canvas_id}/host-items/remove",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def remove_project_canvas_host_item(
     project_id: str,
     canvas_id: str,
@@ -1819,7 +1841,10 @@ async def remove_project_canvas_host_item(
     )
 
 
-@AgenticRouter.post("/projects/{project_id}/canvases/{canvas_id}/loop/{action}")
+@AgenticRouter.post(
+    "/projects/{project_id}/canvases/{canvas_id}/loop/{action}",
+    dependencies=[Depends(require_canvas_enabled)],
+)
 async def update_project_canvas_loop(
     project_id: str,
     canvas_id: str,

--- a/echo/server/dembrane/api/feature_flags.py
+++ b/echo/server/dembrane/api/feature_flags.py
@@ -1,0 +1,13 @@
+"""FastAPI dependencies that gate routes behind feature flags."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from dembrane.settings import get_settings
+
+
+def require_canvas_enabled() -> None:
+    """404 (not 403, to hide existence) when the canvas feature is disabled."""
+    if not get_settings().feature_flags.enable_canvas:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")

--- a/echo/server/dembrane/api/v2/bff/canvases.py
+++ b/echo/server/dembrane/api/v2/bff/canvases.py
@@ -7,7 +7,7 @@ import time
 from typing import Any
 from datetime import datetime, timezone, timedelta
 
-from fastapi import Query, Request, APIRouter, HTTPException, status
+from fastapi import Query, Depends, Request, APIRouter, HTTPException, status
 from pydantic import Field, BaseModel
 from fastapi.responses import StreamingResponse
 
@@ -38,10 +38,11 @@ from dembrane.canvas.service import (
 )
 from dembrane.directus_async import async_directus
 from dembrane.canvas.sanitize import sanitize_canvas_html
+from dembrane.api.feature_flags import require_canvas_enabled
 from dembrane.api.v2.bff._access import resolve_report_access, resolve_project_access
 from dembrane.api.dependency_auth import DependencyDirectusSession
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_canvas_enabled)])
 
 REFRESH_TTL_SECONDS = 30
 PREVIEW_TTL_SECONDS = 10

--- a/echo/server/dembrane/settings.py
+++ b/echo/server/dembrane/settings.py
@@ -277,6 +277,12 @@ class FeatureFlagSettings(BaseSettings):
         alias="ENABLE_MONITOR",
         validation_alias=AliasChoices("ENABLE_MONITOR", "FEATURE_FLAGS__ENABLE_MONITOR"),
     )
+    # Default on; production sets ENABLE_CANVAS=0 to pull the feature this release.
+    enable_canvas: bool = Field(
+        default=True,
+        alias="ENABLE_CANVAS",
+        validation_alias=AliasChoices("ENABLE_CANVAS", "FEATURE_FLAGS__ENABLE_CANVAS"),
+    )
 
 
 class DirectusSettings(BaseSettings):


### PR DESCRIPTION
  Add an ENABLE_CANVAS flag so the Library/canvas feature is off in
  production but stays on in next/staging/local. Frontend hides the
  Library nav item and library/canvas routes (byEnv); backend 404s the
  bff canvas router and agentic canvas endpoints when disabled.