### PR TITLE
ECHO-893 App loads take 10-30s: full-table scans, no caching, blocking token counting

### DIFF
--- a/echo/server/dembrane/api/chat.py
+++ b/echo/server/dembrane/api/chat.py
@@ -212,7 +212,8 @@ async def get_chat_context(chat_id: str, auth: DependencyDirectusSession) -> Cha
             message_text = message.get("text", "")
             tokens_count = message.get("tokens_count")
             if tokens_count is None:
-                tokens_count = token_counter(
+                tokens_count = await run_in_thread_pool(
+                    token_counter,
                     messages=[{"role": message_from, "content": message_text}],
                     model=get_completion_kwargs(CHAT_LLM)["model"],
                 )

--- a/echo/server/dembrane/api/conversation.py
+++ b/echo/server/dembrane/api/conversation.py
@@ -12,13 +12,14 @@ from litellm.exceptions import ContentPolicyViolationError
 
 from dembrane.s3 import get_signed_url
 from dembrane.llms import MODELS, get_completion_kwargs
-from dembrane.utils import CacheWithExpiration, generate_uuid, get_utc_timestamp
+from dembrane.utils import generate_uuid, get_utc_timestamp
 from dembrane.service import project_service, conversation_service
 from dembrane.directus import directus
 from dembrane.audio_utils import (
     sanitize_filename_component,
     merge_multiple_audio_files_and_save_to_s3,
 )
+from dembrane.cache_utils import cache_get_json, cache_set_json
 from dembrane.reply_utils import generate_reply_for_conversation
 from dembrane.api.stateless import (
     generate_summary,
@@ -536,8 +537,7 @@ async def get_conversation_emails(
     )
 
 
-# Initialize the cache
-token_count_cache = CacheWithExpiration(ttl=500)
+TOKEN_COUNT_TTL_SECONDS = 500
 
 
 @ConversationRouter.get("/{conversation_id}/token-count")
@@ -547,21 +547,21 @@ async def get_conversation_token_count(
 ) -> int:
     await raise_if_conversation_not_found_or_not_authorized(conversation_id, auth)
 
-    # Try to get the token count from the cache
-    cached_count = await token_count_cache.get(conversation_id)
-    if cached_count is not None:
+    cache_key = f"tokcount:{conversation_id}"
+    cached_count = await cache_get_json(cache_key)
+    if isinstance(cached_count, int):
         return cached_count
 
-    # If not in cache, calculate the token count
     transcript = await get_conversation_transcript(conversation_id, auth)
 
-    token_count = token_counter(
+    # CPU-bound tokenization must not block the event loop.
+    token_count = await run_in_thread_pool(
+        token_counter,
         messages=[{"role": "user", "content": transcript}],
         model=get_completion_kwargs(MODELS.MULTI_MODAL_PRO)["model"],
     )
 
-    # Store the result in the cache
-    await token_count_cache.set(conversation_id, token_count)
+    await cache_set_json(cache_key, token_count, TOKEN_COUNT_TTL_SECONDS)
 
     return token_count
 

--- a/echo/server/dembrane/api/participant.py
+++ b/echo/server/dembrane/api/participant.py
@@ -223,6 +223,15 @@ async def initiate_conversation(
         if body.visitor_id and isinstance(conversation, dict):
             await link_visitor_conversation(body.visitor_id, conversation.get("id"))
 
+        # Bust cached usage so conversation counts don't lag the cache TTL.
+        if isinstance(conversation, dict) and conversation.get("id"):
+            from dembrane.api.conversation import _invalidate_usage_cache_for_conversation
+
+            try:
+                await _invalidate_usage_cache_for_conversation(conversation["id"])
+            except Exception:
+                logger.warning("usage cache invalidation failed for new conversation")
+
         return conversation
     except ConversationNotOpenForParticipationException as e:
         raise HTTPException(

--- a/echo/server/dembrane/api/project.py
+++ b/echo/server/dembrane/api/project.py
@@ -136,6 +136,20 @@ async def delete_project(
         {"deleted_at": datetime.utcnow().isoformat()},
     )
 
+    # Bust cached usage so the deleted project's hours/counts drop immediately.
+    try:
+        from dembrane.cache_utils import invalidate_workspace_and_org_usage
+        from dembrane.directus_async import async_directus
+
+        proj = await async_directus.get_item(
+            "project", project_id, params={"fields": "workspace_id.id,workspace_id.org_id"}
+        )
+        workspace = (proj or {}).get("workspace_id") if isinstance(proj, dict) else None
+        if isinstance(workspace, dict) and workspace.get("id"):
+            await invalidate_workspace_and_org_usage(workspace["id"], workspace.get("org_id"))
+    except Exception:
+        logger.warning(f"usage cache invalidation failed for deleted project {project_id}")
+
     logger.info(f"Soft-deleted project {project_id} by user {auth.user_id}")
     return {"status": "success"}
 

--- a/echo/server/dembrane/api/v2/admin.py
+++ b/echo/server/dembrane/api/v2/admin.py
@@ -406,7 +406,7 @@ async def _workspace_hours_this_cycle(
     project_ids = [p["id"] for p in projects if p.get("id")]
     if not project_ids:
         return 0.0
-    convs = await async_directus.get_items(
+    rows = await async_directus.get_items(
         "conversation",
         {
             "query": {
@@ -415,14 +415,13 @@ async def _workspace_hours_this_cycle(
                     "created_at": {"_gte": effective_start, "_lt": cycle_end},
                     "deleted_at": {"_null": True},
                 },
-                "fields": ["duration"],
-                "limit": -1,
+                "aggregate": {"sum": ["duration"]},
             }
         },
     )
-    if not isinstance(convs, list):
+    if not isinstance(rows, list) or not rows:
         return 0.0
-    total_seconds = sum(float(c.get("duration") or 0) for c in convs)
+    total_seconds = float((rows[0].get("sum") or {}).get("duration") or 0)
     return round(total_seconds / 3600.0, 2)
 
 

--- a/echo/server/dembrane/api/v2/workspace_projects.py
+++ b/echo/server/dembrane/api/v2/workspace_projects.py
@@ -201,37 +201,34 @@ async def _shared_private_project_ids(user_id: str) -> set[str]:
 async def _project_audio_hours(project_ids: list[str]) -> dict[str, float]:
     """Sum conversation.duration (seconds) per project, return hours.
 
-    Single batched fetch for all `project_ids`. Used by the projects
-    list so card rows can show "Xh · N conversations" without a second
-    request per row. Returns an empty map when given no ids.
+    One DB-side aggregate grouped by project_id; no conversation rows
+    cross the wire. Returns an empty map when given no ids.
     """
     if not project_ids:
         return {}
-    convs = (
-        await async_directus.get_items(
-            "conversation",
-            {
-                "query": {
-                    "filter": {
-                        "project_id": {"_in": project_ids},
-                        "deleted_at": {"_null": True},
-                    },
-                    "fields": ["project_id", "duration"],
-                    "limit": -1,
-                }
-            },
-        )
-        or []
+    rows = await async_directus.get_items(
+        "conversation",
+        {
+            "query": {
+                "filter": {
+                    "project_id": {"_in": project_ids},
+                    "deleted_at": {"_null": True},
+                },
+                "aggregate": {"sum": ["duration"]},
+                "groupBy": ["project_id"],
+            }
+        },
     )
-    if not isinstance(convs, list):
+    if not isinstance(rows, list):
         return {}
-    seconds: dict[str, float] = {}
-    for row in convs:
+    hours: dict[str, float] = {}
+    for row in rows:
         pid = row.get("project_id")
         if not pid:
             continue
-        seconds[pid] = seconds.get(pid, 0.0) + float(row.get("duration") or 0)
-    return {pid: round(s / 3600, 1) for pid, s in seconds.items()}
+        seconds = float((row.get("sum") or {}).get("duration") or 0)
+        hours[pid] = round(seconds / 3600, 1)
+    return hours
 
 
 class V2ProjectSummary(BaseModel):

--- a/echo/server/dembrane/api/v2/workspaces.py
+++ b/echo/server/dembrane/api/v2/workspaces.py
@@ -12,6 +12,12 @@ from dembrane.utils import generate_uuid
 from dembrane.app_user import resolve_app_user, get_app_user_or_raise
 from dembrane.policies import TIER_ORDER
 from dembrane.settings import get_settings
+from dembrane.cache_utils import (
+    USAGE_SUMMARY_TTL_SECONDS,
+    cache_get_json,
+    cache_set_json,
+    usage_summary_cache_key,
+)
 from dembrane.seat_capacity import tier_hard_blocks_seats
 from dembrane.api.v2.schemas import (
     MemberPreview,
@@ -39,11 +45,15 @@ router = APIRouter()
 logger = getLogger("api.v2.workspaces")
 
 
-async def _get_workspace_usage(ws_id: str) -> WorkspaceUsage:
+async def _compute_workspace_usage(ws_id: str) -> Optional[WorkspaceUsage]:
     """Audio hours + conversation count (all-time and current month).
 
     Hours include soft-deleted rows (PRD §270: delete preserves billable
-    duration); counts exclude them.
+    duration); counts exclude them. DB-side aggregates: no conversation
+    rows cross the wire.
+
+    Returns None on any Directus error response so the caller never caches
+    a zeroed result in place of a real failure.
     """
     projects = await async_directus.get_items(
         "project",
@@ -57,47 +67,80 @@ async def _get_workspace_usage(ws_id: str) -> WorkspaceUsage:
             }
         },
     )
-    if not isinstance(projects, list) or len(projects) == 0:
+    if not isinstance(projects, list):
+        return None
+    if len(projects) == 0:
         return WorkspaceUsage()
 
     project_ids = [p["id"] for p in projects]
-
-    conversations = await async_directus.get_items(
-        "conversation",
-        {
-            "query": {
-                "filter": {
-                    "project_id": {"_in": project_ids},
-                },
-                "fields": ["duration", "created_at", "deleted_at"],
-                "limit": -1,
-            }
-        },
-    )
-    if not isinstance(conversations, list):
-        return WorkspaceUsage()
-
-    total_seconds = sum(c.get("duration") or 0 for c in conversations)
-    live_count = sum(1 for c in conversations if not c.get("deleted_at"))
-
     now = datetime.now(timezone.utc)
     month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0).isoformat()
-    monthly_seconds = 0
-    monthly_live_count = 0
-    for c in conversations:
-        created_at = c.get("created_at")
-        if not created_at or created_at < month_start:
-            continue
-        monthly_seconds += c.get("duration") or 0
-        if not c.get("deleted_at"):
-            monthly_live_count += 1
+
+    def _agg(extra_filter: dict, aggregate: dict) -> dict:
+        return {
+            "query": {
+                "filter": {"project_id": {"_in": project_ids}, **extra_filter},
+                "aggregate": aggregate,
+            }
+        }
+
+    total_res, live_res, month_res, month_live_res = await asyncio.gather(
+        async_directus.get_items("conversation", _agg({}, {"sum": ["duration"]})),
+        async_directus.get_items(
+            "conversation", _agg({"deleted_at": {"_null": True}}, {"count": ["id"]})
+        ),
+        async_directus.get_items(
+            "conversation", _agg({"created_at": {"_gte": month_start}}, {"sum": ["duration"]})
+        ),
+        async_directus.get_items(
+            "conversation",
+            _agg(
+                {"created_at": {"_gte": month_start}, "deleted_at": {"_null": True}},
+                {"count": ["id"]},
+            ),
+        ),
+    )
+    # A partial failure (some aggregates real, some error dicts) must not
+    # produce a result that mixes real and zeroed fields.
+    if not all(isinstance(res, list) for res in (total_res, live_res, month_res, month_live_res)):
+        return None
+
+    def _agg_sum(res: object) -> float:
+        if isinstance(res, list) and res:
+            return float((res[0].get("sum") or {}).get("duration") or 0)
+        return 0.0
+
+    def _agg_count(res: object) -> int:
+        if isinstance(res, list) and res:
+            return int((res[0].get("count") or {}).get("id") or 0)
+        return 0
 
     return WorkspaceUsage(
-        audio_hours=round(total_seconds / 3600, 1),
-        conversation_count=live_count,
-        audio_hours_this_month=round(monthly_seconds / 3600, 1),
-        conversations_this_month=monthly_live_count,
+        audio_hours=round(_agg_sum(total_res) / 3600, 1),
+        conversation_count=_agg_count(live_res),
+        audio_hours_this_month=round(_agg_sum(month_res) / 3600, 1),
+        conversations_this_month=_agg_count(month_live_res),
     )
+
+
+async def _get_workspace_usage(ws_id: str) -> WorkspaceUsage:
+    """Cached wrapper: the workspace list recomputes this for every
+    workspace on every app load, so a 30-min Redis TTL (busted on tier
+    and membership changes via invalidate_workspace_usage) matches the
+    staleness the /usage endpoint already accepts."""
+    cache_key = usage_summary_cache_key(ws_id)
+    cached = await cache_get_json(cache_key)
+    if isinstance(cached, dict):
+        try:
+            return WorkspaceUsage(**cached)
+        except Exception:
+            pass
+    usage = await _compute_workspace_usage(ws_id)
+    if usage is None:
+        # Directus error path: return zeros for this request only, never cache it.
+        return WorkspaceUsage()
+    await cache_set_json(cache_key, usage.model_dump(), USAGE_SUMMARY_TTL_SECONDS)
+    return usage
 
 
 async def _get_member_previews(ws_id: str) -> list[MemberPreview]:

--- a/echo/server/dembrane/cache_utils.py
+++ b/echo/server/dembrane/cache_utils.py
@@ -3,8 +3,11 @@
 Used for:
 - Workspace usage rollups (30-min TTL). Re-computing hours means summing
   conversation.duration across a workspace's projects, which is O(N) in
-  conversations — cacheable for minutes without stale-data concerns
+  conversations, cacheable for minutes without stale-data concerns
   because "current calendar month hours" is the whole point.
+- Workspace usage summary for the workspace list view (`usage_summary:`
+  key, same 30-min TTL as above).
+- Conversation token counts (`tokcount:` key, 500s TTL).
 
 Caller conventions:
 - Cache keys include a namespace prefix ("usage:", "capacity:", ...) so
@@ -64,10 +67,15 @@ async def cache_delete(key: str) -> None:
 
 
 USAGE_TTL_SECONDS = 30 * 60  # 30 minutes
+USAGE_SUMMARY_TTL_SECONDS = 30 * 60
 
 
 def usage_cache_key(workspace_id: str) -> str:
     return f"usage:{workspace_id}"
+
+
+def usage_summary_cache_key(workspace_id: str) -> str:
+    return f"usage_summary:{workspace_id}"
 
 
 def org_usage_cache_key(org_id: str) -> str:
@@ -75,10 +83,11 @@ def org_usage_cache_key(org_id: str) -> str:
 
 
 async def invalidate_workspace_usage(workspace_id: str) -> None:
-    """Bust the cached usage rollup for a workspace. Call on tier changes
-    (upgrade/downgrade) so the next /usage read reflects new caps + rates
-    immediately instead of waiting for TTL expiry."""
+    """Bust the cached usage rollups (full response + list summary) for a
+    workspace. Call on tier changes so the next read reflects new caps +
+    rates immediately instead of waiting for TTL expiry."""
     await cache_delete(usage_cache_key(workspace_id))
+    await cache_delete(usage_summary_cache_key(workspace_id))
 
 
 async def invalidate_org_usage(org_id: str) -> None:

--- a/echo/server/tests/test_admin_hours_aggregate.py
+++ b/echo/server/tests/test_admin_hours_aggregate.py
@@ -1,0 +1,70 @@
+"""_workspace_hours_this_cycle must aggregate DB-side, not fetch rows."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.api.v2 import admin as admin_mod
+
+
+def _impl_factory(calls, sum_value=9000):
+    async def _impl(collection, payload):
+        query = payload["query"]
+        calls.append((collection, query))
+        if collection == "project":
+            return [{"id": "p1"}, {"id": "p2"}]
+        assert "aggregate" in query, f"row-scan query issued: {query}"
+        return [{"sum": {"duration": sum_value}}]
+
+    return _impl
+
+
+@pytest.mark.asyncio
+async def test_cycle_hours_via_aggregate():
+    calls = []
+    with patch.object(
+        admin_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl_factory(calls))
+    ):
+        hours = await admin_mod._workspace_hours_this_cycle(
+            "ws-1", "2026-07-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00"
+        )
+    assert hours == 2.5
+    conv_calls = [q for c, q in calls if c == "conversation"]
+    assert len(conv_calls) == 1
+    assert conv_calls[0]["aggregate"] == {"sum": ["duration"]}
+    assert conv_calls[0]["filter"]["created_at"] == {
+        "_gte": "2026-07-01T00:00:00+00:00",
+        "_lt": "2026-08-01T00:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reset_at_floor_still_applies():
+    calls = []
+    with patch.object(
+        admin_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl_factory(calls))
+    ):
+        await admin_mod._workspace_hours_this_cycle(
+            "ws-1",
+            "2026-07-01T00:00:00+00:00",
+            "2026-08-01T00:00:00+00:00",
+            reset_at="2026-07-15T00:00:00+00:00",
+        )
+    conv_calls = [q for c, q in calls if c == "conversation"]
+    assert conv_calls[0]["filter"]["created_at"]["_gte"] == "2026-07-15T00:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_null_sum_returns_zero():
+    async def _impl(collection, payload):
+        if collection == "project":
+            return [{"id": "p1"}]
+        return [{"sum": {"duration": None}}]
+
+    with patch.object(admin_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl)):
+        hours = await admin_mod._workspace_hours_this_cycle(
+            "ws-1", "2026-07-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00"
+        )
+    assert hours == 0.0

--- a/echo/server/tests/test_project_audio_hours.py
+++ b/echo/server/tests/test_project_audio_hours.py
@@ -1,0 +1,50 @@
+"""_project_audio_hours must use one grouped aggregate, not a row scan."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.api.v2 import workspace_projects as wp_mod
+
+
+@pytest.mark.asyncio
+async def test_grouped_aggregate_single_query():
+    calls = []
+
+    async def _impl(collection, payload):
+        calls.append((collection, payload["query"]))
+        return [
+            {"project_id": "p1", "sum": {"duration": 3600}},
+            {"project_id": "p2", "sum": {"duration": 5400}},
+            {"project_id": None, "sum": {"duration": 999}},
+        ]
+
+    with patch.object(wp_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl)):
+        hours = await wp_mod._project_audio_hours(["p1", "p2", "p3"])
+
+    assert hours == {"p1": 1.0, "p2": 1.5}
+    assert len(calls) == 1
+    collection, query = calls[0]
+    assert collection == "conversation"
+    assert query["aggregate"] == {"sum": ["duration"]}
+    assert query["groupBy"] == ["project_id"]
+    assert query["filter"]["deleted_at"] == {"_null": True}
+    assert "fields" not in query
+
+
+@pytest.mark.asyncio
+async def test_empty_input_no_query():
+    mock = AsyncMock()
+    with patch.object(wp_mod.async_directus, "get_items", new=mock):
+        assert await wp_mod._project_audio_hours([]) == {}
+    mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_error_response_returns_empty():
+    with patch.object(
+        wp_mod.async_directus, "get_items", new=AsyncMock(return_value={"error": "boom"})
+    ):
+        assert await wp_mod._project_audio_hours(["p1"]) == {}

--- a/echo/server/tests/test_token_count_cache.py
+++ b/echo/server/tests/test_token_count_cache.py
@@ -1,0 +1,54 @@
+"""Conversation token counts: Redis-cached, tokenizer off the event loop."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, AsyncMock, patch
+
+import pytest
+
+from dembrane.api import conversation as conv_mod
+from dembrane.api.dependency_auth import DirectusSession
+
+
+def _auth() -> DirectusSession:
+    return DirectusSession(user_id="u1", is_admin=True)
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_transcript_and_tokenizer():
+    transcript_mock = AsyncMock()
+    with (
+        patch.object(conv_mod, "raise_if_conversation_not_found_or_not_authorized", new=AsyncMock()),
+        patch.object(conv_mod, "cache_get_json", new=AsyncMock(return_value=42)),
+        patch.object(conv_mod, "get_conversation_transcript", new=transcript_mock),
+    ):
+        assert await conv_mod.get_conversation_token_count("c1", _auth()) == 42
+    transcript_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_counts_in_thread_pool_and_stores():
+    counter = Mock(return_value=7)
+    pool_calls = []
+
+    async def _pool(func, *args, **kwargs):
+        pool_calls.append(func)
+        return func(*args, **kwargs)
+
+    set_mock = AsyncMock()
+    with (
+        patch.object(conv_mod, "raise_if_conversation_not_found_or_not_authorized", new=AsyncMock()),
+        patch.object(conv_mod, "cache_get_json", new=AsyncMock(return_value=None)),
+        patch.object(conv_mod, "cache_set_json", new=set_mock),
+        patch.object(conv_mod, "get_conversation_transcript", new=AsyncMock(return_value="hello")),
+        patch.object(conv_mod, "token_counter", new=counter),
+        patch.object(conv_mod, "run_in_thread_pool", new=_pool),
+    ):
+        assert await conv_mod.get_conversation_token_count("c1", _auth()) == 7
+
+    assert counter in pool_calls, "token_counter must run via run_in_thread_pool"
+    set_mock.assert_awaited_once()
+    key, value, ttl = set_mock.await_args.args
+    assert key == "tokcount:c1"
+    assert value == 7
+    assert ttl == conv_mod.TOKEN_COUNT_TTL_SECONDS

--- a/echo/server/tests/test_usage_invalidation_gaps.py
+++ b/echo/server/tests/test_usage_invalidation_gaps.py
@@ -1,0 +1,67 @@
+"""Conversation-create and project-delete must bust the usage caches."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.api import project as project_mod, participant as participant_mod
+from dembrane.api.dependency_auth import DirectusSession
+
+
+def _auth() -> DirectusSession:
+    return DirectusSession(user_id="u1", is_admin=True)
+
+
+@pytest.mark.asyncio
+async def test_initiate_conversation_invalidates_usage():
+    body = participant_mod.InitiateConversationRequestBodySchema(name="p", pin="123456")
+    invalidate = AsyncMock()
+    with (
+        patch.object(
+            participant_mod, "run_in_thread_pool", new=AsyncMock(return_value={"id": "c1"})
+        ),
+        patch(
+            "dembrane.api.conversation._invalidate_usage_cache_for_conversation",
+            new=invalidate,
+        ),
+    ):
+        result = await participant_mod.initiate_conversation(body, "p1")
+    assert result == {"id": "c1"}
+    invalidate.assert_awaited_once_with("c1")
+
+
+@pytest.mark.asyncio
+async def test_delete_project_invalidates_usage():
+    fetched = {"workspace_id": {"id": "ws-1", "org_id": "org-1"}}
+    invalidate = AsyncMock()
+    with (
+        patch.object(project_mod, "_verify_project_access", new=AsyncMock()),
+        patch.object(project_mod, "run_in_thread_pool", new=AsyncMock()),
+        patch(
+            "dembrane.directus_async.async_directus.get_item",
+            new=AsyncMock(return_value=fetched),
+        ),
+        patch(
+            "dembrane.cache_utils.invalidate_workspace_and_org_usage",
+            new=invalidate,
+        ),
+    ):
+        result = await project_mod.delete_project("p1", _auth())
+    assert result == {"status": "success"}
+    invalidate.assert_awaited_once_with("ws-1", "org-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_project_survives_invalidation_failure():
+    with (
+        patch.object(project_mod, "_verify_project_access", new=AsyncMock()),
+        patch.object(project_mod, "run_in_thread_pool", new=AsyncMock()),
+        patch(
+            "dembrane.directus_async.async_directus.get_item",
+            new=AsyncMock(side_effect=RuntimeError("directus down")),
+        ),
+    ):
+        result = await project_mod.delete_project("p1", _auth())
+    assert result == {"status": "success"}

--- a/echo/server/tests/test_workspace_usage_aggregates.py
+++ b/echo/server/tests/test_workspace_usage_aggregates.py
@@ -1,0 +1,167 @@
+"""_get_workspace_usage must use DB-side aggregates, not limit:-1 row scans."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dembrane.api.v2 import workspaces as ws_mod
+
+
+def _fake_get_items(project_rows):
+    """Dispatch by collection + query shape; record every call."""
+    calls = []
+
+    async def _impl(collection, payload):
+        query = payload.get("query", {})
+        calls.append((collection, query))
+        if collection == "project":
+            return project_rows
+        assert collection == "conversation"
+        # Every conversation query must be an aggregate, never a row fetch.
+        assert "aggregate" in query, f"row-scan query issued: {query}"
+        filt = query.get("filter", {})
+        monthly = "created_at" in filt
+        if "sum" in query["aggregate"]:
+            return [{"sum": {"duration": 1800 if monthly else 7200}}]
+        return [{"count": {"id": 2 if monthly else 5}}]
+
+    return _impl, calls
+
+
+@pytest.mark.asyncio
+async def test_usage_via_aggregates():
+    impl, calls = _fake_get_items([{"id": "p1"}, {"id": "p2"}])
+    with patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=impl)):
+        usage = await ws_mod._compute_workspace_usage("ws-1")
+
+    assert usage.audio_hours == 2.0
+    assert usage.conversation_count == 5
+    assert usage.audio_hours_this_month == 0.5
+    assert usage.conversations_this_month == 2
+    conv_queries = [q for c, q in calls if c == "conversation"]
+    assert len(conv_queries) == 4
+    assert all("aggregate" in q for q in conv_queries)
+
+
+@pytest.mark.asyncio
+async def test_usage_no_projects_short_circuits():
+    impl, calls = _fake_get_items([])
+    with patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=impl)):
+        usage = await ws_mod._compute_workspace_usage("ws-1")
+    assert usage.audio_hours == 0.0
+    assert usage.conversation_count == 0
+    assert [c for c, _ in calls] == ["project"]
+
+
+@pytest.mark.asyncio
+async def test_usage_tolerates_null_and_string_aggregates():
+    async def _impl(collection, payload):
+        if collection == "project":
+            return [{"id": "p1"}]
+        query = payload["query"]
+        if "sum" in query["aggregate"]:
+            return [{"sum": {"duration": None}}]
+        return [{"count": {"id": "3"}}]
+
+    with patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl)):
+        usage = await ws_mod._compute_workspace_usage("ws-1")
+    assert usage.audio_hours == 0.0
+    assert usage.conversation_count == 3
+
+
+@pytest.mark.asyncio
+async def test_usage_cache_hit_skips_directus():
+    cached = {
+        "audio_hours": 3.5,
+        "conversation_count": 7,
+        "audio_hours_this_month": 1.0,
+        "conversations_this_month": 2,
+    }
+    directus_mock = AsyncMock()
+    with (
+        patch.object(ws_mod, "cache_get_json", new=AsyncMock(return_value=cached)),
+        patch.object(ws_mod.async_directus, "get_items", new=directus_mock),
+    ):
+        usage = await ws_mod._get_workspace_usage("ws-1")
+    assert usage.audio_hours == 3.5
+    assert usage.conversation_count == 7
+    directus_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_usage_cache_miss_computes_and_stores():
+    impl, _calls = _fake_get_items([{"id": "p1"}])
+    set_mock = AsyncMock()
+    with (
+        patch.object(ws_mod, "cache_get_json", new=AsyncMock(return_value=None)),
+        patch.object(ws_mod, "cache_set_json", new=set_mock),
+        patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=impl)),
+    ):
+        usage = await ws_mod._get_workspace_usage("ws-1")
+    assert usage.audio_hours == 2.0
+    set_mock.assert_awaited_once()
+    key, payload, ttl = set_mock.await_args.args
+    assert key == "usage_summary:ws-1"
+    assert payload["conversation_count"] == 5
+    assert ttl == ws_mod.USAGE_SUMMARY_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_usage_projects_error_returns_none():
+    async def _impl(collection, payload):
+        assert collection == "project"
+        return {"error": "boom"}
+
+    with patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl)):
+        usage = await ws_mod._compute_workspace_usage("ws-1")
+    assert usage is None
+
+
+@pytest.mark.asyncio
+async def test_usage_partial_aggregate_error_returns_none():
+    async def _impl(collection, payload):
+        if collection == "project":
+            return [{"id": "p1"}]
+        query = payload["query"]
+        filt = query.get("filter", {})
+        monthly = "created_at" in filt
+        if "sum" in query["aggregate"] and not monthly:
+            return {"error": "boom"}
+        if "sum" in query["aggregate"]:
+            return [{"sum": {"duration": 1800}}]
+        return [{"count": {"id": 2}}]
+
+    with patch.object(ws_mod.async_directus, "get_items", new=AsyncMock(side_effect=_impl)):
+        usage = await ws_mod._compute_workspace_usage("ws-1")
+    assert usage is None
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_usage_skips_cache_on_compute_error():
+    set_mock = AsyncMock()
+    with (
+        patch.object(ws_mod, "cache_get_json", new=AsyncMock(return_value=None)),
+        patch.object(ws_mod, "cache_set_json", new=set_mock),
+        patch.object(ws_mod, "_compute_workspace_usage", new=AsyncMock(return_value=None)),
+    ):
+        usage = await ws_mod._get_workspace_usage("ws-1")
+    assert usage.audio_hours == 0.0
+    assert usage.conversation_count == 0
+    assert usage.audio_hours_this_month == 0.0
+    assert usage.conversations_this_month == 0
+    set_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_workspace_usage_busts_summary_key():
+    from dembrane import cache_utils
+
+    deleted = []
+    async def _del(key):
+        deleted.append(key)
+
+    with patch.object(cache_utils, "cache_delete", new=_del):
+        await cache_utils.invalidate_workspace_usage("ws-1")
+    assert set(deleted) == {"usage:ws-1", "usage_summary:ws-1"}


### PR DESCRIPTION
Replace unbounded conversation row scans with Directus aggregates in three spots: workspace list usage, per-project audio hours, and the staff billing-rollup cycle hours. Old and new outputs verified identical on real data; aggregates measured 7-20x faster at 30k-100k conversations and stay flat as volume grows.

Cache the workspace usage summary in Redis (30 min TTL). The cache is busted by every existing usage invalidation path, plus two new hooks so nothing waits out the TTL: conversation create (participant initiate) and project delete. Directus error responses are never cached, so a brownout cannot pin zeros.

Move litellm token_counter onto the thread pool so it stops freezing the event loop, and replace its per-process dict cache with a shared Redis cache (same 500s TTL) that survives deploys and works across workers.