### PR TITLE
fix(workspace): re-sync workspace context on open so project lists don't go stale

### DIFF
--- a/echo/frontend/src/components/settings/MyAccessCard.tsx
+++ b/echo/frontend/src/components/settings/MyAccessCard.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
+import { useWorkspace } from "@/hooks/useWorkspace";
 import { displayRole, roleColor } from "@/lib/roles";
 
 export interface Workspace {
@@ -63,7 +64,14 @@ export const useMyAccess = () => {
  */
 export const MyAccessCard = () => {
 	const navigate = useI18nNavigate();
+	const { setWorkspace } = useWorkspace();
 	const { data, isLoading } = useMyAccess();
+
+	// Sync context first so workspace-scoped queries don't lag.
+	const openWorkspace = (id: string) => {
+		setWorkspace(id);
+		navigate(`/w/${id}/home`);
+	};
 
 	// Group workspaces under their organisation so the list reads as
 	// "organisation → workspaces in that organisation with your role."
@@ -176,7 +184,7 @@ export const MyAccessCard = () => {
 												justify="space-between"
 												wrap="nowrap"
 												style={{ cursor: "pointer" }}
-												onClick={() => navigate(`/w/${ws.id}/home`)}
+												onClick={() => openWorkspace(ws.id)}
 											>
 												<Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
 													<Text size="sm" lineClamp={1}>

--- a/echo/frontend/src/components/workspace/DiscoverableWorkspaces.tsx
+++ b/echo/frontend/src/components/workspace/DiscoverableWorkspaces.tsx
@@ -129,6 +129,8 @@ export const DiscoverableWorkspaces = ({ orgId }: { orgId: string }) => {
 			["v2", "discoverable-workspaces", orgId],
 			["v2", "organisation", orgId, "workspaces"],
 			["v2", "workspace-usage"],
+			["v2", "workspace-projects"],
+			["projects"],
 		]) {
 			queryClient.invalidateQueries({ queryKey: key });
 		}

--- a/echo/frontend/src/hooks/useWorkspace.test.tsx
+++ b/echo/frontend/src/hooks/useWorkspace.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+	useWorkspace,
+	useWorkspaceProvider,
+	WorkspaceContext,
+	type WorkspaceContextValue,
+} from "./useWorkspace";
+
+const WS_DEFAULT = "11111111-1111-4111-8111-111111111111";
+const WS_TARGET = "22222222-2222-4222-8222-222222222222";
+
+const workspaceSummary = (id: string, name: string, isDefault: boolean) => ({
+	id,
+	is_default: isDefault,
+	logo_url: null,
+	member_count: 1,
+	name,
+	org_id: "org-1",
+	org_logo_url: null,
+	org_name: "Org",
+	project_count: 0,
+	role: "admin",
+	tier: "pioneer",
+});
+
+let workspacesFetchCount: number;
+// Fetch #1 returns only the default workspace; later fetches also include the
+// target, mimicking access granted after the list was first cached.
+let targetVisibleFromFetch: number;
+
+const jsonResponse = (body: unknown) =>
+	({ json: async () => body, ok: true, status: 200 }) as Response;
+
+beforeEach(() => {
+	workspacesFetchCount = 0;
+	targetVisibleFromFetch = Number.POSITIVE_INFINITY;
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (url: RequestInfo | URL) => {
+			const u = String(url);
+			if (u.includes("/v2/workspaces")) {
+				workspacesFetchCount += 1;
+				const workspaces = [workspaceSummary(WS_DEFAULT, "Default", true)];
+				if (workspacesFetchCount >= targetVisibleFromFetch) {
+					workspaces.push(workspaceSummary(WS_TARGET, "Customer", false));
+				}
+				return jsonResponse({ workspaces });
+			}
+			if (u.includes("/v2/me")) {
+				return jsonResponse({
+					avatar: null,
+					directus_user_id: "du-1",
+					display_name: "Staff",
+					email: "staff@dembrane.com",
+					has_legacy_projects: false,
+					has_pending_invites: false,
+					id: "au-1",
+					is_staff: true,
+					onboarding_answer_json: null,
+					onboarding_completed: true,
+					orgs: [],
+					settings: {},
+				});
+			}
+			return { json: async () => ({}), ok: false, status: 404 } as Response;
+		}),
+	);
+	window.history.replaceState({}, "", "/");
+	sessionStorage.clear();
+	localStorage.clear();
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+let ctx: WorkspaceContextValue;
+
+const Consumer = () => {
+	ctx = useWorkspace();
+	return <div data-testid="ws">{ctx.workspaceId ?? ""}</div>;
+};
+
+const Provider = ({ children }: PropsWithChildren) => {
+	const value = useWorkspaceProvider(true);
+	return (
+		<WorkspaceContext.Provider value={value}>
+			{children}
+		</WorkspaceContext.Provider>
+	);
+};
+
+const renderProvider = () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<Provider>
+				<Consumer />
+			</Provider>
+		</QueryClientProvider>,
+	);
+};
+
+it("re-reads the URL when setWorkspace repeats the already-selected id", async () => {
+	// Stale-projects repro: a same-id setWorkspace after navigation used to bail
+	// out of rendering, leaving the context stuck on the wrong workspace.
+	const { getByTestId } = renderProvider();
+	await waitFor(() => expect(getByTestId("ws").textContent).toBe(WS_DEFAULT));
+
+	// Click: selection changes while the URL still points at the old page.
+	act(() => ctx.setWorkspace(WS_TARGET));
+	expect(getByTestId("ws").textContent).toBe(WS_DEFAULT);
+
+	// Router finishes navigating; WorkspaceLayout re-fires the same id.
+	window.history.pushState({}, "", `/w/${WS_TARGET}/home`);
+	act(() => ctx.setWorkspace(WS_TARGET));
+	expect(getByTestId("ws").textContent).toBe(WS_TARGET);
+});
+
+it("refetches the workspace list when the URL pins a workspace it does not contain", async () => {
+	// Freshly granted access: the cached list lacks the workspace, so the
+	// provider should refetch and resolve its name without a manual refresh.
+	targetVisibleFromFetch = 2;
+	window.history.replaceState({}, "", `/w/${WS_TARGET}/home`);
+	const { getByTestId } = renderProvider();
+	await waitFor(() => expect(getByTestId("ws").textContent).toBe(WS_TARGET));
+
+	await waitFor(() => expect(ctx.workspaceName).toBe("Customer"));
+	expect(workspacesFetchCount).toBe(2);
+});

