### PR TITLE
fix(frontend): stop the announcement query firing before auth (ECHO-870)

### DIFF
--- a/docs/_authoring/release-video/agentic-chat-script.md
+++ b/docs/_authoring/release-video/agentic-chat-script.md
@@ -1,0 +1,105 @@
+# dembrane — Ask, the new chat (general release)
+
+**Draft v1** · screen-recording walkthrough + voiceover · target runtime **~2:30**
+
+**Why this shape:** the getting-started video ends by opening Ask and asking one question.
+This one picks up exactly there and earns the word *assistant*. The spine is the deep-dive
+loop the docs already teach — **broad → zoom → evidence** — and everything new hangs off it
+rather than being listed. Show the work being shown: the step-by-step progress is the thing
+people have not seen before, so let it play rather than cutting around it.
+
+**Tone:** calm, plain, confident. Short sentences. No hype. "dembrane" (lowercase), never
+"ECHO". "Language model", not "AI". British spelling (*organisation*) to match the UI.
+Say *assistant*, not *agent*.
+
+**Audience switches:** 🆕 = lands for new users · ♻️ = lands for existing users.
+
+**One honesty rule for this script:** never show an answer without showing its citation
+being clicked at least once. The whole argument for this feature is that you can check it.
+
+---
+
+## ACT 1 — One bar, one loop · ~0:00–1:10
+
+### 1. Cold open — where would you like to start 🆕♻️ · ~0:00–0:18
+> **VISUAL:** inside a project, click **Ask question**. Ask opens on its home: the single
+> input, *Where would you like to start?*, with a few earlier chats listed beneath.
+
+**VO:** "This is Ask. It's how you question everything people said, without reading every
+transcript. One bar. Type a question and it becomes a new chat. Type a few words and it
+finds an old one instead. Same bar, both jobs."
+
+### 2. Start broad, and watch it work ♻️🆕 · ~0:18–0:50
+> **VISUAL:** ask *"What are the main themes?"* → let the step list play in full: searching
+> conversations, reading transcripts, chaining. Do not cut it short. Answer lands.
+
+**VO:** "Start broad. 'What are the main themes?' Now watch what it does. It searches your
+conversations, opens the transcripts it thinks matter, and follows what it finds. You see
+each step as it happens, so when the answer arrives you already know how it got there. If
+it's heading the wrong way, Stop is right where Send was."
+
+### 3. Zoom in, then ask for evidence 🆕 · ~0:50–1:10
+> **VISUAL:** follow-up — *"What concerns came up about the bike lanes?"* → then *"Show me
+> the quotes."* → **click a citation** and land on the exact spot in the transcript.
+
+**VO:** "Then narrow. 'What concerns came up about the bike lanes?' Then ask for the
+receipts: 'Show me the quotes.' Every answer names its source — Maria's conversation,
+Maria's transcript — and every one of those is a link. Click it, and you're at the exact
+moment she said it. Nothing here asks you to take its word for it."
+
+---
+
+## ACT 2 — What else it can reach · ~1:10–2:05
+
+### 4. It knows what's happening now ♻️ · ~1:10–1:24
+> **VISUAL:** ask *"is anyone recording right now?"* → answer reflects the live monitor.
+
+**VO:** "It isn't only looking backwards. Ask 'is anyone recording right now?' and it reads
+the same live status the monitor shows you. Mid-session, that's the question you actually
+have."
+
+### 5. It proposes, you decide ♻️🆕 · ~1:24–1:48
+> **VISUAL:** ask for a settings change → the **proposal** card appears → hover the Apply and
+> Reject controls, then apply one and show it take effect.
+
+**VO:** "Ask it to change something about your project, and it won't. It proposes. The change
+arrives as something you read, then apply or reject. The assistant never edits your project
+behind you — that line is deliberate, and it doesn't move."
+
+### 6. It remembers, and you can see what 🆕♻️ · ~1:48–2:05
+> **VISUAL:** brief — Settings → Assistant, showing saved notes, and the remove control.
+
+**VO:** "It also remembers — how you like answers, what this project is for — so the next
+chat starts further along. And everything it has remembered is listed for you to read, and
+remove. It writes those notes; you decide which ones stay."
+
+---
+
+## ACT 3 — When you want the old way · ~2:05–2:30
+
+### 7. Specific Details, and the sign-off ♻️ · ~2:05–2:30
+> **VISUAL:** *Prefer the old chat? Start a Specific Details chat* → conversation picker,
+> select a few (or all), optional tag filter → one answer with exact quotes. Close on the
+> Ask home.
+
+**VO:** "Sometimes you want to choose the ground yourself. 'Specific Details' is the classic
+chat: pick the conversations, or all of them, filter by tag, and every answer comes from
+exactly that set. Use it when the answer has to come from one session, or one cohort, and
+nothing else. Everything else — start broad, zoom in, ask for the quotes. That's Ask."
+
+---
+
+## Decisions to confirm with Sameer
+- **Length:** ~2:30. If it needs to be shorter, §4 (live status) and §6 (memory) are the
+  modular ones; the loop and the citations are not.
+- **The Overview mode retirement** is deliberately not mentioned. Existing users will notice
+  it is gone, and a video is a bad place to explain a removal. Better in release notes.
+- **Recording on EchoNext**, same as the getting-started video, so every flag is live.
+
+## Still open / nice-to-haves
+- §2 only works if the step list is genuinely legible at recording resolution. Worth one
+  test take before committing to the full run.
+- A real project with real disagreement in it makes §3 land far better than a tidy demo.
+  The bike-lanes example is a placeholder — swap in whatever the actual data supports.
+- The proposal card in §5 is the strongest single moment for a sceptical buyer. If anything
+  gets a second take, that one.

--- a/echo/frontend/src/components/announcement/hooks/index.ts
+++ b/echo/frontend/src/components/announcement/hooks/index.ts
@@ -68,6 +68,13 @@ export const useLatestAnnouncement = () => {
 				throw error;
 			}
 		},
+		// The query is meaningless without a user: it filters `activity` by
+		// currentUser.id, and `announcement` is readable only by the Basic User
+		// policy. Firing it before auth resolves means an unauthenticated request
+		// that Directus answers 403, three times over because of `retry: 2`, and
+		// a red console error on every cold load. `useInfiniteAnnouncementActivity`
+		// in this same file already gates on the user; this one was missed.
+		enabled: !!currentUser?.id,
 		queryKey: ["announcements", "latest"],
 		retry: 2,
 		staleTime: 1000 * 60 * 5, // 5 minutes


### PR DESCRIPTION
`useLatestAnnouncement` had no `enabled` guard. It filters `activity` by `currentUser.id` and reads `announcement`, which only the Basic User policy can see, so on a cold load it fires unauthenticated and Directus answers 403. With `retry: 2` that is three failed requests and a red console error on every load.

**Why not the Directus permission change.** The other way to silence this is granting the public policy read on `announcement`. That fixes the console error by making admin broadcasts readable by anyone unauthenticated, which is a worse position than the error. This keeps the collection private and simply stops asking for it before we can.

`useInfiniteAnnouncementActivity` in the same file already does `enabled: !!currentUser?.id`; this hook was the one that missed it.

One line plus a comment. Recording for the release videos happens on EchoNext this afternoon and a clean console is part of that.