### PR TITLE
fix(deps): sync stale lockfiles to litellm 1.84.0

### DIFF
--- a/echo/server/requirements-dev.lock
+++ b/echo/server/requirements-dev.lock
@@ -483,9 +483,9 @@ grpcio-status==1.81.0 \
     --hash=sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab \
     --hash=sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69
     # via google-api-core
-gunicorn==21.2.0 \
-    --hash=sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0 \
-    --hash=sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
+gunicorn==22.0.0 \
+    --hash=sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9 \
+    --hash=sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
     # via dembrane
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -628,9 +628,9 @@ librt==0.11.0 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89 \
     --hash=sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5
     # via mypy
-litellm==1.83.10 \
-    --hash=sha256:55203a7b5551efec8f2fccde29ee045ba057e768591e0b6b9fe1d12f00685ff8 \
-    --hash=sha256:d54eaa98f93a1eb02decf593dbb525fa1ddd4cf03686c1d5c7bb69c2a9ba2a41
+litellm==1.84.0 \
+    --hash=sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2 \
+    --hash=sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6
     # via dembrane
 lz4==4.4.5 \
     --hash=sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d \
@@ -1104,13 +1104,13 @@ s3transfer==0.11.5 \
     --hash=sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4 \
     --hash=sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7
     # via boto3
-scikit-learn==1.4.2 \
-    --hash=sha256:1d0b25d9c651fd050555aadd57431b53d4cf664e749069da77f3d52c5ad14b3b \
-    --hash=sha256:44c62f2b124848a28fd695db5bc4da019287abf390bfce602ddc8aa1ec186aae \
-    --hash=sha256:45dee87ac5309bb82e3ea633955030df9bbcb8d2cdb30383c6cd483691c546cc \
-    --hash=sha256:5cd7b524115499b18b63f0c96f4224eb885564937a0b3477531b2b63ce331904 \
-    --hash=sha256:b0203c368058ab92efc6168a1507d388d41469c873e96ec220ca8e74079bf62e \
-    --hash=sha256:daa1c471d95bad080c6e44b4946c9390a4842adc3082572c20e4f8884e39e959
+scikit-learn==1.5.0 \
+    --hash=sha256:118a8d229a41158c9f90093e46b3737120a165181a1b58c03461447aa4657415 \
+    --hash=sha256:1f77547165c00625551e5c250cefa3f03f2fc92c5e18668abd90bfc4be2e0bff \
+    --hash=sha256:2a65af2d8a6cce4e163a7951a4cfbfa7fceb2d5c013a4b593686c7f16445cf9d \
+    --hash=sha256:4c0c56c3005f2ec1db3787aeaabefa96256580678cec783986836fc64f8ff622 \
+    --hash=sha256:789e3db01c750ed6d496fa2db7d50637857b451e57bcae863bff707c1247bef7 \
+    --hash=sha256:a03b09f9f7f09ffe8c5efffe2e9de1196c696d811be6798ad5eddf323c6f4d40
     # via dembrane
 scipy==1.17.1 \
     --hash=sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec \

--- a/echo/server/requirements.lock
+++ b/echo/server/requirements.lock
@@ -483,9 +483,9 @@ grpcio-status==1.81.0 \
     --hash=sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab \
     --hash=sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69
     # via google-api-core
-gunicorn==21.2.0 \
-    --hash=sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0 \
-    --hash=sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033
+gunicorn==22.0.0 \
+    --hash=sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9 \
+    --hash=sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63
     # via dembrane
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -628,9 +628,9 @@ librt==0.11.0 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89 \
     --hash=sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5
     # via mypy
-litellm==1.83.10 \
-    --hash=sha256:55203a7b5551efec8f2fccde29ee045ba057e768591e0b6b9fe1d12f00685ff8 \
-    --hash=sha256:d54eaa98f93a1eb02decf593dbb525fa1ddd4cf03686c1d5c7bb69c2a9ba2a41
+litellm==1.84.0 \
+    --hash=sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2 \
+    --hash=sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6
     # via dembrane
 lz4==4.4.5 \
     --hash=sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d \
@@ -1104,13 +1104,13 @@ s3transfer==0.11.5 \
     --hash=sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4 \
     --hash=sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7
     # via boto3
