### PR TITLE
feat(frontend): label Monitor as Beta in sidebar and page title

### DIFF
--- a/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
+++ b/echo/frontend/src/features/sidebar/views/project/ProjectHomeView.tsx
@@ -86,6 +86,7 @@ export const ProjectHomeView = () => {
 					to={`${base}/monitor`}
 					label={<Trans>Monitor</Trans>}
 					icon={BroadcastIcon}
+					badge={<Trans>Beta</Trans>}
 				/>
 			)}
 			{/* Library is the canvas surface: the env flag mounts the routes,

--- a/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
+++ b/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
@@ -1,6 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import {
+	Badge,
 	Box,
 	Divider,
 	Group,
@@ -76,9 +77,14 @@ export const ProjectMonitorRoute = () => {
 				{projectId && <MonitorSessionAnalytics projectId={projectId} />}
 				<Group justify="space-between" align="flex-start" wrap="nowrap">
 					<Stack gap={4}>
-						<Title order={2} fw={500}>
-							<Trans>Monitor</Trans>
-						</Title>
+						<Group gap="xs" align="center">
+							<Title order={2} fw={500}>
+								<Trans>Monitor</Trans>
+							</Title>
+							<Badge size="sm" color="mauve" c="graphite">
+								<Trans>Beta</Trans>
+							</Badge>
+						</Group>
 						<Text size="sm" maw={560}>
 							<Trans>
 								Watch live recordings, transcription progress, and errors across


### PR DESCRIPTION
## What

Monitor was not labelled anywhere in the UI. It now reads as Beta in the two places a host actually sees the feature:

1. Project sidebar nav item (`ProjectHomeView.tsx`) via the existing `NavItem` `badge` prop
2. Monitor page title (`ProjectMonitorRoute.tsx`) via the standard `<Badge size="sm" color="mauve" c="graphite">` recipe

## Notes

- Reuses the existing `Beta` msgid, so there is no new translatable string and no locale catalog changes. Translations are already present in all 8 locales.
- The sidebar deliberately passes `<Trans>Beta</Trans>` to the `badge` prop rather than a nested Mantine `Badge`: `NavItem` renders its own badge chrome (`BADGE_TONES`), the same treatment already used by the "Planned" and "External" rows. Nesting a filled Mantine badge inside that span would double the chrome.
- One thing to eyeball in review: on the Monitor page, filled mauve is already in use as a status colour for the offline count in `LiveMonitorSection`. The Beta badge is in the page header and the offline badge is further down in the "Live monitoring" section header, so they do not sit side by side, but the colour is now doing two jobs on one page.

## Verification

`pnpm lint` (biome, 461 files) and `pnpm build` (tsc + vite) both pass.