### PR TITLE
chore(directus): project.is_canvas_enabled snapshot (canvas beta toggle)

### DIFF
--- a/echo/directus/sync/snapshot/fields/project/is_canvas_enabled.json
+++ b/echo/directus/sync/snapshot/fields/project/is_canvas_enabled.json
@@ -1,0 +1,46 @@
+{
+  "collection": "project",
+  "field": "is_canvas_enabled",
+  "type": "boolean",
+  "meta": {
+    "collection": "project",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "is_canvas_enabled",
+    "group": null,
+    "hidden": false,
+    "interface": "boolean",
+    "note": "Experimental: opt this project into the living canvas beta.",
+    "options": null,
+    "readonly": false,
+    "required": false,
+    "searchable": true,
+    "sort": 100,
+    "special": [
+      "cast-boolean"
+    ],
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "full"
+  },
+  "schema": {
+    "name": "is_canvas_enabled",
+    "table": "project",
+    "data_type": "boolean",
+    "default_value": false,
+    "max_length": null,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}


### PR DESCRIPTION
The release-k-01-02 merge (#876) shipped the per-project canvas gate and the experimental settings toggle, but the `is_canvas_enabled` column snapshot never landed (only `forwarded_at` did). Result on echo-next today: canvas is dark for every project (gate fails closed, the safe direction) and the Experimental toggle errors when flipped.

This adds the missing snapshot, produced by the sanctioned flow against local Directus: `sync.sh push` (so the committed snapshot including the newest fields was applied first), then `migrations/add_project_canvas_flag.py`, then `sync.sh pull`. The only delta was the new field file; an unrelated `_syncId` shuffle in `operations.json` was discarded.

Ops note: environments still need the column applied (migration script or snapshot push per env). echo-next first; production at release time, off-hours per the schema-change rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)