-scikit-learn==1.4.2 \
-    --hash=sha256:1d0b25d9c651fd050555aadd57431b53d4cf664e749069da77f3d52c5ad14b3b \
-    --hash=sha256:44c62f2b124848a28fd695db5bc4da019287abf390bfce602ddc8aa1ec186aae \
-    --hash=sha256:45dee87ac5309bb82e3ea633955030df9bbcb8d2cdb30383c6cd483691c546cc \
-    --hash=sha256:5cd7b524115499b18b63f0c96f4224eb885564937a0b3477531b2b63ce331904 \
-    --hash=sha256:b0203c368058ab92efc6168a1507d388d41469c873e96ec220ca8e74079bf62e \
-    --hash=sha256:daa1c471d95bad080c6e44b4946c9390a4842adc3082572c20e4f8884e39e959
+scikit-learn==1.5.0 \
+    --hash=sha256:118a8d229a41158c9f90093e46b3737120a165181a1b58c03461447aa4657415 \
+    --hash=sha256:1f77547165c00625551e5c250cefa3f03f2fc92c5e18668abd90bfc4be2e0bff \
+    --hash=sha256:2a65af2d8a6cce4e163a7951a4cfbfa7fceb2d5c013a4b593686c7f16445cf9d \
+    --hash=sha256:4c0c56c3005f2ec1db3787aeaabefa96256580678cec783986836fc64f8ff622 \
+    --hash=sha256:789e3db01c750ed6d496fa2db7d50637857b451e57bcae863bff707c1247bef7 \
+    --hash=sha256:a03b09f9f7f09ffe8c5efffe2e9de1196c696d811be6798ad5eddf323c6f4d40
     # via dembrane
 scipy==1.17.1 \
     --hash=sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec \

--- a/echo/tools/usage-tracker/pyproject.toml
+++ b/echo/tools/usage-tracker/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "streamlit>=1.54.0",
-    "litellm>=1.83.0",
+    "litellm>=1.84.0",
     "jinja2>=3.1.4",
     "requests>=2.33.0",
     "python-dotenv>=1.0.0",

--- a/echo/tools/usage-tracker/uv.lock
+++ b/echo/tools/usage-tracker/uv.lock
@@ -1016,7 +1016,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.8"
+version = "1.84.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1032,9 +1032,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/5a/a7b4b4bf9443b1f1d8fb1e1ed7d1936eca93851ff3e43113c3dad17c6556/litellm-1.83.8.tar.gz", hash = "sha256:38db022b4bf5a51cbe597a8308e6e51eb71254ae684d41aa210b76df0c827063", size = 14751978, upload-time = "2026-04-15T03:37:51.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/e9/8941b7e72a187000561d932c0f2f2ed2b0fd080dfc33ba6e05961d45ca7d/litellm-1.84.0.tar.gz", hash = "sha256:b8ad0cbea11a5941b18d5af973017a340abd3d3ab41cb86e5401b970626d71a6", size = 15103206, upload-time = "2026-05-14T05:45:53.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/02/ee86522b2cb359079596d224db9b23dc12c02d7eeaf3d458abd7a0c54444/litellm-1.83.8-py3-none-any.whl", hash = "sha256:3bc8cfeff9d73a6a11409006c0d66bafeed9a23db65f642000f72f1cdb2e9ce8", size = 16333221, upload-time = "2026-04-15T03:37:47.934Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/77fa1bbf5e42eb596b06318b3f7e6af5d0f44028046d1d598c6a595d028f/litellm-1.84.0-py3-none-any.whl", hash = "sha256:2a58d6041e6aa27d1a28dc8d8828ab500fef1a00ef74ca65e60899035010c2f2", size = 16735062, upload-time = "2026-05-14T05:45:49.927Z" },
 ]
 
 [[package]]
@@ -2471,7 +2471,7 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.2.0" },
     { name = "boto3", specifier = ">=1.28.57" },
     { name = "jinja2", specifier = ">=3.1.4" },
-    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "litellm", specifier = ">=1.84.0" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "plotly", specifier = ">=5.24.0" },


### PR DESCRIPTION
The litellm bump (GHSA host-header auth bypass, patched in 1.84.0) only updated server/pyproject.toml and uv.lock. Three manifests Dependabot also scans were left on vulnerable versions, and CI/deploy workflows pip-install requirements.lock directly:

- server/requirements.lock: regenerated via uv export (litellm 1.83.10 -> 1.84.0, plus pending gunicorn 22.0.0 and scikit-learn 1.5.0 from the committed uv.lock)
- server/requirements-dev.lock: same regeneration
- tools/usage-tracker: floor litellm>=1.84.0, relock to 1.84.0