### PR TITLE
feat(agentic): focus chat on selected conversations

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -8,6 +8,7 @@ import {
 	Divider,
 	Group,
 	Loader,
+	Modal,
 	Paper,
 	Skeleton,
 	Stack,
@@ -19,6 +20,7 @@ import {
 	UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { ChatCircleTextIcon } from "@phosphor-icons/react";
 import {
 	IconAlertCircle,
 	IconChevronDown,
@@ -37,10 +39,19 @@ import {
 	useState,
 } from "react";
 import { useLocation } from "react-router";
-import { useChatHistory, useUpdateChatMutation } from "@/components/chat/hooks";
+import {
+	useChatHistory,
+	useProjectChatContext,
+	useUpdateChatMutation,
+} from "@/components/chat/hooks";
 import { InsertTemplateMenu } from "@/components/chat/InsertTemplateMenu";
 import { consumeChatPrefill } from "@/components/chat/prefill";
-import { useConversationsByProjectId } from "@/components/conversation/hooks";
+import { ConversationLinks } from "@/components/conversation/ConversationLinks";
+import {
+	useClearChatContextMutation,
+	useConversationsByProjectId,
+} from "@/components/conversation/hooks";
+import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { GoalSuggestionCard } from "@/components/goal/GoalSuggestionCard";
 import { useElementOnScreen } from "@/hooks/useElementOnScreen";
@@ -70,6 +81,7 @@ import {
 import { testId } from "@/lib/testUtils";
 import { CopyRichTextIconButton } from "../common/CopyRichTextIconButton";
 import { ScrollToBottomButton } from "../common/ScrollToBottom";
+import { focusedConversationIdsFromPayload } from "./agenticFocus";
 import {
 	extractTopLevelToolActivity,
 	parseCanvasSuggestion,
@@ -104,6 +116,7 @@ type RenderMessage = {
 	content: string;
 	timestamp: string;
 	sortSeq: number;
+	focusedConversationIds?: string[];
 };
 
 type TimelineItem =
@@ -254,6 +267,7 @@ const toMessage = ({
 				projectId,
 				workspaceId,
 			}),
+			focusedConversationIds: focusedConversationIdsFromPayload(payload),
 			id: `u-${event.seq}`,
 			role: "user",
 			sortSeq: event.seq,
@@ -607,6 +621,16 @@ export const AgenticChatPanel = ({
 	const queryClient = useQueryClient();
 	const chatQuery = useProjectChat(chatId);
 	const persistedHistoryQuery = useChatHistory(chatId);
+	const chatContextQuery = useProjectChatContext(chatId);
+	const focusedContextConversations = useMemo(
+		() =>
+			(chatContextQuery.data?.conversations ?? []).map((item) => ({
+				id: item.conversation_id,
+				participant_name: item.conversation_participant_name,
+			})),
+		[chatContextQuery.data?.conversations],
+	);
+	const clearChatContextMutation = useClearChatContextMutation();
 	const [runId, setRunId] = useState<string | null>(null);
 	const [runStatus, setRunStatus] = useState<AgenticRunStatus | null>(null);
 	const [afterSeq, setAfterSeq] = useState(0);
@@ -628,6 +652,8 @@ export const AgenticChatPanel = ({
 	const [expandedGroupIds, setExpandedGroupIds] = useState<
 		Record<string, boolean>
 	>({});
+	const [conversationPickerOpened, conversationPickerHandlers] =
+		useDisclosure(false);
 	const streamAbortRef = useRef<AbortController | null>(null);
 	const streamRunIdRef = useRef<string | null>(null);
 	const stopArmedRunIdRef = useRef<string | null>(null);
@@ -1535,8 +1561,35 @@ export const AgenticChatPanel = ({
 
 					{timelineNodes.map((node) => {
 						if (node.kind === "message") {
+							const focusedConversations = (
+								node.item.role === "user"
+									? (node.item.focusedConversationIds ?? [])
+									: []
+							)
+								.filter((id) => conversationNames.has(id))
+								.map((id) => ({
+									id,
+									participant_name: conversationNames.get(id) ?? "",
+								}));
 							return (
 								<div key={node.id}>
+									{focusedConversations.length > 0 && (
+										<Group
+											gap="xs"
+											align="baseline"
+											justify="flex-end"
+											className="mb-2 italic"
+										>
+											<Text size="xs" c="dimmed" fw={500}>
+												<Trans>Focusing on:</Trans>
+											</Text>
+											<ConversationLinks
+												conversations={
+													focusedConversations as unknown as Conversation[]
+												}
+											/>
+										</Group>
+									)}
 									<ChatHistoryMessage
 										message={toHistoryMessage(node.item)}
 										chatMode="agentic"
@@ -1741,7 +1794,6 @@ export const AgenticChatPanel = ({
 					{atTurnLimit && (
 						<ChatTurnLimitCard onUpgrade={upgradeHandlers.open} />
 					)}
-					<Divider />
 					<form
 						onSubmit={(event) => {
 							event.preventDefault();
@@ -1755,6 +1807,41 @@ export const AgenticChatPanel = ({
 								borderColor: "var(--mantine-color-primary-light)",
 							}}
 						>
+							{focusedContextConversations.length > 0 && (
+								<Group
+									gap="xs"
+									align="baseline"
+									wrap="wrap"
+									className="mb-2 border-0 border-b border-solid pb-2 italic"
+									style={{ borderColor: "var(--mantine-color-primary-light)" }}
+								>
+									<Text size="xs" c="dimmed" fw={500}>
+										<Trans>Focusing on:</Trans>
+									</Text>
+									<ConversationLinks
+										conversations={
+											focusedContextConversations as unknown as Conversation[]
+										}
+									/>
+									<Button
+										variant="subtle"
+										size="compact-xs"
+										className="not-italic"
+										onClick={() =>
+											clearChatContextMutation.mutate({
+												chatId,
+												conversationIds: focusedContextConversations.map(
+													(conversation) => conversation.id,
+												),
+											})
+										}
+										loading={clearChatContextMutation.isPending}
+										{...testId("agentic-clear-focus-button")}
+									>
+										<Trans>Clear all</Trans>
+									</Button>
+								</Group>
+							)}
 							<Textarea
 								variant="unstyled"
 								styles={{ input: { backgroundColor: "transparent" } }}
@@ -1779,9 +1866,18 @@ export const AgenticChatPanel = ({
 										workspaceId={workspaceId}
 										onInsert={(content) => setInput(content)}
 									/>
-									<Text size="xs" className="select-none">
-										<Trans>Enter to send, Shift+Enter for a new line</Trans>
-									</Text>
+									<Button
+										variant="subtle"
+										size="compact-xs"
+										aria-label={t`Select conversations`}
+										onClick={conversationPickerHandlers.open}
+										{...testId("agentic-select-conversations-button")}
+									>
+										<ChatCircleTextIcon size={14} />
+										<span className="ms-1.5 hidden md:inline">
+											<Trans>Select conversations</Trans>
+										</span>
+									</Button>
 								</Group>
 								<Group gap="xs" wrap="nowrap">
 									<Button
@@ -1805,8 +1901,37 @@ export const AgenticChatPanel = ({
 								</Group>
 							</Group>
 						</Box>
+						<Group
+							justify="space-between"
+							gap="sm"
+							wrap="wrap"
+							className="mt-1"
+						>
+							<Text size="xs" className="hidden italic md:block">
+								<Trans>Use Shift + Enter to add a new line</Trans>
+							</Text>
+							<Text size="xs" className="italic">
+								<Trans>
+									dembrane can make mistakes. Please double-check responses.
+								</Trans>
+							</Text>
+						</Group>
 					</form>
 				</Stack>
+				<Modal
+					opened={conversationPickerOpened}
+					onClose={conversationPickerHandlers.close}
+					title={t`Select conversations`}
+					size="xl"
+					padding="lg"
+				>
+					<ProjectConversationsPanel
+						projectId={projectId}
+						workspaceId={workspaceId}
+						selectionChatId={chatId}
+						selectionMode
+					/>
+				</Modal>
 			</Box>
 			<ChatUpgradeModal
 				opened={upgradeOpened}

--- a/echo/frontend/src/components/chat/InsertTemplateMenu.tsx
+++ b/echo/frontend/src/components/chat/InsertTemplateMenu.tsx
@@ -1,6 +1,7 @@
+import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { Button, Menu, Text } from "@mantine/core";
-import { IconTemplate } from "@tabler/icons-react";
+import { CardsThreeIcon } from "@phosphor-icons/react";
 import { useUserTemplates } from "@/components/chat/hooks/useUserTemplates";
 
 /** Quiet insert-only entry point to saved templates: picking one drops its
@@ -20,12 +21,11 @@ export const InsertTemplateMenu = ({
 	return (
 		<Menu position="top-start" withinPortal shadow="md">
 			<Menu.Target>
-				<Button
-					variant="subtle"
-					size="xs"
-					leftSection={<IconTemplate size={14} />}
-				>
-					<Trans>Templates</Trans>
+				<Button variant="subtle" size="xs" aria-label={t`Templates`}>
+					<CardsThreeIcon size={14} />
+					<span className="ms-1.5 hidden md:inline">
+						<Trans>Templates</Trans>
+					</span>
 				</Button>
 			</Menu.Target>
 			<Menu.Dropdown className="max-w-md">

--- a/echo/frontend/src/components/chat/agenticFocus.test.ts
+++ b/echo/frontend/src/components/chat/agenticFocus.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { focusedConversationIdsFromPayload } from "./agenticFocus";
+
+describe("focusedConversationIdsFromPayload", () => {
+	it("returns the ids from a well-formed payload", () => {
+		expect(
+			focusedConversationIdsFromPayload({
+				content: "hello",
+				focused_conversation_ids: ["conv-1", "conv-2"],
+			}),
+		).toEqual(["conv-1", "conv-2"]);
+	});
+
+	it("drops non-string and empty entries", () => {
+		expect(
+			focusedConversationIdsFromPayload({
+				focused_conversation_ids: ["conv-1", 42, null, ""],
+			}),
+		).toEqual(["conv-1"]);
+	});
+
+	it("returns empty for missing or malformed payloads", () => {
+		expect(focusedConversationIdsFromPayload(null)).toEqual([]);
+		expect(focusedConversationIdsFromPayload("nope")).toEqual([]);
+		expect(focusedConversationIdsFromPayload({})).toEqual([]);
+		expect(
+			focusedConversationIdsFromPayload({ focused_conversation_ids: "conv-1" }),
+		).toEqual([]);
+	});
+});

--- a/echo/frontend/src/components/chat/agenticFocus.ts
+++ b/echo/frontend/src/components/chat/agenticFocus.ts
@@ -1,0 +1,12 @@
+// Reads the host's "focusing on" selection stamped into a user.message
+// event payload by the agentic API.
+export const focusedConversationIdsFromPayload = (
+	payload: unknown,
+): string[] => {
+	if (!payload || typeof payload !== "object") return [];
+	const value = (payload as Record<string, unknown>).focused_conversation_ids;
+	if (!Array.isArray(value)) return [];
+	return value.filter(
+		(id): id is string => typeof id === "string" && id.length > 0,
+	);
+};

--- a/echo/frontend/src/components/conversation/ConversationLinks.tsx
+++ b/echo/frontend/src/components/conversation/ConversationLinks.tsx
@@ -163,6 +163,7 @@ export const ConversationLinks = ({
 							size="md"
 							variant="light"
 							ml="xs"
+							c="graphite"
 							className="cursor-pointer not-italic"
 							onClick={() => setModalOpened(true)}
 						>

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -660,7 +660,7 @@ export const ProjectConversationsPanel = ({
 			enabled:
 				selectionMode &&
 				ENABLE_CHAT_SELECT_ALL &&
-				chatMode === "deep_dive" &&
+				(chatMode === "deep_dive" || chatMode === "agentic") &&
 				!!selectionChatId,
 		},
 	);
@@ -840,7 +840,7 @@ export const ProjectConversationsPanel = ({
 
 				{selectionMode &&
 					ENABLE_CHAT_SELECT_ALL &&
-					chatMode === "deep_dive" &&
+					(chatMode === "deep_dive" || chatMode === "agentic") &&
 					allConversations.length > 0 && (
 						<Button
 							variant="outline"

--- a/echo/frontend/src/components/conversation/hooks/index.ts
+++ b/echo/frontend/src/components/conversation/hooks/index.ts
@@ -496,6 +496,52 @@ export const useDeleteChatContextMutation = () => {
 	});
 };
 
+export const useClearChatContextMutation = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (payload: {
+			chatId: string;
+			conversationIds: string[];
+		}) => {
+			const results = await Promise.allSettled(
+				payload.conversationIds.map((conversationId) =>
+					deleteChatContext(payload.chatId, conversationId),
+				),
+			);
+			const failed = results.filter((result) => result.status === "rejected");
+			return {
+				cleared: results.length - failed.length,
+				failed,
+				total: results.length,
+			};
+		},
+		mutationKey: ["chat-context", "clear"],
+		onError: (error) => {
+			posthog.captureException(error);
+			toast.error(t`Failed to clear conversations`);
+		},
+		onSettled: (_, __, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: ["chats", "context", variables.chatId],
+			});
+		},
+		onSuccess: ({ cleared, failed, total }) => {
+			if (failed.length === 0) {
+				toast.success(t`Conversations cleared`);
+				return;
+			}
+			for (const failure of failed) {
+				posthog.captureException(failure.reason);
+			}
+			if (cleared === 0) {
+				toast.error(t`Failed to clear conversations`);
+				return;
+			}
+			toast.error(t`Cleared ${cleared} of ${total} conversations`);
+		},
+	});
+};
+
 export const useSelectAllContextMutation = () => {
 	const queryClient = useQueryClient();
 	return useMutation({

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -15,10 +15,10 @@ import {
 	Title,
 } from "@mantine/core";
 import { useDisclosure, useDocumentTitle } from "@mantine/hooks";
+import { ChatCircleTextIcon } from "@phosphor-icons/react";
 import { usePostHog } from "@posthog/react";
 import {
 	IconAlertCircle,
-	IconListDetails,
 	IconRefresh,
 	IconSend,
 	IconSquare,
@@ -35,10 +35,7 @@ import {
 import { ChatContextProgress } from "@/components/chat/ChatContextProgress";
 import { ChatHistoryMessage } from "@/components/chat/ChatHistoryMessage";
 import { ChatMessage } from "@/components/chat/ChatMessage";
-import {
-	ChatModeSelector,
-	MODE_COLORS,
-} from "@/components/chat/ChatModeSelector";
+import { ChatModeSelector } from "@/components/chat/ChatModeSelector";
 import { ChatTemplatesMenu } from "@/components/chat/ChatTemplatesMenu";
 import { formatMessage } from "@/components/chat/chatUtils";
 import {
@@ -903,7 +900,7 @@ export const ProjectChatRoute = () => {
 							<Button
 								variant="light"
 								size="xs"
-								leftSection={<IconListDetails size={16} />}
+								leftSection={<ChatCircleTextIcon size={16} />}
 								onClick={() => setConversationPickerOpen(true)}
 								{...testId("chat-select-conversations-button")}
 							>
@@ -938,8 +935,6 @@ export const ProjectChatRoute = () => {
 										id: c.conversation_id,
 										participant_name: c.conversation_participant_name,
 									}))}
-									color="var(--app-text)"
-									hoverUnderlineColor={MODE_COLORS.deep_dive.primary}
 								/>
 							</Group>
 						</ChatMessage>

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -356,6 +356,57 @@ async def _get_workspace_context_for_project(project: dict[str, Any]) -> Optiona
     return _to_non_empty_string(workspace.get("context"))
 
 
+def _format_focused_conversations(focused: list[dict[str, str]]) -> str:
+    labels = ", ".join(
+        f"{item['name']} ({item['id']})" if item.get("name") else item["id"]
+        for item in focused
+    )
+    return (
+        "The user wants you to focus on these conversations: "
+        f"{labels}. Prioritize them when gathering context."
+    )
+
+
+def _build_followup_agent_prompt_content(
+    user_message: str,
+    focused_conversations: list[dict[str, str]],
+) -> str:
+    return (
+        f"{_format_focused_conversations(focused_conversations)}\n\n"
+        f"User Message: {user_message.strip()}"
+    )
+
+
+def _get_focused_conversations(project_chat_id: Optional[str]) -> list[dict[str, str]]:
+    """Conversations the host selected for this chat, as focus hints.
+
+    Agentic never preloads transcripts or locks context rows; the selection is
+    only folded into the prompt. Failures degrade to no hint, never a failed run."""
+    if not project_chat_id:
+        return []
+    try:
+        chat = chat_service.get_by_id_or_raise(project_chat_id, with_used_conversations=True)
+    except Exception:  # noqa: BLE001
+        logger.warning("Could not load chat %s for focus hint", project_chat_id)
+        return []
+
+    focused: list[dict[str, str]] = []
+    for link in chat.get("used_conversations") or []:
+        ref = link.get("conversation_id") if isinstance(link, dict) else None
+        if not isinstance(ref, dict):
+            continue
+        conversation_id = _to_non_empty_string(ref.get("id"))
+        if not conversation_id:
+            continue
+        focused.append(
+            {
+                "id": conversation_id,
+                "name": _to_non_empty_string(ref.get("participant_name")) or "",
+            }
+        )
+    return focused
+
+
 def _build_initial_agent_prompt_content(
     *,
     project_name: Optional[str],
@@ -363,18 +414,25 @@ def _build_initial_agent_prompt_content(
     project_goal: Optional[str] = None,
     user_message: str,
     workspace_context: Optional[str] = None,
+    focused_conversations: Optional[list[dict[str, str]]] = None,
 ) -> str:
     normalized_name = _to_non_empty_string(project_name) or "(none)"
     normalized_context = _to_non_empty_string(project_context) or "(none)"
     normalized_goal = _to_non_empty_string(project_goal) or "(none)"
     normalized_workspace_context = _to_non_empty_string(workspace_context) or "(none)"
     normalized_message = user_message.strip()
+    focus_block = (
+        f"{_format_focused_conversations(focused_conversations)}\n\n"
+        if focused_conversations
+        else ""
+    )
 
     return (
         f"Project Name: {normalized_name}\n"
         f"Workspace Context: {normalized_workspace_context}\n"
         f"Project Context: {normalized_context}\n"
         f"Project Goal: {normalized_goal}\n\n"
+        f"{focus_block}"
         f"User Message: {normalized_message}"
     )
 
@@ -950,22 +1008,32 @@ async def create_run(
     project_context = _to_non_empty_string(project.get("context"))
     workspace_context = await _get_workspace_context_for_project(project)
     project_goal = await get_current_project_goal_content(body.project_id)
+    focused_conversations = await run_in_thread_pool(
+        _get_focused_conversations, body.project_chat_id
+    )
     agent_prompt_content = _build_initial_agent_prompt_content(
         project_name=project_name,
         project_context=project_context,
         project_goal=project_goal,
         user_message=body.message,
         workspace_context=workspace_context,
+        focused_conversations=focused_conversations or None,
     )
+
+    event_payload: dict[str, Any] = {
+        "content": body.message,
+        "agent_prompt_content": agent_prompt_content,
+    }
+    if focused_conversations:
+        event_payload["focused_conversation_ids"] = [
+            item["id"] for item in focused_conversations
+        ]
 
     await run_in_thread_pool(
         agentic_run_service.append_event,
         run["id"],
         "user.message",
-        {
-            "content": body.message,
-            "agent_prompt_content": agent_prompt_content,
-        },
+        event_payload,
     )
     await run_in_thread_pool(_persist_chat_user_message, body.project_chat_id, body.message)
     _schedule_chat_title_generation(body.project_chat_id, body.message, body.language)
@@ -1007,11 +1075,24 @@ async def append_message(
         ):
             raise free_tier_limit_error("chat_turns")
 
+    focused_conversations = await run_in_thread_pool(
+        _get_focused_conversations,
+        _to_non_empty_string(run.get("project_chat_id")),
+    )
+    event_payload: dict[str, Any] = {"content": body.message}
+    if focused_conversations:
+        event_payload["agent_prompt_content"] = _build_followup_agent_prompt_content(
+            body.message, focused_conversations
+        )
+        event_payload["focused_conversation_ids"] = [
+            item["id"] for item in focused_conversations
+        ]
+
     await run_in_thread_pool(
         agentic_run_service.append_event,
         run_id,
         "user.message",
-        {"content": body.message},
+        event_payload,
     )
     await run_in_thread_pool(
         _persist_chat_user_message,

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -79,7 +79,7 @@ async def _wait_for_updated_titles(
     for _ in range(20):
         if len(chat_service.updated_titles) >= expected_count:
             return
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
 
     assert len(chat_service.updated_titles) >= expected_count
 
@@ -372,6 +372,48 @@ async def test_create_run_persists_user_message_without_dispatch(monkeypatch) ->
     )
 
 
+@pytest.mark.asyncio
+async def test_create_run_injects_focus_hint_from_chat_context(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+    fake_chat_service = _FakeChatService(
+        chats={
+            "chat-1": {
+                "id": "chat-1",
+                "name": "Named chat",
+                "project_id": {"id": "project-1"},
+                "used_conversations": [
+                    {"id": 1, "conversation_id": {"id": "conv-1", "participant_name": "Alice"}},
+                    {"id": 2, "conversation_id": {"id": "conv-2", "participant_name": "Bob"}},
+                ],
+            }
+        }
+    )
+    session = _make_session(user_id="user-1")
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=session,
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+        chat_service=fake_chat_service,
+    ) as client:
+        response = await client.post(
+            "/api/agentic/runs",
+            json={"project_id": "project-1", "project_chat_id": "chat-1", "message": "hello"},
+        )
+
+    assert response.status_code == 201
+    events = run_service.list_events(response.json()["id"])
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert payload["content"] == "hello"
+    assert payload["focused_conversation_ids"] == ["conv-1", "conv-2"]
+    assert (
+        "The user wants you to focus on these conversations: "
+        "Alice (conv-1), Bob (conv-2). Prioritize them when gathering context."
+    ) in payload["agent_prompt_content"]
+
+
 def test_initial_prompt_includes_workspace_context() -> None:
     from dembrane.api.agentic import _build_initial_agent_prompt_content
 
@@ -409,6 +451,80 @@ def test_initial_prompt_defaults_workspace_context_to_none_marker() -> None:
     )
     assert "Workspace Context: (none)" in content
     assert "Project Goal: (none)" in content
+
+
+def test_initial_prompt_includes_focus_line_before_user_message() -> None:
+    from dembrane.api.agentic import _build_initial_agent_prompt_content
+
+    content = _build_initial_agent_prompt_content(
+        project_name="Street interviews",
+        project_context="Ask about the market",
+        user_message="hello",
+        focused_conversations=[
+            {"id": "conv-1", "name": "Alice"},
+            {"id": "conv-2", "name": ""},
+        ],
+    )
+    assert (
+        "The user wants you to focus on these conversations: "
+        "Alice (conv-1), conv-2. Prioritize them when gathering context."
+    ) in content
+    assert content.index("focus on these conversations") < content.index("User Message:")
+
+
+def test_initial_prompt_omits_focus_line_without_selection() -> None:
+    from dembrane.api.agentic import _build_initial_agent_prompt_content
+
+    content = _build_initial_agent_prompt_content(
+        project_name="Street interviews",
+        project_context="Ask about the market",
+        user_message="hello",
+        focused_conversations=None,
+    )
+    assert "focus on these conversations" not in content
+
+
+def test_followup_prompt_wraps_message_with_focus_line() -> None:
+    from dembrane.api.agentic import _build_followup_agent_prompt_content
+
+    content = _build_followup_agent_prompt_content(
+        "  and what about themes?  ",
+        [{"id": "conv-1", "name": "Alice"}],
+    )
+    assert content == (
+        "The user wants you to focus on these conversations: Alice (conv-1). "
+        "Prioritize them when gathering context.\n\n"
+        "User Message: and what about themes?"
+    )
+
+
+def test_get_focused_conversations_maps_links(monkeypatch) -> None:
+    fake_chat_service = _FakeChatService(
+        chats={
+            "chat-1": {
+                "id": "chat-1",
+                "used_conversations": [
+                    {"id": 1, "conversation_id": {"id": "conv-1", "participant_name": "Alice"}},
+                    {"id": 2, "conversation_id": {"id": "conv-2", "participant_name": None}},
+                    {"id": 3, "conversation_id": None},
+                    "garbage",
+                ],
+            }
+        }
+    )
+    monkeypatch.setattr(agentic_api, "chat_service", fake_chat_service)
+
+    assert agentic_api._get_focused_conversations("chat-1") == [
+        {"id": "conv-1", "name": "Alice"},
+        {"id": "conv-2", "name": ""},
+    ]
+
+
+def test_get_focused_conversations_degrades_to_empty(monkeypatch) -> None:
+    monkeypatch.setattr(agentic_api, "chat_service", _FakeChatService())
+
+    assert agentic_api._get_focused_conversations(None) == []
+    assert agentic_api._get_focused_conversations("missing-chat") == []
 
 
 @pytest.mark.asyncio
@@ -634,6 +750,82 @@ async def test_append_message_skips_title_generation_for_named_chat(monkeypatch)
 
     assert response.status_code == 200
     assert fake_chat_service.updated_titles == []
+
+
+@pytest.mark.asyncio
+async def test_append_message_injects_focus_hint_from_chat_context(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+    run = run_service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+        status="completed",
+    )
+    fake_chat_service = _FakeChatService(
+        chats={
+            "chat-1": {
+                "id": "chat-1",
+                "name": "Named chat",
+                "project_id": {"id": "project-1"},
+                "used_conversations": [
+                    {"id": 1, "conversation_id": {"id": "conv-1", "participant_name": "Alice"}},
+                ],
+            }
+        }
+    )
+    session = _make_session(user_id="user-1")
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=session,
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+        chat_service=fake_chat_service,
+    ) as client:
+        response = await client.post(
+            f"/api/agentic/runs/{run['id']}/messages",
+            json={"message": "what about themes?"},
+        )
+
+    assert response.status_code == 200
+    events = run_service.list_events(run["id"])
+    payload = events[-1]["payload"]
+    assert payload["content"] == "what about themes?"
+    assert payload["focused_conversation_ids"] == ["conv-1"]
+    assert payload["agent_prompt_content"] == (
+        "The user wants you to focus on these conversations: Alice (conv-1). "
+        "Prioritize them when gathering context.\n\n"
+        "User Message: what about themes?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_append_message_payload_unchanged_without_focus(monkeypatch) -> None:
+    run_service = AgenticRunService(directus_client=InMemoryDirectus())
+    run = run_service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+        status="completed",
+    )
+    fake_chat_service = _FakeChatService()
+    session = _make_session(user_id="user-1")
+
+    async with _build_api_client(
+        monkeypatch=monkeypatch,
+        session=session,
+        run_service=run_service,
+        owner_by_project_id={"project-1": "user-1"},
+        chat_service=fake_chat_service,
+    ) as client:
+        response = await client.post(
+            f"/api/agentic/runs/{run['id']}/messages",
+            json={"message": "hello-again"},
+        )
+
+    assert response.status_code == 200
+    events = run_service.list_events(run["id"])
+    assert events[-1]["payload"] == {"content": "hello-again"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hosts can pick conversations from the existing picker in the agentic composer. The selection persists as chat-context rows and is folded into the agent prompt each turn as a "focus on these" hint. No transcript preloading, no locking, no change when nothing is selected.

- server: inject focus line in create_run and append_message, stamp focused_conversation_ids on user.message events
- frontend: picker modal, "Focusing on" line with clear-all, select-all enabled for agentic chats
- unify conversation/template icons with the sidebar, collapse composer labels to icons on mobile
- fix flaky _wait_for_updated_titles (zero-duration sleeps)