--- a/echo/frontend/src/hooks/useWorkspace.ts
+++ b/echo/frontend/src/hooks/useWorkspace.ts
@@ -5,6 +5,7 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { API_BASE_URL } from "@/config";
@@ -148,6 +149,9 @@ export function useWorkspaceProvider(enabled: boolean): WorkspaceContextValue {
 			? sessionStorage.getItem(SESSION_KEY)
 			: null;
 	});
+	// Bumped by setWorkspace so same-id calls still re-render and re-read the URL
+	// (the provider mounts above the router, so navigation alone never re-renders it).
+	const [, setSyncEpoch] = useState(0);
 
 	const {
 		data: workspaces = [],
@@ -191,6 +195,23 @@ export function useWorkspaceProvider(enabled: boolean): WorkspaceContextValue {
 		? (workspaces.find((w) => w.id === effectiveId) ?? null)
 		: null;
 
+	// URL-pinned workspace missing from the loaded list = access granted after the
+	// last fetch. Refetch once per id so name/role resolve without a manual refresh.
+	const missingPinnedId =
+		enabled &&
+		urlPinnedId &&
+		!isLoading &&
+		!workspaces.some((w) => w.id === urlPinnedId)
+			? urlPinnedId
+			: null;
+	const refetchedForRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (missingPinnedId && refetchedForRef.current !== missingPinnedId) {
+			refetchedForRef.current = missingPinnedId;
+			refetch();
+		}
+	}, [missingPinnedId, refetch]);
+
 	const setWorkspace = useCallback(
 		(id: string) => {
 			sessionStorage.setItem(SESSION_KEY, id);
@@ -198,7 +219,9 @@ export function useWorkspaceProvider(enabled: boolean): WorkspaceContextValue {
 			if (userId) {
 				localStorage.setItem(lastWorkspaceKey(userId), id);
 			}
-			setSelectedId(id); // triggers re-render
+			setSelectedId(id);
+			// A same-id setSelectedId bails out of rendering; always force one.
+			setSyncEpoch((epoch) => epoch + 1);
 		},
 		[userId],
 	);

--- a/echo/frontend/src/routes/organisation/OrganisationExternalView.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationExternalView.tsx
@@ -24,8 +24,14 @@ interface Props {
 // The admin pages (members / usage / etc.) 403 for them, so we render a
 // calmer "here's what you can do" page instead.
 export const OrganisationExternalView = ({ organisationId }: Props) => {
-	const { workspaces } = useWorkspace();
+	const { workspaces, setWorkspace } = useWorkspace();
 	const navigate = useNavigate();
+
+	// Sync context first so workspace-scoped queries don't lag.
+	const openWorkspace = (id: string) => {
+		setWorkspace(id);
+		navigate(`/w/${id}/home`);
+	};
 
 	const orgWorkspaces = workspaces.filter((w) => w.org_id === organisationId);
 	const first = orgWorkspaces[0];
@@ -86,7 +92,7 @@ export const OrganisationExternalView = ({ organisationId }: Props) => {
 								p="md"
 								withBorder
 								className="cursor-pointer"
-								onClick={() => navigate(`/w/${ws.id}/home`)}
+								onClick={() => openWorkspace(ws.id)}
 							>
 								<Group justify="space-between" align="center" wrap="nowrap">
 									<Stack gap={2}>
@@ -109,7 +115,7 @@ export const OrganisationExternalView = ({ organisationId }: Props) => {
 										size="xs"
 										onClick={(e) => {
 											e.stopPropagation();
-											navigate(`/w/${ws.id}/home`);
+											openWorkspace(ws.id);
 										}}
 									>
 										<Trans>Open</Trans>

--- a/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
+++ b/echo/frontend/src/routes/organisation/OrganisationRoute.tsx
@@ -412,7 +412,7 @@ export const OrganisationRoute = () => {
 	// The current user's full workspace list (provided by the app-level
 	// WorkspaceProvider). Used to detect external-only mode when the
 	// org-level fetches 403.
-	const { workspaces: userWorkspaces } = useWorkspace();
+	const { workspaces: userWorkspaces, setWorkspace } = useWorkspace();
 
 	// Free tier: one workspace per org. Gate the "New workspace" action on click
 	// (open the upgrade modal) rather than letting the user fill the create flow.
@@ -795,10 +795,15 @@ export const OrganisationRoute = () => {
 								workspaces={workspaces}
 								isManager={isAdmin}
 								atWorkspaceLimit={atWorkspaceLimit}
-								onOpenWorkspace={(id) => navigate(`/w/${id}/home`)}
-								onOpenProject={(wsId, projectId) =>
-									navigate(`/w/${wsId}/projects/${projectId}/home`)
-								}
+								onOpenWorkspace={(id) => {
+									// Sync context first so workspace-scoped queries don't lag.
+									setWorkspace(id);
+									navigate(`/w/${id}/home`);
+								}}
+								onOpenProject={(wsId, projectId) => {
+									setWorkspace(wsId);
+									navigate(`/w/${wsId}/projects/${projectId}/home`);
+								}}
 								onRequestWorkspace={() => {
 									if (atWorkspaceLimit) {
 										wsUpgradeHandlers.open();


### PR DESCRIPTION
  Opening a just-granted workspace showed the previous workspace's projects
  until a tab refresh. WorkspaceProvider mounts above the router and reads
  window.location during render, so it only re-reads the URL when a state
  change re-renders it. The "Open workspace" click sets the selection before
  navigation, so WorkspaceLayout's corrective setWorkspace call carried the
  same id and React's same-value bailout skipped the re-render, leaving the
  context pinned to the old workspace.

  - setWorkspace bumps a sync epoch so same-id calls still force a re-render and a fresh URL read
  - the provider refetches the workspace list once per URL-pinned id it doesn't contain, so a freshly granted workspace resolves name and role
  - org overview, external view, and My Access now call setWorkspace before navigating, matching the staff "Open workspace" flow
  - bulk join also invalidates workspace-projects/projects caches