### PR TITLE
fix(dev): wire agentic chat to run in the local devcontainer

### DIFF
--- a/echo/.devcontainer/docker-compose.yml
+++ b/echo/.devcontainer/docker-compose.yml
@@ -70,6 +70,9 @@ services:
       dockerfile: echo/agent/Dockerfile
     ports:
       - 8001:8001
+    env_file:
+      - path: ../agent/.env
+        required: false
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - ECHO_API_URL=http://devcontainer:8000/api

--- a/echo/agent/.env.sample
+++ b/echo/agent/.env.sample
@@ -1,5 +1,7 @@
-GEMINI_API_KEY=
 ECHO_API_URL=http://host.docker.internal:8000/api
-LLM_MODEL=gemini-3-pro-preview
+LLM_MODEL=gemini-3.5-flash
+VERTEX_LOCATION=eu
 AGENT_GRAPH_RECURSION_LIMIT=80
 AGENT_CORS_ORIGINS=http://localhost:5173,http://localhost:5174
+VERTEX_CREDENTIALS=
+GCP_SA_JSON=

--- a/echo/mprocs.yaml
+++ b/echo/mprocs.yaml
@@ -6,7 +6,7 @@
 # Tip:  mprocs --names server,workers   to launch a subset
 procs:
   server:
-    shell: "uv run uvicorn dembrane.main:app --port 8000 --reload --loop asyncio"
+    shell: "uv run uvicorn dembrane.main:app --host 0.0.0.0 --port 8000 --reload --loop asyncio"
     cwd: server
 
   workers:

--- a/echo/server/run.sh
+++ b/echo/server/run.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-uv run uvicorn dembrane.main:app --port 8000 --reload --loop asyncio
+# --host 0.0.0.0 lets sibling containers (the agent service) reach the API.
+uv run uvicorn dembrane.main:app --host 0.0.0.0 --port 8000 --reload --loop asyncio


### PR DESCRIPTION
  Agentic chat worked on echo-next but not locally due to dev-only
  networking gaps. No application code changed.

  - server/run.sh, mprocs.yaml: bind uvicorn to 0.0.0.0 so the agent container can call back into the API by hostname (was 127.0.0.1, which refused cross-container requests). Prod already binds 0.0.0.0.
  - .devcontainer/docker-compose.yml: load echo/agent/.env (required: false) so the agent gets Vertex creds; the empty GEMINI_API_KEY default left it unable to authenticate.
  - agent/.env.sample: fix stale model, document required Vertex auth.