### PR TITLE
feat(agentic): make Specific Details the default, keep Agentic opt-in everywhere

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -1150,12 +1150,22 @@ def create_agent_graph(
         }
 
     @tool
-    async def listProjectConversations(limit: int = 20) -> dict[str, Any]:
-        """List conversations for the current project scope."""
+    async def listProjectConversations(limit: int = 20, offset: int = 0) -> dict[str, Any]:
+        """List conversations for the current project scope.
+
+        `limit` caps one call at 100. Use `offset` to page: pass the number of
+        conversations you have already seen. `has_more` says whether another
+        page exists, so you never have to guess.
+        """
         normalized_limit = max(1, min(limit, 100))
+        normalized_offset = max(0, offset)
         client = _create_echo_client()
         try:
-            payload = await client.list_project_conversations(project_id, normalized_limit)
+            payload = await client.list_project_conversations(
+                project_id,
+                normalized_limit,
+                offset=normalized_offset,
+            )
         finally:
             await client.close()
 
@@ -1168,7 +1178,52 @@ def create_agent_graph(
         return {
             "project_id": project_id,
             "count": int(payload.get("count") or len(conversations)),
+            "offset": normalized_offset,
+            "has_more": bool(payload.get("has_more")),
             "conversations": conversations,
+        }
+
+    @tool
+    async def listFocusedConversations(limit: int = 50, offset: int = 0) -> dict[str, Any]:
+        """List the conversations the host focused THIS chat on, paginated.
+
+        Use this when the focus block says it was truncated. It returns only
+        the host's selection, which the project-wide conversation list cannot
+        tell you. Pass `offset` from the truncation line, then keep paging
+        while `has_more` is true.
+        """
+        if not chat_id:
+            return {
+                "project_id": project_id,
+                "total": 0,
+                "count": 0,
+                "offset": 0,
+                "has_more": False,
+                "conversations": [],
+                "note": "This run has no chat, so there is no focus selection.",
+            }
+
+        normalized_limit = max(1, min(limit, 100))
+        normalized_offset = max(0, offset)
+        client = _create_echo_client()
+        try:
+            payload = await client.list_focused_conversations(
+                project_id,
+                chat_id,
+                limit=normalized_limit,
+                offset=normalized_offset,
+            )
+        finally:
+            await client.close()
+
+        conversations = payload.get("conversations")
+        return {
+            "project_id": project_id,
+            "total": int(payload.get("total") or 0),
+            "count": int(payload.get("count") or 0),
+            "offset": normalized_offset,
+            "has_more": bool(payload.get("has_more")),
+            "conversations": conversations if isinstance(conversations, list) else [],
         }
 
     @tool
@@ -2189,6 +2244,7 @@ def create_agent_graph(
         get_project_scope,
         findConversationsByKeywords,
         listProjectConversations,
+        listFocusedConversations,
         listConversationSummary,
         listConversationFullTranscript,
         grepConversationSnippets,

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -330,8 +330,11 @@ class EchoClient:
         limit: int = 20,
         conversation_id: str | None = None,
         transcript_query: str | None = None,
+        offset: int = 0,
     ) -> AgentProjectConversationsResponse:
         params: dict[str, object] = {"limit": limit}
+        if offset:
+            params["offset"] = offset
         if conversation_id:
             params["conversation_id"] = conversation_id
         if transcript_query:
@@ -346,6 +349,25 @@ class EchoClient:
         if not isinstance(payload, dict):
             raise ValueError("Unexpected list project conversations response shape")
         return cast(AgentProjectConversationsResponse, payload)
+
+    async def list_focused_conversations(
+        self,
+        project_id: str,
+        project_chat_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        response = await self._client.get(
+            f"/agentic/projects/{project_id}/focused-conversations",
+            params={
+                "project_chat_id": project_chat_id,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
 
     async def get_project_monitor(
         self,

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -73,6 +73,7 @@ class _FakeEchoClient:
         self.search_calls: list[dict[str, object]] = []
         self.transcript_calls: list[str] = []
         self.project_conversations_calls: list[dict[str, object]] = []
+        self.focused_conversations_calls: list[dict[str, object]] = []
         self.list_memory_calls: list[str] = []
         self.write_memory_calls: list[dict[str, object]] = []
         self.read_goal_calls: list[str] = []
@@ -108,17 +109,39 @@ class _FakeEchoClient:
     async def get_project_monitor(self, project_id: str, window_seconds: int = 45) -> dict:  # noqa: ARG002
         return type(self).monitor_payload
 
+    # Set on the class so a test can swap it in without touching the factory.
+    focused_conversations_payload: dict = {}
+
+    async def list_focused_conversations(
+        self,
+        project_id: str,
+        project_chat_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict:
+        self.focused_conversations_calls.append(
+            {
+                "project_id": project_id,
+                "project_chat_id": project_chat_id,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return type(self).focused_conversations_payload
+
     async def list_project_conversations(
         self,
         project_id: str,
         limit: int = 20,
         conversation_id: str | None = None,
         transcript_query: str | None = None,
+        offset: int = 0,
     ) -> dict:
         self.project_conversations_calls.append(
             {
                 "project_id": project_id,
                 "limit": limit,
+                "offset": offset,
                 "conversation_id": conversation_id,
                 "transcript_query": transcript_query,
             }
@@ -962,6 +985,7 @@ async def test_find_convos_by_keywords_filters_to_current_project():
         {
             "project_id": "project-1",
             "limit": 7,
+            "offset": 0,
             "conversation_id": None,
             "transcript_query": "policy",
         }
@@ -1023,6 +1047,7 @@ async def test_find_convos_by_keywords_uses_single_transcript_query_call_for_lon
         {
             "project_id": "project-1",
             "limit": 5,
+            "offset": 0,
             "conversation_id": None,
             "transcript_query": long_query,
         }
@@ -1240,6 +1265,7 @@ async def test_list_project_conversations_returns_project_scoped_cards():
         {
             "project_id": "project-1",
             "limit": 9,
+            "offset": 0,
             "conversation_id": None,
             "transcript_query": None,
         }
@@ -1284,6 +1310,7 @@ async def test_list_convo_full_transcript_uses_scoped_lookup_for_exact_id():
         {
             "project_id": "project-1",
             "limit": 1,
+            "offset": 0,
             "conversation_id": "conv-1",
             "transcript_query": None,
         }
@@ -2189,3 +2216,106 @@ def test_system_prompt_offers_dembrane_support_path():
     prompt = SYSTEM_PROMPT.lower()
     assert "getting help from the dembrane team" in prompt
     assert "the dembrane team" in prompt
+
+
+@pytest.mark.asyncio
+async def test_list_project_conversations_passes_offset_through():
+    """Paging is what makes "call the list tool for the rest" a real
+    instruction rather than a dead end at the per-call cap."""
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(
+        search_payload={"conversations": []},
+        transcripts={},
+        project_conversations_payload={
+            "project_id": "project-1",
+            "count": 1,
+            "has_more": True,
+            "conversations": [
+                {"conversation_id": "conv-101", "participant_name": "Alice", "status": "done"},
+            ],
+        },
+    )
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["listProjectConversations"].ainvoke({"limit": 100, "offset": 100})
+
+    assert result["offset"] == 100
+    assert result["has_more"] is True
+    assert factory.instances[0].project_conversations_calls == [
+        {
+            "project_id": "project-1",
+            "limit": 100,
+            "offset": 100,
+            "conversation_id": None,
+            "transcript_query": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_focused_conversations_returns_the_chats_selection():
+    """The truncation line in the focus block points here, so this has to
+    return the host's selection for THIS chat, paged."""
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(search_payload={"conversations": []}, transcripts={})
+    _FakeEchoClient.focused_conversations_payload = {
+        "project_id": "project-1",
+        "project_chat_id": "chat-1",
+        "total": 250,
+        "count": 2,
+        "offset": 134,
+        "has_more": True,
+        "conversations": [{"id": "conv-134", "name": "Alice"}, {"id": "conv-135", "name": "Bob"}],
+    }
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+        chat_id="chat-1",
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["listFocusedConversations"].ainvoke({"limit": 50, "offset": 134})
+
+    assert result["total"] == 250
+    assert result["has_more"] is True
+    assert [c["id"] for c in result["conversations"]] == ["conv-134", "conv-135"]
+    assert factory.instances[0].focused_conversations_calls == [
+        {
+            "project_id": "project-1",
+            "project_chat_id": "chat-1",
+            "limit": 50,
+            "offset": 134,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_focused_conversations_without_a_chat_says_so():
+    """A run with no chat has no selection. Say that rather than calling the
+    endpoint with an empty chat id."""
+    llm = _CaptureLLM()
+    factory = _FakeEchoClientFactory(search_payload={"conversations": []}, transcripts={})
+
+    create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=factory,
+    )
+    tools = _tool_map(llm.bound_tools)
+
+    result = await tools["listFocusedConversations"].ainvoke({})
+
+    assert result["total"] == 0
+    assert result["conversations"] == []
+    assert factory.instances == []

--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import {
 	Alert,
 	Box,
@@ -136,6 +136,12 @@ const storageKeyForChat = (chatId: string) => `agentic-run:${chatId}`;
 // Internal placeholders the agent/worker may have persisted before the
 // server-side guard landed. They are never meant to be shown to a host.
 const INTERNAL_ASSISTANT_PLACEHOLDERS = new Set(["(calling tools)"]);
+
+// Past this, naming every conversation above the composer is a wall of chips
+// that also implies the whole list reaches the assistant in one go. It does
+// not: the prompt carries a size-bounded head and the assistant pages through
+// the rest, so say that instead of listing them.
+const FOCUS_CHIP_LIMIT = 12;
 
 const isTerminalStatus = (status: AgenticRunStatus | null) =>
 	status === "completed" || status === "failed" || status === "timeout";
@@ -1840,13 +1846,26 @@ export const AgenticChatPanel = ({
 									style={{ borderColor: "var(--mantine-color-primary-light)" }}
 								>
 									<Text size="xs" c="dimmed" fw={500}>
-										<Trans>Focusing on:</Trans>
+										<Plural
+											value={focusedContextConversations.length}
+											one="Focusing on # conversation:"
+											other="Focusing on # conversations:"
+										/>
 									</Text>
-									<ConversationLinks
-										conversations={
-											focusedContextConversations as unknown as Conversation[]
-										}
-									/>
+									{focusedContextConversations.length <= FOCUS_CHIP_LIMIT ? (
+										<ConversationLinks
+											conversations={
+												focusedContextConversations as unknown as Conversation[]
+											}
+										/>
+									) : (
+										<Text size="xs">
+											<Trans>
+												Too many to list here. The assistant reads through them
+												in batches.
+											</Trans>
+										</Text>
+									)}
 									<Button
 										variant="subtle"
 										size="compact-xs"

--- a/echo/frontend/src/components/chat/ChatModeSelector.tsx
+++ b/echo/frontend/src/components/chat/ChatModeSelector.tsx
@@ -51,12 +51,6 @@ export const MODE_COLORS = {
 };
 
 // Sample questions for each mode - wrapped in function to enable translation
-const getOverviewExamples = () => [
-	t`What are the main themes across all conversations?`,
-	t`Summarize key insights from my interviews`,
-	t`What patterns emerge from the data?`,
-];
-
 const getDeepDiveExamples = () => [
 	t`Summarize this interview into a shareable article`,
 	t`Pull out the most impactful quotes from this session`,
@@ -169,7 +163,7 @@ const ModeCard = ({
 										</Badge>
 									)}
 								</Group>
-								<Text size="sm" c="dimmed">
+								<Text size="sm">
 									{subtitle}
 								</Text>
 							</Stack>
@@ -180,7 +174,6 @@ const ModeCard = ({
 					<Stack gap="sm">
 						<Text
 							size="xs"
-							c="dimmed"
 							fw={600}
 							tt="uppercase"
 							style={{ letterSpacing: 0.5 }}
@@ -194,7 +187,7 @@ const ModeCard = ({
 									color="var(--app-text)"
 									style={{ flexShrink: 0, marginTop: 2 }}
 								/>
-								<Text size="sm" c="dimmed" lh={1.5}>
+								<Text size="sm" lh={1.5}>
 									{example}
 								</Text>
 							</Group>
@@ -272,12 +265,14 @@ export const ChatModeSelector = ({
 					>
 						<Trans>What would you like to explore?</Trans>
 					</Title>
-					<Text size="md" c="dimmed">
+					<Text size="md">
 						<Trans>Pick the approach that fits your question</Trans>
 					</Text>
 				</Stack>
 
-				{/* Mode Cards */}
+				{/* Mode Cards. Overview is no longer startable: chats that already
+				    have chat_mode="overview" keep working, but nothing creates a
+				    new one. */}
 				<Stack gap="lg">
 				{ENABLE_AGENTIC_CHAT && (
 					<ModeCard
@@ -305,29 +300,7 @@ export const ChatModeSelector = ({
 					isLoading={isLoading}
 					onSelectMode={handleSelectMode}
 				/>
-
-				<ModeCard
-					mode="overview"
-					title={t`Overview`}
-					subtitle={t`Explore themes & patterns across all conversations`}
-					examples={getOverviewExamples()}
-					icon={IconSparkles}
-					isBeta
-					atLimit={atChatLimit}
-					selectedMode={selectedMode}
-					isLoading={isLoading}
-					onSelectMode={handleSelectMode}
-				/>
 				</Stack>
-
-				{/* Loading message */}
-				{isLoading && selectedMode === "overview" && (
-					<Text size="sm" c="dimmed" ta="center" fs="italic">
-						<Trans>
-							Preparing your conversations... This may take a moment.
-						</Trans>
-					</Text>
-				)}
 			</Stack>
 		</Box>
 	);

--- a/echo/frontend/src/components/conversation/ConversationAccordion.tsx
+++ b/echo/frontend/src/components/conversation/ConversationAccordion.tsx
@@ -71,7 +71,6 @@ import {
 	useInfiniteProjects,
 	useProjectById,
 } from "@/components/project/hooks";
-import { ENABLE_CHAT_SELECT_ALL } from "@/config";
 import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
 import { testId } from "@/lib/testUtils";
 import { BaseSkeleton } from "../common/BaseSkeleton";
@@ -468,7 +467,7 @@ const ConversationProjectTagPill = ({
 		return null;
 	}
 
-	const isClickable = ENABLE_CHAT_SELECT_ALL && onClick;
+	const isClickable = onClick;
 
 	return (
 		<Pill
@@ -918,7 +917,7 @@ export const ConversationAccordion = ({
 			verifiedOnly: showOnlyVerified || undefined,
 		},
 		{
-			enabled: ENABLE_CHAT_SELECT_ALL && inChatMode && chatMode === "deep_dive",
+			enabled: inChatMode && chatMode === "deep_dive",
 		},
 	);
 
@@ -1422,8 +1421,7 @@ export const ConversationAccordion = ({
 					</Box>
 
 					{/* Select All - show in deep dive mode, disable when all relevant conversations are in context */}
-					{ENABLE_CHAT_SELECT_ALL &&
-						inChatMode &&
+					{inChatMode &&
 						chatMode === "deep_dive" &&
 						allConversations.length > 0 && (
 							<Tooltip
@@ -1543,43 +1541,39 @@ export const ConversationAccordion = ({
 				</Stack>
 
 				{/* Select All Confirmation Modal */}
-				{ENABLE_CHAT_SELECT_ALL && (
-					<SelectAllConfirmationModal
-						opened={selectAllModalOpened}
-						onClose={handleSelectAllModalClose}
-						onExitTransitionEnd={handleModalExitTransitionEnd}
-						onConfirm={handleSelectAllConfirm}
-						totalCount={remainingCount}
-						hasFilters={hasActiveFilters}
-						isLoading={selectAllLoading}
-						existingContextCount={conversationsInContext.size}
-						filterNames={selectedTagNames}
-						hasVerifiedOutcomesFilter={showOnlyVerified}
-						searchText={debouncedConversationSearchValue || undefined}
-						result={
-							selectAllResult
-								? {
-										added: selectAllResult.added,
-										contextLimitReached: selectAllResult.context_limit_reached,
-										skipped: selectAllResult.skipped,
-									}
-								: null
-						}
-					/>
-				)}
+				<SelectAllConfirmationModal
+					opened={selectAllModalOpened}
+					onClose={handleSelectAllModalClose}
+					onExitTransitionEnd={handleModalExitTransitionEnd}
+					onConfirm={handleSelectAllConfirm}
+					totalCount={remainingCount}
+					hasFilters={hasActiveFilters}
+					isLoading={selectAllLoading}
+					existingContextCount={conversationsInContext.size}
+					filterNames={selectedTagNames}
+					hasVerifiedOutcomesFilter={showOnlyVerified}
+					searchText={debouncedConversationSearchValue || undefined}
+					result={
+						selectAllResult
+							? {
+									added: selectAllResult.added,
+									contextLimitReached: selectAllResult.context_limit_reached,
+									skipped: selectAllResult.skipped,
+								}
+							: null
+					}
+				/>
 
 				{/* Add Tag Filter Modal */}
-				{ENABLE_CHAT_SELECT_ALL && (
-					<AddTagFilterModal
-						opened={addTagFilterModalOpened}
-						onClose={addTagFilterModalHandlers.close}
-						onExitTransitionEnd={handleTagFilterModalExitTransitionEnd}
-						onConfirm={handleAddTagFilter}
-						tagName={
-							(selectedTagForFilter?.project_tag_id as ProjectTag)?.text ?? ""
-						}
-					/>
-				)}
+				<AddTagFilterModal
+					opened={addTagFilterModalOpened}
+					onClose={addTagFilterModalHandlers.close}
+					onExitTransitionEnd={handleTagFilterModalExitTransitionEnd}
+					onConfirm={handleAddTagFilter}
+					tagName={
+						(selectedTagForFilter?.project_tag_id as ProjectTag)?.text ?? ""
+					}
+				/>
 			</Accordion.Panel>
 		</Accordion.Item>
 	);

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -87,6 +87,13 @@ type ProjectConversationsPanelProps = {
 	selectionChatId?: string;
 	selectionMode?: boolean;
 	showUpload?: boolean;
+	/** Selection before a chat exists. With `onSelectionChange` set, the ticked
+	 * ids live in the parent's state and nothing is written to a chat: pass
+	 * `selectionChatId` instead to write straight through to an existing chat. */
+	selection?: string[];
+	onSelectionChange?: (conversationIds: string[]) => void;
+	/** Renders the "Ask about these" action above the list. */
+	onAskAboutSelection?: () => void;
 };
 
 const lineClampStyle = {
@@ -224,6 +231,8 @@ type ConversationRowProps = {
 	onLockedClick?: (conversation: Conversation) => void;
 	selectionChatId?: string;
 	selectionMode?: boolean;
+	/** Set when selection is held in the parent's state (no chat yet). */
+	onToggleChecked?: (conversationId: string) => void;
 };
 
 const ConversationRow = ({
@@ -236,6 +245,7 @@ const ConversationRow = ({
 	onLockedClick,
 	selectionChatId,
 	selectionMode,
+	onToggleChecked,
 }: ConversationRowProps) => {
 	const primary =
 		conversation.title?.trim() ||
@@ -255,6 +265,19 @@ const ConversationRow = ({
 		!conversation.is_anonymized &&
 		!conversation.has_only_text_chunks;
 
+	// Empty and gated conversations can never join a chat context, so they can't
+	// be ticked either. Same rule as the write-through checkbox above.
+	const localCheckbox = onToggleChecked ? (
+		<Checkbox
+			aria-label={t`Select conversation`}
+			checked={!!isSelected}
+			disabled={isLocked || conversation.has_transcript === false}
+			onChange={() => onToggleChecked(conversation.id)}
+			color={MODE_COLOR}
+			{...testId(`conversation-select-checkbox-${conversation.id}`)}
+		/>
+	) : null;
+
 	const body = (
 		<Group align="flex-start" gap="md" wrap="nowrap">
 			{selectionMode && selectionChatId && (
@@ -264,6 +287,9 @@ const ConversationRow = ({
 						chatId={selectionChatId}
 					/>
 				</Box>
+			)}
+			{selectionMode && !selectionChatId && localCheckbox && (
+				<Box pt={4}>{localCheckbox}</Box>
 			)}
 
 			<Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
@@ -508,6 +534,9 @@ export const ProjectConversationsPanel = ({
 	selectionChatId,
 	selectionMode = false,
 	showUpload = false,
+	selection,
+	onSelectionChange,
+	onAskAboutSelection,
 }: ProjectConversationsPanelProps) => {
 	const navigate = useI18nNavigate();
 	const { ref: loadMoreRef, inView } = useInView();
@@ -630,15 +659,28 @@ export const ProjectConversationsPanel = ({
 	]);
 
 	const chatContextQuery = useProjectChatContext(selectionChatId ?? "");
-	const selectedConversationIds = useMemo(
-		() =>
-			new Set(
-				(chatContextQuery.data?.conversations ?? []).map(
-					(c) => c.conversation_id,
-				),
+	// chatId-less mode (no chat exists yet): the ticked set lives in the
+	// parent's state and is reported back via onSelectionChange, instead of
+	// being written straight through addChatContext.
+	const isLocalSelectionMode = selectionMode && !selectionChatId;
+	const selectedConversationIds = useMemo(() => {
+		if (isLocalSelectionMode) return new Set(selection ?? []);
+		return new Set(
+			(chatContextQuery.data?.conversations ?? []).map(
+				(c) => c.conversation_id,
 			),
-		[chatContextQuery.data?.conversations],
-	);
+		);
+	}, [isLocalSelectionMode, selection, chatContextQuery.data?.conversations]);
+	const toggleLocalSelection = (conversationId: string) => {
+		const current = selection ?? [];
+		const next = current.includes(conversationId)
+			? current.filter((id) => id !== conversationId)
+			: [...current, conversationId];
+		onSelectionChange?.(next);
+	};
+	// Named to match ChatModeBanner's "{conversationCount} selected" so both
+	// reuse the same translated string.
+	const conversationCount = selectedConversationIds.size;
 	const chatMode = chatContextQuery.data?.chat_mode;
 	const hasActiveFilters =
 		selectedTagIds.length > 0 || showOnlyVerified || debouncedSearch !== "";
@@ -862,6 +904,31 @@ export const ProjectConversationsPanel = ({
 							)}
 						</Button>
 					)}
+
+				{isLocalSelectionMode && onAskAboutSelection && (
+					<Group gap="sm" align="center">
+						<Text size="sm" fw={500}>
+							<Trans>{conversationCount} selected</Trans>
+						</Text>
+						<Button
+							size="xs"
+							disabled={selectedConversationIds.size === 0}
+							onClick={onAskAboutSelection}
+							{...testId("conversations-ask-about-selection")}
+						>
+							<Trans>Ask about these</Trans>
+						</Button>
+						{selectedConversationIds.size > 0 && (
+							<Button
+								variant="subtle"
+								size="xs"
+								onClick={() => onSelectionChange?.([])}
+							>
+								<Trans>Clear</Trans>
+							</Button>
+						)}
+					</Group>
+				)}
 			</Stack>
 
 			<Divider />
@@ -909,6 +976,9 @@ export const ProjectConversationsPanel = ({
 							onLockedClick={upgradeHandlers.open}
 							selectionChatId={selectionChatId}
 							selectionMode={selectionMode}
+							onToggleChecked={
+								isLocalSelectionMode ? toggleLocalSelection : undefined
+							}
 						/>
 					);
 					const isLast = index === allConversations.length - 1;

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -49,7 +49,6 @@ import { UploadConversationDropzone } from "@/components/dropzone/UploadConversa
 import { useProjectById } from "@/components/project/hooks";
 import { UploadLockedCard } from "@/components/project/UploadLockedCard";
 import { UpgradeModal } from "@/components/workspace/FeatureGate";
-import { ENABLE_CHAT_SELECT_ALL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
@@ -273,7 +272,7 @@ const ConversationRow = ({
 			checked={!!isSelected}
 			disabled={isLocked || conversation.has_transcript === false}
 			onChange={() => onToggleChecked(conversation.id)}
-			color={MODE_COLOR}
+			color="primary"
 			{...testId(`conversation-select-checkbox-${conversation.id}`)}
 		/>
 	) : null;
@@ -701,7 +700,6 @@ export const ProjectConversationsPanel = ({
 		{
 			enabled:
 				selectionMode &&
-				ENABLE_CHAT_SELECT_ALL &&
 				(chatMode === "deep_dive" || chatMode === "agentic") &&
 				!!selectionChatId,
 		},
@@ -881,7 +879,6 @@ export const ProjectConversationsPanel = ({
 				</Paper>
 
 				{selectionMode &&
-					ENABLE_CHAT_SELECT_ALL &&
 					(chatMode === "deep_dive" || chatMode === "agentic") &&
 					allConversations.length > 0 && (
 						<Button
@@ -1021,7 +1018,7 @@ export const ProjectConversationsPanel = ({
 				)}
 			</Modal>
 
-			{selectionMode && ENABLE_CHAT_SELECT_ALL && (
+			{selectionMode && (
 				<SelectAllConfirmationModal
 					opened={selectAllModalOpened}
 					onClose={() => setSelectAllModalOpened(false)}

--- a/echo/frontend/src/components/project/hooks/index.ts
+++ b/echo/frontend/src/components/project/hooks/index.ts
@@ -7,11 +7,11 @@ import {
 	useQueryClient,
 } from "@tanstack/react-query";
 import { toast } from "@/components/common/Toaster";
-import { useAddChatContextMutation } from "@/components/conversation/hooks";
 import { API_BASE_URL } from "@/config";
 import { useParams } from "react-router";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import {
+	addChatContext,
 	api,
 	type CreateCustomTopicPayload,
 	cloneProjectById,
@@ -346,12 +346,13 @@ export const useDeleteTagByIdMutation = () => {
 export const useCreateChatMutation = () => {
 	const navigate = useI18nNavigate();
 	const queryClient = useQueryClient();
-	const addChatContextMutation = useAddChatContextMutation();
 	const { workspaceId } = useParams();
 	return useMutation({
 		mutationFn: async (payload: {
 			navigateToNewChat?: boolean;
-			conversationId?: string;
+			/** Conversations picked before the chat existed. Attached and awaited
+			 * here, so the rows are in place before the first turn runs. */
+			conversationIds?: string[];
 			project_id: {
 				id: string;
 			};
@@ -376,11 +377,20 @@ export const useCreateChatMutation = () => {
 				);
 			}
 
-			if (payload.conversationId) {
-				addChatContextMutation.mutate({
-					chatId: chat.id,
-					conversationId: payload.conversationId,
-				});
+			const conversationIds = payload.conversationIds ?? [];
+			if (conversationIds.length > 0) {
+				const results = await Promise.allSettled(
+					conversationIds.map((conversationId) =>
+						addChatContext(chat.id, { conversationId }),
+					),
+				);
+				const failed = results.filter((r) => r.status === "rejected").length;
+				if (failed > 0) {
+					// The chat itself is fine, so keep it and say what was dropped.
+					toast.error(
+						t`Could not add ${failed} of ${conversationIds.length} conversations to this chat`,
+					);
+				}
 			}
 
 			return chat;
@@ -389,7 +399,7 @@ export const useCreateChatMutation = () => {
 			queryClient.invalidateQueries({
 				queryKey: ["projects", variables.project_id.id, "chats"],
 			});
-			toast.success("Chat created successfully");
+			toast.success(t`Chat created`);
 		},
 	});
 };

--- a/echo/frontend/src/components/project/hooks/index.ts
+++ b/echo/frontend/src/components/project/hooks/index.ts
@@ -1,5 +1,5 @@
 import type { Query } from "@directus/sdk";
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import {
 	useInfiniteQuery,
 	useMutation,
@@ -350,9 +350,6 @@ export const useCreateChatMutation = () => {
 	return useMutation({
 		mutationFn: async (payload: {
 			navigateToNewChat?: boolean;
-			/** Conversations picked before the chat existed. Attached and awaited
-			 * here, so the rows are in place before the first turn runs. */
-			conversationIds?: string[];
 			project_id: {
 				id: string;
 			};
@@ -377,22 +374,6 @@ export const useCreateChatMutation = () => {
 				);
 			}
 
-			const conversationIds = payload.conversationIds ?? [];
-			if (conversationIds.length > 0) {
-				const results = await Promise.allSettled(
-					conversationIds.map((conversationId) =>
-						addChatContext(chat.id, { conversationId }),
-					),
-				);
-				const failed = results.filter((r) => r.status === "rejected").length;
-				if (failed > 0) {
-					// The chat itself is fine, so keep it and say what was dropped.
-					toast.error(
-						t`Could not add ${failed} of ${conversationIds.length} conversations to this chat`,
-					);
-				}
-			}
-
 			return chat;
 		},
 		onSuccess: (_, variables) => {
@@ -400,6 +381,82 @@ export const useCreateChatMutation = () => {
 				queryKey: ["projects", variables.project_id.id, "chats"],
 			});
 			toast.success(t`Chat created`);
+		},
+	});
+};
+
+/**
+ * Attaches conversations picked before the chat existed, in one request.
+ *
+ * One call, not one per conversation. The server walks the whole batch in
+ * order against a single running token budget, so it can attach as much as
+ * fits and tell us exactly why it stopped. Firing a request per conversation
+ * instead lets each one read the same starting context and pass, which puts a
+ * Specific Details chat over its context limit and breaks its next message.
+ *
+ * Call this after initialize-mode: the server skips the budget for agentic
+ * chats, and it can only tell that a chat is agentic once chat_mode is set.
+ */
+export const useAttachChatConversationsMutation = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (payload: {
+			chatId: string;
+			projectId: string;
+			conversationIds: string[];
+		}) => {
+			return addChatContext(payload.chatId, {
+				conversationIds: payload.conversationIds,
+				project_id: payload.projectId,
+			});
+		},
+		onError: () => {
+			// The chat itself is fine, so keep it and say what did not happen.
+			toast.error(t`Could not add your conversations to this chat`);
+		},
+		onSuccess: (response, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: ["chats", variables.chatId],
+			});
+
+			const skipped = response?.skipped ?? [];
+			if (skipped.length === 0) return;
+
+			// Say why, not just how many. The context limit is the one a host can
+			// act on (drop a conversation, or ask a narrower question).
+			const overLimit = skipped.filter(
+				(item) =>
+					item.reason === "context_limit_reached" || item.reason === "too_long",
+			).length;
+			const empty = skipped.filter((item) => item.reason === "empty").length;
+
+			if (overLimit > 0) {
+				toast.error(
+					plural(overLimit, {
+						one: "# conversation did not fit in this chat. Start another chat to cover the rest.",
+						other:
+							"# conversations did not fit in this chat. Start another chat to cover the rest.",
+					}),
+				);
+				return;
+			}
+
+			if (empty === skipped.length) {
+				toast.error(
+					plural(empty, {
+						one: "# conversation has no transcript yet, so it was left out.",
+						other: "# conversations have no transcript yet, so they were left out.",
+					}),
+				);
+				return;
+			}
+
+			toast.error(
+				plural(skipped.length, {
+					one: "# conversation could not be added to this chat.",
+					other: "# conversations could not be added to this chat.",
+				}),
+			);
 		},
 	});
 };

--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -166,7 +166,6 @@ export const getDocumentationUrl = (locale = "en-US") =>
 
 export const DEBUG_MODE = import.meta.env.VITE_DEBUG_MODE === "1";
 
-export const ENABLE_CHAT_SELECT_ALL = true;
 export const ENABLE_CONVERSATION_HEALTH = true;
 export const ENABLE_ANNOUNCEMENTS = true;
 export const ENABLE_DISPLAY_CONVERSATION_LINKS = true;

--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -171,10 +171,18 @@ export const ENABLE_CONVERSATION_HEALTH = true;
 export const ENABLE_ANNOUNCEMENTS = true;
 export const ENABLE_DISPLAY_CONVERSATION_LINKS = true;
 export const ENABLE_WEBHOOKS = true;
-// On everywhere except production: local, testing/dev, next/staging.
-// Re-enabled 2026-07-02 with the agent on gemini-3.5-flash via Vertex and the
-// #573 harvest (server-side grep, chunk citations, titles) on main.
-export const ENABLE_AGENTIC_CHAT = byEnv({ production: false }, true);
+// Availability of agentic chat: on in every environment, production included.
+//
+// Availability and default-ness are deliberately two separate constants. Each
+// chat persists its own chat_mode, so agentic chats already exist in the data;
+// switching this to false would strand them on the legacy chat UI, which posts
+// to /chats/{id} and is rejected for agentic chats. Only flip this off if you
+// also have a story for those chats.
+export const ENABLE_AGENTIC_CHAT = true;
+// Which mode a new chat starts in. False means hosts get Specific Details by
+// default and opt in to Agentic from the Ask entry screen. Linear ECHO-898
+// decides when (and under what name) agentic becomes the default.
+export const AGENTIC_CHAT_IS_DEFAULT = false;
 // Re-enabled on echo-next (2026-06-21). Runtime render gate only; the build
 // always ships the (lazy) agentation chunk and JSX source metadata — other
 // environments just never render or download it. Widen to more envs by adding

--- a/echo/frontend/src/lib/api.ts
+++ b/echo/frontend/src/lib/api.ts
@@ -1078,6 +1078,9 @@ export const addChatContext = async (
 	chatId: string,
 	options?: {
 		conversationId?: string;
+		/** An explicit pick. One request for the whole batch: the server walks
+		 * the token budget once and reports a reason per conversation. */
+		conversationIds?: string[];
 		select_all?: boolean;
 		project_id?: string;
 		tag_ids?: string[];
@@ -1087,6 +1090,7 @@ export const addChatContext = async (
 ) => {
 	return api.post<unknown, AddContextResponse>(`/chats/${chatId}/add-context`, {
 		conversation_id: options?.conversationId,
+		conversation_ids: options?.conversationIds,
 		project_id: options?.project_id,
 		search_text: options?.search_text,
 		select_all: options?.select_all,

--- a/echo/frontend/src/lib/types.d.ts
+++ b/echo/frontend/src/lib/types.d.ts
@@ -203,11 +203,13 @@ type SelectAllConversationResult = {
 		| "context_limit_reached"
 		| "empty" // No transcript content
 		| "too_long" // Single conversation exceeds context
+		| "locked" // Over the tier's recording cap
+		| "not_found" // Not in this project, or already deleted
 		| "error"; // Processing error occurred
 };
 
 type AddContextResponse = {
-	// Optional fields populated when select_all is used
+	// Optional fields populated for the batch paths (select_all, conversation_ids)
 	added?: SelectAllConversationResult[];
 	skipped?: SelectAllConversationResult[];
 	total_processed?: number;

--- a/echo/frontend/src/routes/project/CreateProjectRoute.tsx
+++ b/echo/frontend/src/routes/project/CreateProjectRoute.tsx
@@ -23,7 +23,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "@/components/common/Toaster";
 import { useUpdateProjectByIdMutation } from "@/components/project/hooks";
-import { API_BASE_URL, ENABLE_AGENTIC_CHAT } from "@/config";
+import {
+	AGENTIC_CHAT_IS_DEFAULT,
+	API_BASE_URL,
+	ENABLE_AGENTIC_CHAT,
+} from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -74,8 +78,13 @@ export const CreateProjectRoute = () => {
 	const [name, setName] = useState("");
 	const [context, setContext] = useState("");
 	const [access, setAccess] = useState<Access>("workspace");
-	const [setupWithAssistant, setSetupWithAssistant] =
-		useState(ENABLE_AGENTIC_CHAT);
+	// Availability is not default-ness. The assistant setup starts an agentic
+	// chat, so it follows AGENTIC_CHAT_IS_DEFAULT: off unless the host ticks it
+	// (or picks "Help me figure it out"). Pre-ticking it would fire an agentic
+	// run on every project created, before the host has typed anything.
+	const [setupWithAssistant, setSetupWithAssistant] = useState(
+		AGENTIC_CHAT_IS_DEFAULT,
+	);
 	const [setupInitialMessage, setSetupInitialMessage] = useState(
 		SETUP_INITIAL_MESSAGE,
 	);
@@ -124,8 +133,13 @@ export const CreateProjectRoute = () => {
 			posthog?.capture("project_created", { project_id: project.id });
 			toast.success(t`Project created`);
 			if (ENABLE_AGENTIC_CHAT && setupWithAssistant) {
+				// Ticking the toggle is the opt-in, so name the mode explicitly
+				// rather than letting the Ask screen assume agentic.
 				navigate(`/w/${workspaceId}/projects/${project.id}/chats/new`, {
-					state: { initialMessage: setupInitialMessage },
+					state: {
+						initialMessage: setupInitialMessage,
+						preferMode: "agentic",
+					},
 				});
 			} else {
 				navigate(`/w/${workspaceId}/projects/${project.id}/home`);

--- a/echo/frontend/src/routes/project/ProjectRoutes.tsx
+++ b/echo/frontend/src/routes/project/ProjectRoutes.tsx
@@ -1,6 +1,13 @@
 import { Trans } from "@lingui/react/macro";
-import { Alert, Divider, LoadingOverlay, Stack } from "@mantine/core";
-import { useMemo } from "react";
+import {
+	Alert,
+	Button,
+	Divider,
+	Group,
+	LoadingOverlay,
+	Stack,
+} from "@mantine/core";
+import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { ProjectGoalSection } from "@/components/goal/ProjectGoalSection";
@@ -25,22 +32,58 @@ import {
 import { WebhookSection } from "@/components/project/webhooks/WebhookSettingsCard";
 import { FeatureGate } from "@/components/workspace/FeatureGate";
 import { ENABLE_CANVAS, ENABLE_WEBHOOKS } from "@/config";
+import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { getProjectTranscriptsLink } from "@/lib/api";
 import type { Tier } from "@/lib/tiers";
 
 export const ProjectConversationsRoute = () => {
 	const { projectId, workspaceId } = useParams();
+	const navigate = useI18nNavigate();
+	// Off by default so the page keeps browsing normally (full row actions,
+	// click-through to the conversation). Turning it on swaps in the same
+	// checkbox picker used inside a chat, plus "Ask about these" to start a
+	// new chat pre-focused on the pick, before any chat exists.
+	const [pickerMode, setPickerMode] = useState(false);
+	const [selectedConversationIds, setSelectedConversationIds] = useState<
+		string[]
+	>([]);
 
 	if (!projectId) return null;
 
 	return (
 		<PageContainer width="xl">
-			<ProjectConversationsPanel
-				projectId={projectId}
-				workspaceId={workspaceId}
-				showUpload
-			/>
+			<Stack gap="md">
+				<Group justify="flex-end">
+					<Button
+						variant="outline"
+						size="xs"
+						onClick={() => {
+							if (pickerMode) setSelectedConversationIds([]);
+							setPickerMode((current) => !current);
+						}}
+					>
+						{pickerMode ? (
+							<Trans>Cancel selection</Trans>
+						) : (
+							<Trans>Select conversations</Trans>
+						)}
+					</Button>
+				</Group>
+				<ProjectConversationsPanel
+					projectId={projectId}
+					workspaceId={workspaceId}
+					showUpload
+					selectionMode={pickerMode}
+					selection={selectedConversationIds}
+					onSelectionChange={setSelectedConversationIds}
+					onAskAboutSelection={() => {
+						navigate(`/w/${workspaceId}/projects/${projectId}/chats/new`, {
+							state: { selectedConversationIds },
+						});
+					}}
+				/>
+			</Stack>
 		</PageContainer>
 	);
 };

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import {
 	ActionIcon,
 	Alert,
@@ -41,7 +41,10 @@ import { BaseSkeleton } from "@/components/common/BaseSkeleton";
 import { NavigationButton } from "@/components/common/NavigationButton";
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { PageContainer } from "@/components/layout/PageContainer";
-import { useCreateChatMutation } from "@/components/project/hooks";
+import {
+	useAttachChatConversationsMutation,
+	useCreateChatMutation,
+} from "@/components/project/hooks";
 import {
 	AGENTIC_CHAT_IS_DEFAULT,
 	ASK_DOCS_URL,
@@ -195,6 +198,7 @@ export const NewChatRoute = () => {
 	const isObserver = isReadOnlyRole(workspace?.role);
 	const { language } = useLanguage();
 	const createChatMutation = useCreateChatMutation();
+	const attachConversationsMutation = useAttachChatConversationsMutation();
 	const initializeModeMutation = useInitializeChatModeMutation();
 	const prefetchSuggestions = usePrefetchSuggestions();
 	const [isInitializing, setIsInitializing] = useState(false);
@@ -244,16 +248,10 @@ export const NewChatRoute = () => {
 		setIsInitializing(true);
 
 		try {
-			// Step 1: Create the chat without mode, attaching any conversations
-			// picked up-front (awaited: they need to exist before the mode
-			// initializes and the first turn runs).
+			// Step 1: Create the chat. It has no mode yet.
 			const chat = await createChatMutation.mutateAsync({
 				navigateToNewChat: false, // Don't navigate yet
 				project_id: { id: projectId },
-				conversationIds:
-					selectedConversationIds.length > 0
-						? selectedConversationIds
-						: undefined,
 			});
 
 			if (!chat?.id) {
@@ -273,13 +271,27 @@ export const NewChatRoute = () => {
 				projectId,
 			});
 
-			// Step 3: For overview mode, prefetch suggestions (wait up to 5s for better UX)
+			// Step 3: Attach the conversations picked up-front, in one request,
+			// after the mode exists and before the first turn runs. Order
+			// matters: the server only skips the transcript token budget once it
+			// can see that the chat is agentic, so attaching first would make a
+			// long selection fail with "Conversation is too long" even for
+			// agentic.
+			if (selectedConversationIds.length > 0) {
+				await attachConversationsMutation.mutateAsync({
+					chatId: chat.id,
+					conversationIds: selectedConversationIds,
+					projectId,
+				});
+			}
+
+			// Step 4: For overview mode, prefetch suggestions (wait up to 5s for better UX)
 			// For deep_dive mode, navigate immediately - suggestions will be fetched when context changes
 			if (mode === "overview") {
 				await prefetchSuggestions(chat.id, language, 5000);
 			}
 
-			// Step 4: Navigate to the new chat; the panel sends the typed
+			// Step 5: Navigate to the new chat; the panel sends the typed
 			// question as the first message (router state, consumed once).
 			navigate(`/w/${workspaceId}/projects/${projectId}/chats/${chat.id}`, {
 				state: initialMessage ? { initialMessage } : undefined,
@@ -295,28 +307,35 @@ export const NewChatRoute = () => {
 		}
 	};
 
-	// "Open the old chat experience" from inside an agentic chat lands here
-	// with a preferred mode; start that chat right away, once.
+	// Two ways to land here with the choice already made:
+	//   - "Open the old chat experience" inside an agentic chat passes
+	//     preferMode: "deep_dive".
+	//   - Project creation with "Set up with the assistant" ticked passes
+	//     preferMode: "agentic" plus the seed question.
+	// Anything that arrives with only a seed follows the default mode rather
+	// than assuming agentic.
 	const preferredMode =
 		typeof (location.state as { preferMode?: unknown } | null)?.preferMode ===
 		"string"
 			? ((location.state as { preferMode: ChatMode }).preferMode as ChatMode)
 			: null;
-	const preferredModeStartedRef = useRef(false);
 	const queryPrefillStartedRef = useRef(false);
 	const initialMessage =
 		typeof (location.state as { initialMessage?: unknown } | null)
 			?.initialMessage === "string"
 			? (location.state as { initialMessage: string }).initialMessage
 			: null;
-	const initialMessageStartedRef = useRef(false);
+	const autoStartMode: ChatMode | null =
+		preferredMode ?? (initialMessage ? modeToStart : null);
+	const autoStartedRef = useRef(false);
 	// biome-ignore lint/correctness/useExhaustiveDependencies: handleModeSelected is recreated per render; the ref guards a single run
 	useEffect(() => {
-		if (!preferredMode || preferredModeStartedRef.current) return;
-		preferredModeStartedRef.current = true;
+		if (!autoStartMode || autoStartedRef.current) return;
+		if (autoStartMode === "agentic" && !ENABLE_AGENTIC_CHAT) return;
+		autoStartedRef.current = true;
 		window.history.replaceState({}, "");
-		void handleModeSelected(preferredMode);
-	}, [preferredMode]);
+		void handleModeSelected(autoStartMode, initialMessage ?? undefined);
+	}, [autoStartMode]);
 
 	useEffect(() => {
 		if (queryPrefillStartedRef.current) return;
@@ -330,18 +349,6 @@ export const NewChatRoute = () => {
 		);
 		if (prefill) setDraft(prefill);
 	}, [location.hash, location.pathname, location.search]);
-
-	// Project creation lands on Ask home with a setup seed. Start the agentic
-	// chat immediately and pass the seed through to the chat panel, which sends
-	// it as the first user message.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: handleModeSelected is recreated per render; the ref guards a single run
-	useEffect(() => {
-		if (!ENABLE_AGENTIC_CHAT) return;
-		if (!initialMessage || initialMessageStartedRef.current) return;
-		initialMessageStartedRef.current = true;
-		window.history.replaceState({}, "");
-		void handleModeSelected("agentic", initialMessage);
-	}, [initialMessage]);
 
 	if (!projectId || !workspaceId) {
 		return (
@@ -377,6 +384,7 @@ export const NewChatRoute = () => {
 	const isPending =
 		isInitializing ||
 		createChatMutation.isPending ||
+		attachConversationsMutation.isPending ||
 		initializeModeMutation.isPending;
 
 	const startChat = () => {
@@ -440,37 +448,55 @@ export const NewChatRoute = () => {
 							}
 							{...{ "data-testid": "ask-home-input" }}
 						/>
-						{selectedConversationIds.length > 0 && (
-							<Group gap="sm" align="center">
-								<Text size="sm">
-									{modeToStart === "agentic" ? (
-										<Trans>
-											Focusing on {selectedConversationIds.length} conversations
-										</Trans>
-									) : (
-										<Trans>
-											Using {selectedConversationIds.length} conversations
-										</Trans>
-									)}
-								</Text>
+						{/* The picker has to be reachable from an empty selection: this
+						    screen is where a host narrows the chat before it exists. */}
+						<Group gap="sm" align="center">
+							{selectedConversationIds.length > 0 ? (
+								<>
+									<Text size="sm">
+										{modeToStart === "agentic" ? (
+											<Plural
+												value={selectedConversationIds.length}
+												one="Focusing on # conversation"
+												other="Focusing on # conversations"
+											/>
+										) : (
+											<Plural
+												value={selectedConversationIds.length}
+												one="Using # conversation"
+												other="Using # conversations"
+											/>
+										)}
+									</Text>
+									<Button
+										variant="subtle"
+										size="xs"
+										disabled={isPending}
+										onClick={pickerHandlers.open}
+									>
+										<Trans>Change</Trans>
+									</Button>
+									<Button
+										variant="subtle"
+										size="xs"
+										disabled={isPending}
+										onClick={() => setSelectedConversationIds([])}
+									>
+										<Trans>Clear</Trans>
+									</Button>
+								</>
+							) : (
 								<Button
 									variant="subtle"
 									size="xs"
 									disabled={isPending}
 									onClick={pickerHandlers.open}
+									{...{ "data-testid": "ask-home-choose-conversations" }}
 								>
-									<Trans>Change</Trans>
+									<Trans>Choose conversations</Trans>
 								</Button>
-								<Button
-									variant="subtle"
-									size="xs"
-									disabled={isPending}
-									onClick={() => setSelectedConversationIds([])}
-								>
-									<Trans>Clear</Trans>
-								</Button>
-							</Group>
-						)}
+							)}
+						</Group>
 						<Group gap="lg">
 							<InsertTemplateMenu
 								workspaceId={workspaceId}
@@ -502,6 +528,10 @@ export const NewChatRoute = () => {
 						</Group>
 					</Stack>
 				) : (
+					// Unreachable while ENABLE_AGENTIC_CHAT is true everywhere. Kept as
+					// the fallback entry screen if availability is ever narrowed again;
+					// ChatModeSelector is still live for mode-less chats in
+					// ProjectChatRoute, and five modules import its MODE_COLORS.
 					<ChatModeSelector
 						isNewChat
 						isCreating={isPending}

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -10,6 +10,7 @@ import {
 	Center,
 	Group,
 	Loader,
+	Modal,
 	Stack,
 	Text,
 	Textarea,
@@ -38,9 +39,14 @@ import { InsertTemplateMenu } from "@/components/chat/InsertTemplateMenu";
 import { consumeChatPrefill } from "@/components/chat/prefill";
 import { BaseSkeleton } from "@/components/common/BaseSkeleton";
 import { NavigationButton } from "@/components/common/NavigationButton";
+import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { useCreateChatMutation } from "@/components/project/hooks";
-import { ASK_DOCS_URL, ENABLE_AGENTIC_CHAT } from "@/config";
+import {
+	AGENTIC_CHAT_IS_DEFAULT,
+	ASK_DOCS_URL,
+	ENABLE_AGENTIC_CHAT,
+} from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -198,6 +204,30 @@ export const NewChatRoute = () => {
 	const atChatLimit = Boolean(
 		freeTier?.active && freeTier.chats_used >= freeTier.chats_limit,
 	);
+	// Which mode the primary Start button (and the count line's wording)
+	// targets. Agentic stays available via the "Try Agentic instead" link
+	// regardless of this default.
+	const modeToStart: ChatMode = AGENTIC_CHAT_IS_DEFAULT
+		? "agentic"
+		: "deep_dive";
+
+	// Conversations picked before the chat exists, from either this screen's
+	// own "Change" picker or the "Ask about these" action on the Conversations
+	// page (router state). Held here, not written through, until the chat is
+	// created.
+	const [selectedConversationIds, setSelectedConversationIds] = useState<
+		string[]
+	>(() => {
+		const state = location.state as
+			| { selectedConversationIds?: unknown }
+			| null;
+		return Array.isArray(state?.selectedConversationIds)
+			? state.selectedConversationIds.filter(
+					(id): id is string => typeof id === "string",
+				)
+			: [];
+	});
+	const [pickerOpened, pickerHandlers] = useDisclosure(false);
 
 	const handleModeSelected = async (
 		mode: ChatMode,
@@ -214,10 +244,16 @@ export const NewChatRoute = () => {
 		setIsInitializing(true);
 
 		try {
-			// Step 1: Create the chat without mode
+			// Step 1: Create the chat without mode, attaching any conversations
+			// picked up-front (awaited: they need to exist before the mode
+			// initializes and the first turn runs).
 			const chat = await createChatMutation.mutateAsync({
 				navigateToNewChat: false, // Don't navigate yet
 				project_id: { id: projectId },
+				conversationIds:
+					selectedConversationIds.length > 0
+						? selectedConversationIds
+						: undefined,
 			});
 
 			if (!chat?.id) {
@@ -345,6 +381,11 @@ export const NewChatRoute = () => {
 
 	const startChat = () => {
 		if (isPending) return;
+		void handleModeSelected(modeToStart, draft.trim() || undefined);
+	};
+
+	const startAgentic = () => {
+		if (isPending) return;
 		void handleModeSelected("agentic", draft.trim() || undefined);
 	};
 
@@ -353,23 +394,9 @@ export const NewChatRoute = () => {
 			<Stack gap="xl">
 				{ENABLE_AGENTIC_CHAT ? (
 					<Stack gap="lg" className="pb-4 pt-10">
-						<Group justify="space-between" align="baseline" gap="sm">
-							<Title order={2} fw={500}>
-								<Trans>Where would you like to start?</Trans>
-							</Title>
-							{/* Escape hatch to the classic experience while the new
-							    chat matures. */}
-							<Button
-								variant="subtle"
-								size="xs"
-								disabled={isPending}
-								onClick={() => void handleModeSelected("deep_dive")}
-							>
-								<Trans>
-									Prefer the old chat? Start a Specific Details chat
-								</Trans>
-							</Button>
-						</Group>
+						<Title order={2} fw={500}>
+							<Trans>Where would you like to start?</Trans>
+						</Title>
 						<Textarea
 							autosize
 							minRows={2}
@@ -413,6 +440,37 @@ export const NewChatRoute = () => {
 							}
 							{...{ "data-testid": "ask-home-input" }}
 						/>
+						{selectedConversationIds.length > 0 && (
+							<Group gap="sm" align="center">
+								<Text size="sm">
+									{modeToStart === "agentic" ? (
+										<Trans>
+											Focusing on {selectedConversationIds.length} conversations
+										</Trans>
+									) : (
+										<Trans>
+											Using {selectedConversationIds.length} conversations
+										</Trans>
+									)}
+								</Text>
+								<Button
+									variant="subtle"
+									size="xs"
+									disabled={isPending}
+									onClick={pickerHandlers.open}
+								>
+									<Trans>Change</Trans>
+								</Button>
+								<Button
+									variant="subtle"
+									size="xs"
+									disabled={isPending}
+									onClick={() => setSelectedConversationIds([])}
+								>
+									<Trans>Clear</Trans>
+								</Button>
+							</Group>
+						)}
 						<Group gap="lg">
 							<InsertTemplateMenu
 								workspaceId={workspaceId}
@@ -428,6 +486,19 @@ export const NewChatRoute = () => {
 									<Trans>What can Ask do?</Trans>
 								</Anchor>
 							)}
+						</Group>
+						<Group gap="xs" align="center">
+							<Button
+								variant="subtle"
+								size="xs"
+								disabled={isPending}
+								onClick={startAgentic}
+							>
+								<Trans>Try Agentic instead</Trans>
+							</Button>
+							<Badge size="sm" color="mauve" c="graphite">
+								<Trans>Beta</Trans>
+							</Badge>
 						</Group>
 					</Stack>
 				) : (
@@ -453,6 +524,23 @@ export const NewChatRoute = () => {
 				onClose={upgradeHandlers.close}
 				reason="chats"
 			/>
+			<Modal
+				opened={pickerOpened}
+				onClose={pickerHandlers.close}
+				title={t`Select conversations`}
+				size="xl"
+				padding="lg"
+			>
+				{projectId && (
+					<ProjectConversationsPanel
+						projectId={projectId}
+						workspaceId={workspaceId}
+						selectionMode
+						selection={selectedConversationIds}
+						onSelectionChange={setSelectedConversationIds}
+					/>
+				)}
+			</Modal>
 		</PageContainer>
 	);
 };

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -332,6 +332,18 @@ export const ProjectChatRoute = () => {
 	>(null);
 	const [conversationPickerOpen, setConversationPickerOpen] = useState(false);
 	const queryPrefillStartedRef = useRef(false);
+	// A question typed on the Ask home page arrives as router state. The
+	// agentic panel consumes this itself; this route consumes it for every
+	// other mode (deep_dive, legacy overview), so Specific Details (the new
+	// default) never silently drops what the host typed. Read once at mount,
+	// exactly like AgenticChatPanel's own initialMessageRef.
+	const initialMessageRef = useRef<string | null>(
+		typeof (location.state as { initialMessage?: unknown } | null)
+			?.initialMessage === "string"
+			? (location.state as { initialMessage: string }).initialMessage
+			: null,
+	);
+	const pendingInitialMessageRef = useRef<string | null>(null);
 
 	const handleSaveAsTemplate = (content: string) => {
 		setSaveAsTemplateContent(content);
@@ -535,6 +547,41 @@ export const ProjectChatRoute = () => {
 		}
 		handleSubmit();
 	};
+
+	// Step 1: once the chat is ready and its mode resolved, type the seeded
+	// question into the input, same as a host would. Runs once.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: setInput identity changes per render; the ref guards a single run
+	useEffect(() => {
+		if (!initialMessageRef.current) return;
+		if (isInitializing || chatQuery.isLoading || chatContextQuery.isLoading)
+			return;
+		if (isAgenticMode) return; // AgenticChatPanel seeds its own first message
+		if (!isModeSelected) return;
+		if (messages.length > 0) return;
+		const seed = initialMessageRef.current;
+		initialMessageRef.current = null;
+		window.history.replaceState({}, "");
+		pendingInitialMessageRef.current = seed;
+		setInput(seed);
+	}, [
+		isInitializing,
+		chatQuery.isLoading,
+		chatContextQuery.isLoading,
+		isAgenticMode,
+		isModeSelected,
+		messages.length,
+	]);
+
+	// Step 2: once the input reflects the seeded text, send it through the
+	// same path a manual Enter/Send would use (turn-limit guard, conversation
+	// lock, posthog capture). Consumed exactly once via the ref.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: guardedSubmit is recreated per render; the ref guards a single run
+	useEffect(() => {
+		if (!pendingInitialMessageRef.current) return;
+		if (normalizedInput !== pendingInitialMessageRef.current) return;
+		pendingInitialMessageRef.current = null;
+		guardedSubmit();
+	}, [normalizedInput]);
 
 	// check if assistant is typing by determining if the last message is an assistant message and has a text part
 	const isAssistantTyping =

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -73,7 +73,11 @@ import { useConversationsCountByProjectId } from "@/components/conversation/hook
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { useProjectById } from "@/components/project/hooks";
-import { API_BASE_URL, ENABLE_AGENTIC_CHAT } from "@/config";
+import {
+	AGENTIC_CHAT_IS_DEFAULT,
+	API_BASE_URL,
+	ENABLE_AGENTIC_CHAT,
+} from "@/config";
 import { useElementOnScreen } from "@/hooks/useElementOnScreen";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useLoadNotification } from "@/hooks/useLoadNotification";
@@ -81,6 +85,7 @@ import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
 import { FREE_TIER_MAX_CHAT_USER_TURNS } from "@/lib/freeTier";
 import { isReadOnlyRole } from "@/lib/roles";
+import { resolveChatScreen } from "./chatModeRouting";
 import { testId } from "@/lib/testUtils";
 
 const useDembraneChat = ({ chatId }: { chatId: string }) => {
@@ -356,6 +361,9 @@ export const ProjectChatRoute = () => {
 	const rawChatMode = chatContextQuery.data?.chat_mode;
 	const hasLockedConversations =
 		(chatContextQuery.data?.locked_conversation_id_list?.length ?? 0) > 0;
+	// Same legacy rule the screen resolver applies (see ./chatModeRouting):
+	// a mode-less chat that locked context predates chat_mode and renders as
+	// Specific Details.
 	const isLegacyChat = rawChatMode == null && hasLockedConversations;
 	const chatMode = isLegacyChat ? "deep_dive" : rawChatMode;
 	const isModeSelected = chatMode !== null && chatMode !== undefined;
@@ -508,6 +516,24 @@ export const ProjectChatRoute = () => {
 	} = useDembraneChat({ chatId: chatId ?? "" });
 	const normalizedInput = typeof input === "string" ? input : "";
 
+	// Which screen this chat opens on. Pure and unit-tested in
+	// ./chatModeRouting, because setting a mode is one-way: the server refuses
+	// to change chat_mode once set, so a wrong call here cannot be walked back.
+	const { screen: chatScreen } = resolveChatScreen({
+		agenticIsDefault: AGENTIC_CHAT_IS_DEFAULT,
+		hasLockedConversations,
+		messageCount: messages.length,
+		rawChatMode,
+	});
+
+	// Specific Details answers out of the conversations attached to the chat.
+	// Mirrors the "Select conversations to continue" alert further down.
+	const noConversationsSelected =
+		contextToBeAdded?.conversations?.length === 0 &&
+		contextToBeAdded?.locked_conversations?.length === 0;
+	const needsConversations =
+		chatMode !== "overview" && Boolean(noConversationsSelected);
+
 	useEffect(() => {
 		if (chatContextQuery.isLoading) return;
 		if (isAgenticMode) return;
@@ -580,8 +606,12 @@ export const ProjectChatRoute = () => {
 		if (!pendingInitialMessageRef.current) return;
 		if (normalizedInput !== pendingInitialMessageRef.current) return;
 		pendingInitialMessageRef.current = null;
+		// With nothing attached, Specific Details has no conversations to answer
+		// from. Leave the question in the box and let the alert below ask for a
+		// selection first, instead of firing an answerless turn.
+		if (needsConversations) return;
 		guardedSubmit();
-	}, [normalizedInput]);
+	}, [normalizedInput, needsConversations]);
 
 	// check if assistant is typing by determining if the last message is an assistant message and has a text part
 	const isAssistantTyping =
@@ -589,10 +619,6 @@ export const ProjectChatRoute = () => {
 		messages.length > 0 &&
 		messages[messages.length - 1].role === "assistant" &&
 		messages[messages.length - 1].parts?.some((part) => part.type === "text");
-
-	const noConversationsSelected =
-		contextToBeAdded?.conversations?.length === 0 &&
-		contextToBeAdded?.locked_conversations?.length === 0;
 
 	const computedChatForCopy = useMemo(() => {
 		const messagesList = messages.map((message) =>
@@ -685,9 +711,11 @@ export const ProjectChatRoute = () => {
 		);
 	}
 
-	// Agentic-only experience: a chat without a mode (and without legacy
-	// markers) becomes agentic automatically; hosts never pick a mode.
-	if (!isModeSelected && ENABLE_AGENTIC_CHAT) {
+	// Only auto-assign a mode when agentic is the default, and only for a chat
+	// with nothing in it. Availability is not default-ness: thousands of chats
+	// still carry chat_mode NULL, and converting one on open would hide its
+	// existing thread behind the agentic panel with no way back.
+	if (chatScreen === "agentic-auto") {
 		return (
 			<AutoInitializeAgentic
 				chatId={chatId ?? ""}
@@ -697,8 +725,10 @@ export const ProjectChatRoute = () => {
 		);
 	}
 
-	// Legacy mode selector (environments where agentic chat is off)
-	if (!isModeSelected) {
+	// A mode-less chat with no messages has nothing to lose, so let the host
+	// pick. One that already has a thread falls through to it below and is
+	// never offered the choice.
+	if (chatScreen === "mode-picker") {
 		return (
 			<Box className="flex min-h-full items-center justify-center px-2 pr-4">
 				<ChatModeSelector
@@ -955,7 +985,7 @@ export const ProjectChatRoute = () => {
 							</Button>
 						</Group>
 					)}
-					{chatMode !== "overview" && noConversationsSelected && (
+					{needsConversations && (
 						<Alert
 							icon={<IconAlertCircle size="1rem" />}
 							title={t`Select conversations to continue`}

--- a/echo/frontend/src/routes/project/chat/chatModeRouting.test.ts
+++ b/echo/frontend/src/routes/project/chat/chatModeRouting.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { resolveChatScreen } from "./chatModeRouting";
+
+/**
+ * The populations here are the real ones, measured against the production
+ * database while reviewing this change: 7,746 live chats have chat_mode NULL,
+ * 4,923 of those have locked conversations, 2,823 do not, and 300 of that last
+ * group have message history. Setting a mode is one-way, so each of those
+ * groups is asserted separately.
+ */
+describe("resolveChatScreen", () => {
+	it("renders the thread for a chat that already picked a mode", () => {
+		for (const mode of ["agentic", "deep_dive", "overview"] as const) {
+			expect(
+				resolveChatScreen({
+					agenticIsDefault: false,
+					hasLockedConversations: false,
+					messageCount: 4,
+					rawChatMode: mode,
+				}),
+			).toEqual({ chatMode: mode, screen: "thread" });
+		}
+	});
+
+	it("treats a mode-less chat with locked conversations as Specific Details", () => {
+		// The 4,923 chats that were already safe before this change.
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: false,
+				hasLockedConversations: true,
+				messageCount: 12,
+				rawChatMode: null,
+			}),
+		).toEqual({ chatMode: "deep_dive", screen: "thread" });
+	});
+
+	it("shows the existing thread for a mode-less chat that has messages", () => {
+		// The 300 chats whose history would have stopped rendering after the
+		// first agentic turn. They are never auto-converted and are never asked
+		// to pick, because picking agentic is not reversible.
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: false,
+				hasLockedConversations: false,
+				messageCount: 1,
+				rawChatMode: null,
+			}),
+		).toEqual({ chatMode: null, screen: "thread" });
+	});
+
+	it("keeps showing that thread even if agentic later becomes the default", () => {
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: true,
+				hasLockedConversations: false,
+				messageCount: 1,
+				rawChatMode: null,
+			}),
+		).toEqual({ chatMode: null, screen: "thread" });
+	});
+
+	it("offers the mode picker for an empty mode-less chat while agentic is opt-in", () => {
+		// The remaining ~2,523. Nothing written yet, so the host chooses.
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: false,
+				hasLockedConversations: false,
+				messageCount: 0,
+				rawChatMode: null,
+			}),
+		).toEqual({ chatMode: null, screen: "mode-picker" });
+	});
+
+	it("auto-starts agentic for an empty mode-less chat only once agentic is the default", () => {
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: true,
+				hasLockedConversations: false,
+				messageCount: 0,
+				rawChatMode: null,
+			}),
+		).toEqual({ chatMode: null, screen: "agentic-auto" });
+	});
+
+	it("never auto-converts a chat that has anything to lose", () => {
+		// The guarantee this whole module exists for, over every mode-less
+		// shape production actually contains.
+		for (const hasLockedConversations of [true, false]) {
+			for (const messageCount of [1, 25]) {
+				expect(
+					resolveChatScreen({
+						agenticIsDefault: true,
+						hasLockedConversations,
+						messageCount,
+						rawChatMode: null,
+					}).screen,
+				).toBe("thread");
+			}
+		}
+	});
+
+	it("treats undefined (context still loading) like null", () => {
+		expect(
+			resolveChatScreen({
+				agenticIsDefault: false,
+				hasLockedConversations: false,
+				messageCount: 0,
+				rawChatMode: undefined,
+			}).screen,
+		).toBe("mode-picker");
+	});
+});

--- a/echo/frontend/src/routes/project/chat/chatModeRouting.ts
+++ b/echo/frontend/src/routes/project/chat/chatModeRouting.ts
@@ -1,0 +1,65 @@
+import type { ChatMode } from "@/lib/api";
+
+/**
+ * Which screen a chat opens on, given what the server knows about it.
+ *
+ * Pulled out of ProjectChatRoute because the consequences are one-way: the
+ * server's initialize-mode refuses to change a chat's mode once it is set, so
+ * picking a mode on the host's behalf can never be undone. Production still
+ * has thousands of chats with chat_mode NULL, several hundred of them with a
+ * real message history, and an automatic agentic init would move those threads
+ * behind a panel that reads a different message store.
+ */
+export type ChatScreen =
+	/** Set the mode to agentic without asking, then hand off to the panel. */
+	| "agentic-auto"
+	/** Ask the host which mode this chat should be. */
+	| "mode-picker"
+	/** Render the message thread. */
+	| "thread";
+
+export type ChatScreenDecision = {
+	screen: ChatScreen;
+	/**
+	 * The mode the thread renders as. `null` means the chat never picked one
+	 * and nothing should write one: it renders like Specific Details, which is
+	 * what its existing messages were produced by.
+	 */
+	chatMode: ChatMode | null;
+};
+
+export const resolveChatScreen = ({
+	rawChatMode,
+	hasLockedConversations,
+	messageCount,
+	agenticIsDefault,
+}: {
+	rawChatMode: ChatMode | null | undefined;
+	hasLockedConversations: boolean;
+	messageCount: number;
+	agenticIsDefault: boolean;
+}): ChatScreenDecision => {
+	if (rawChatMode != null) {
+		return { chatMode: rawChatMode, screen: "thread" };
+	}
+
+	// Locked conversations are the older legacy marker: a chat that locked
+	// context predates chat_mode and has always rendered as Specific Details.
+	if (hasLockedConversations) {
+		return { chatMode: "deep_dive", screen: "thread" };
+	}
+
+	// Messages are the same signal by a different route: this thread came from
+	// the pre-mode /chats/{id} path. Show it, and do not offer a mode, because
+	// choosing agentic here would hide it.
+	if (messageCount > 0) {
+		return { chatMode: null, screen: "thread" };
+	}
+
+	// Nothing written yet, so there is nothing to lose either way. Availability
+	// is not default-ness: only auto-assign when agentic is the default.
+	return {
+		chatMode: null,
+		screen: agenticIsDefault ? "agentic-auto" : "mode-picker",
+	};
+};

--- a/echo/server/dembrane/agentic_focus.py
+++ b/echo/server/dembrane/agentic_focus.py
@@ -12,12 +12,28 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping, Sequence
 
-# The agent's own conversation-list tool caps at 100 rows per call
-# (`GET /agentic/projects/{id}/conversations`, limit le=100), so promising more
-# than that in a focus hint asks for context the agent cannot fetch in one pass.
-# It also bounds the per-turn injection: a 200-conversation selection measured
-# ~11k chars (~2.8k tokens) on every turn; 100 halves that.
-MAX_FOCUSED_CONVERSATIONS = 100
+# Bound what goes INLINE, keep the rest REACHABLE. This block is rebuilt and
+# re-injected on EVERY turn, so its size is paid again on every call of the
+# session: that is the quadratic shape behind runaway per-session token bills,
+# and it is the reason the bound is on rendered size rather than item count.
+#
+# The old cap (100 conversations) was not actually a bound. 100 lines at the
+# 80-char label clamp render ~11k chars, which is the very number that cap
+# claimed to have halved. 4k chars is ~1k tokens per turn: over a 30-turn
+# session that is ~30k tokens of re-sent hint, against ~84k at the old size.
+#
+# Anything past the budget is not lost, it is paged: the truncation line names
+# the tool and the exact offset to call it with.
+MAX_FOCUS_BLOCK_CHARS = 4_000
+
+# The agent tool that returns THIS chat's focused set, paginated. Named here so
+# the truncation line and the tool cannot drift apart. Unlike the project-wide
+# conversation list, it can actually answer "which ones did the host pick".
+FOCUS_LIST_TOOL_NAME = "listFocusedConversations"
+
+# Room set aside for the truncation line, which is only rendered once and whose
+# length varies only by the digits in its counts.
+_TRUNCATION_LINE_RESERVE_CHARS = 260
 
 # Participant names are attacker-controlled: they come from the unauthenticated
 # portal endpoints in `dembrane.api.participant` with no length limit and no
@@ -60,21 +76,47 @@ def sanitize_focus_label(name: Any) -> str:
 
 
 def format_focus_block(focused: Sequence[Mapping[str, Any]]) -> str:
-    """Render the host's focus selection as one delimited, capped data block."""
+    """Render the host's focus selection as one delimited, size-bounded block.
+
+    Conversations are listed in the host's order until the character budget is
+    spent. The remainder is not dropped: the truncation line states the real
+    total, how many are listed here, and the exact tool call that returns the
+    next page. Every instruction in it is one the agent can actually carry out.
+    """
     lines = [FOCUS_BLOCK_OPEN, FOCUS_BLOCK_PREAMBLE]
-    for item in focused[:MAX_FOCUSED_CONVERSATIONS]:
+    # Derived from the constants themselves, so editing the preamble or the
+    # fence cannot silently push the rendered block past the budget.
+    overhead = (
+        len(FOCUS_BLOCK_OPEN)
+        + 1
+        + len(FOCUS_BLOCK_PREAMBLE)
+        + 1
+        + len(FOCUS_BLOCK_CLOSE)
+        + _TRUNCATION_LINE_RESERVE_CHARS
+    )
+    budget = max(0, MAX_FOCUS_BLOCK_CHARS - overhead)
+
+    used = 0
+    listed = 0
+    for item in focused:
         label = sanitize_focus_label(item.get("name"))
         line = f"- id: {item['id']}"
         if label:
             line = f'{line} label: "{label}"'
+        # +1 for the newline this line adds when the block is joined.
+        if used + len(line) + 1 > budget:
+            break
+        used += len(line) + 1
         lines.append(line)
+        listed += 1
 
-    omitted = len(focused) - MAX_FOCUSED_CONVERSATIONS
+    omitted = len(focused) - listed
     if omitted > 0:
         lines.append(
-            f"- (truncated: {omitted} more selected conversation(s) are not listed; "
-            f"the focus hint is capped at {MAX_FOCUSED_CONVERSATIONS}. "
-            "Use your conversation list tool to reach the rest.)"
+            f"- (truncated: {len(focused)} conversations are focused for this chat, "
+            f"{listed} listed above. Call {FOCUS_LIST_TOOL_NAME}(offset={listed}) "
+            f"to read the remaining {omitted}. It returns this chat's focused set, "
+            "not the whole project. Do not guess ids.)"
         )
 
     lines.append(FOCUS_BLOCK_CLOSE)

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -690,11 +690,16 @@ def _list_project_conversations_for_agent(
     *,
     project_id: str,
     limit: int,
+    offset: int = 0,
     conversation_id: Optional[str] = None,
     transcript_query: Optional[str] = None,
     directus_client: Any,
 ) -> dict[str, Any]:
+    # `limit` stays a per-call cap; `offset` is what turns it into a page.
+    # Without it the cap was a ceiling and rows past it were unreachable, which
+    # made any "call the list tool for the rest" guidance untrue.
     normalized_limit = max(1, min(limit, 100))
+    normalized_offset = max(0, offset)
     normalized_conversation_id = _to_non_empty_string(conversation_id)
     normalized_transcript_query = _to_non_empty_string(transcript_query)
 
@@ -726,7 +731,8 @@ def _list_project_conversations_for_agent(
                 {"conversation_id": {"id": {"_eq": normalized_conversation_id}}}
             )
 
-        chunk_limit = min(max(normalized_limit * 25, 25), 250)
+        wanted = normalized_limit + normalized_offset
+        chunk_limit = min(max(wanted * 25, 25), 1000)
         chunk_rows = directus_client.get_items(
             "conversation_chunk",
             {
@@ -765,7 +771,7 @@ def _list_project_conversations_for_agent(
                 if conversation_identifier is None:
                     continue
                 is_new_conversation = conversation_identifier not in conversations_by_id
-                if is_new_conversation and len(conversations_by_id) >= normalized_limit:
+                if is_new_conversation and len(conversations_by_id) >= wanted:
                     continue
                 existing_matches = conversations_by_id.get(conversation_identifier, {}).get(
                     "matches"
@@ -787,10 +793,13 @@ def _list_project_conversations_for_agent(
                     continue
                 conversations_by_id[conversation_identifier] = card
 
-        conversations = list(conversations_by_id.values())
+        matched = list(conversations_by_id.values())
+        conversations = matched[normalized_offset : normalized_offset + normalized_limit]
         return {
             "project_id": project_id,
             "count": len(conversations),
+            "offset": normalized_offset,
+            "has_more": len(matched) > normalized_offset + len(conversations),
             "conversations": conversations,
         }
 
@@ -817,27 +826,34 @@ def _list_project_conversations_for_agent(
                     "updated_at",
                 ],
                 "sort": "-updated_at",
-                "limit": normalized_limit,
+                # One extra row is a cheap, exact has_more: no second COUNT
+                # query, and the agent can stop paging without guessing.
+                "limit": normalized_limit + 1,
+                "offset": normalized_offset,
             }
         },
     )
 
+    normalized_rows = rows if isinstance(rows, list) else []
+    has_more = len(normalized_rows) > normalized_limit
+
     conversation_cards: list[dict[str, Any]] = []
-    if isinstance(rows, list):
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
-            card = _to_agent_conversation_card(
-                row,
-                project_id=project_id,
-                fallback_project_id=project_id,
-            )
-            if card is not None:
-                conversation_cards.append(card)
+    for row in normalized_rows[:normalized_limit]:
+        if not isinstance(row, dict):
+            continue
+        card = _to_agent_conversation_card(
+            row,
+            project_id=project_id,
+            fallback_project_id=project_id,
+        )
+        if card is not None:
+            conversation_cards.append(card)
 
     return {
         "project_id": project_id,
         "count": len(conversation_cards),
+        "offset": normalized_offset,
+        "has_more": has_more,
         "conversations": conversation_cards,
     }
 
@@ -1335,6 +1351,7 @@ async def list_project_conversations(
     project_id: str,
     auth: DependencyDirectusSession,
     limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     conversation_id: Optional[str] = Query(default=None),
     transcript_query: Optional[str] = Query(default=None),
 ) -> dict[str, Any]:
@@ -1351,10 +1368,57 @@ async def list_project_conversations(
         _list_project_conversations_for_agent,
         project_id=project_id,
         limit=limit,
+        offset=offset,
         conversation_id=conversation_id,
         transcript_query=transcript_query,
         directus_client=directus,
     )
+
+
+@AgenticRouter.get("/projects/{project_id}/focused-conversations")
+async def list_focused_conversations_for_agent(
+    project_id: str,
+    auth: DependencyDirectusSession,
+    project_chat_id: str = Query(...),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> dict[str, Any]:
+    """The conversations the host focused THIS chat on, paginated.
+
+    The focus block in the prompt is size-bounded, so on a large selection it
+    lists a head and points here for the rest. The project-wide conversation
+    list cannot answer this: it returns everything in the project and has no
+    idea which rows the host picked.
+
+    Authorization is unchanged from every other agent read: the agent token,
+    project access, and then the chat/project binding, which is enforced inside
+    _get_focused_conversations rather than around it so this route cannot get
+    an unguarded read.
+    """
+    _require_agent_token(auth)
+    await _assert_project_access(project_id, auth)
+    await run_in_thread_pool(
+        _assert_chat_belongs_to_project,
+        project_chat_id,
+        project_id,
+    )
+
+    focused = await run_in_thread_pool(
+        _get_focused_conversations,
+        project_chat_id,
+        project_id=project_id,
+    )
+
+    page = focused[offset : offset + limit]
+    return {
+        "project_id": project_id,
+        "project_chat_id": project_chat_id,
+        "total": len(focused),
+        "count": len(page),
+        "offset": offset,
+        "has_more": len(focused) > offset + len(page),
+        "conversations": page,
+    }
 
 
 @AgenticRouter.get("/projects/{project_id}/monitor")

--- a/echo/server/dembrane/api/chat.py
+++ b/echo/server/dembrane/api/chat.py
@@ -46,9 +46,12 @@ suggestions_rate_limiter = create_rate_limiter(
 logger = logging.getLogger("dembrane.chat")
 
 settings = get_settings()
-ENABLE_CHAT_SELECT_ALL = settings.feature_flags.enable_chat_select_all
 
 CONVERSATION_LOCKED_ERROR = "conversation_locked"
+
+# Upper bound on one add-context batch, for both select_all and an explicit
+# conversation_ids pick. Matches the ceiling select_all has always fetched at.
+MAX_ADD_CONTEXT_CONVERSATIONS = 1000
 
 
 async def _resolve_workspace_tier(project_id: str) -> Optional[str]:
@@ -241,7 +244,6 @@ async def get_chat_context(chat_id: str, auth: DependencyDirectusSession) -> Cha
     used_conversation_links = chat.get("used_conversations") or []
     logger.debug("Used conversation links: %s", used_conversation_links)
 
-
     # Get chat mode (may be None if not yet selected)
     chat_mode = chat.get("chat_mode")
 
@@ -315,6 +317,10 @@ async def get_chat_context(chat_id: str, auth: DependencyDirectusSession) -> Cha
 
 class ChatAddContextSchema(BaseModel):
     conversation_id: Optional[str] = None
+    # An explicit pick, e.g. the conversations chosen on the Ask screen before
+    # the chat existed. Attached in one request so the token budget is walked
+    # once, server-side, instead of once per parallel request.
+    conversation_ids: Optional[List[str]] = None
     select_all: Optional[bool] = None
     project_id: Optional[str] = None
     tag_ids: Optional[List[str]] = None
@@ -327,7 +333,8 @@ class SelectAllConversationResult(BaseModel):
     participant_name: str
     success: bool
     reason: Optional[str] = (
-        None  # "added", "already_in_context", "context_limit_reached", "empty", "too_long"
+        None  # "added", "already_in_context", "context_limit_reached", "empty",
+        # "too_long", "locked", "not_found", "error"
     )
 
 
@@ -338,130 +345,89 @@ class AddContextResponseSchema(BaseModel):
     context_limit_reached: Optional[bool] = None
 
 
-@ChatRouter.post("/{chat_id}/add-context", response_model=AddContextResponseSchema)
-async def add_chat_context(
+async def _attach_conversations_within_budget(
+    *,
     chat_id: str,
-    body: ChatAddContextSchema,
-    auth: DependencyDirectusSession,
+    chat: dict,
+    auth: DirectusSession,
+    project_id: str,
+    candidates: List[dict],
+    extra_skipped: Optional[List[SelectAllConversationResult]] = None,
 ) -> AddContextResponseSchema:
-    chat = await raise_if_chat_not_found_or_not_authorized(
-        chat_id,
-        auth,
-        include_used_conversations=True,
-    )
-    _raise_if_project_mismatch(chat, body.project_id)
+    """Attach as many of `candidates` as this chat can take, in order.
+
+    Shared by every batch entry point (filter-driven select_all and the
+    explicit conversation_ids pick) so the token budget is walked in exactly
+    one place: each conversation's cost accumulates, and once the budget runs
+    out the rest are reported as skipped rather than failing the whole batch.
+    That accumulation is the reason batches must not be split into parallel
+    single-conversation requests, which each read the same starting context.
+
+    Agentic chats preload nothing (the attached rows are only a focus hint the
+    agent reads on demand), so they skip the budget entirely. Same bypass the
+    single-conversation path uses.
+    """
+    from dembrane.free_tier import conversation_is_locked
 
     chat_svc = chat_service
-    conversation_svc = conversation_service
 
-    project_id: Optional[str] = body.project_id or _chat_project_id(chat)
+    enforce_budget = chat.get("chat_mode") != "agentic"
 
-    options_provided = sum(
-        [
-            body.conversation_id is not None,
-            body.select_all is not None,
-        ]
-    )
+    # Conversations already attached to this chat.
+    existing_ids = {
+        (link.get("conversation_id") or {}).get("id")
+        for link in (chat.get("used_conversations") or [])
+    }
 
-    if options_provided == 0:
-        raise HTTPException(
-            status_code=400,
-            detail="conversation_id or select_all is required",
-        )
-
-    if options_provided > 1:
-        raise HTTPException(
-            status_code=400,
-            detail="Only one of conversation_id or select_all can be provided",
-        )
-
-    # Handle select_all
-    if body.select_all is True:
-        if not ENABLE_CHAT_SELECT_ALL:
-            raise HTTPException(
-                status_code=403,
-                detail="Chat select all feature is not enabled",
-            )
-
-        if not project_id:
-            raise HTTPException(
-                status_code=400,
-                detail="project_id is required when select_all is True",
-            )
-
-        try:
-            logger.info(
-                f"Select All: Fetching conversations - "
-                f"project_id={project_id}, tags={body.tag_ids}, verified={body.verified_only}, search='{body.search_text}'"
-            )
-
-            all_conversations = await run_in_thread_pool(
-                conversation_svc.list_by_project_with_filters,
-                project_id=project_id,
-                tag_ids=body.tag_ids,
-                verified_only=body.verified_only or False,
-                search_text=body.search_text,
-                sort="-created_at",
-                limit=1000,
-            )
-
-            logger.info(f"Select All: Fetched {len(all_conversations)} conversations")
-        except Exception as e:
-            logger.error(f"Failed to fetch conversations with filters: {e}")
-            raise
-
-        # Get existing conversation IDs in the chat
-        existing_ids = {
-            (link.get("conversation_id") or {}).get("id")
-            for link in (chat.get("used_conversations") or [])
-        }
-
-        # Get current chat context to track token usage
+    current_token_usage = 0.0
+    if enforce_budget:
         chat_context = await get_chat_context(chat_id, auth)
         current_token_usage = sum(
             conversation_entry.token_usage for conversation_entry in chat_context.conversations
         )
 
-        workspace_tier = await _resolve_workspace_tier(project_id)
-        from dembrane.free_tier import conversation_is_locked
+    workspace_tier = await _resolve_workspace_tier(project_id)
 
-        # One grouped aggregate instead of fetching every chunk transcript.
-        # Guard the empty case: an empty _in has historically degenerated into
-        # a full-table grouped scan in Directus.
-        candidate_ids = [c["id"] for c in all_conversations if c.get("id")]
-        has_content_ids: set[str] = set()
-        if candidate_ids:
-            content_rows = await async_directus.get_items(
-                "conversation_chunk",
-                {
-                    "query": {
-                        "filter": {
-                            "conversation_id": {"_in": candidate_ids},
-                            "transcript": {"_nempty": True},
-                        },
-                        "aggregate": {"count": ["id"]},
-                        "groupBy": ["conversation_id"],
-                        # Directus caps grouped rows at its default limit (100).
-                        "limit": -1,
-                    }
-                },
+    # One grouped aggregate instead of fetching every chunk transcript.
+    # Guard the empty case: an empty _in has historically degenerated into
+    # a full-table grouped scan in Directus.
+    candidate_ids = [c["id"] for c in candidates if c.get("id")]
+    has_content_ids: set[str] = set()
+    if candidate_ids:
+        content_rows = await async_directus.get_items(
+            "conversation_chunk",
+            {
+                "query": {
+                    "filter": {
+                        "conversation_id": {"_in": candidate_ids},
+                        "transcript": {"_nempty": True},
+                    },
+                    "aggregate": {"count": ["id"]},
+                    "groupBy": ["conversation_id"],
+                    # Directus caps grouped rows at its default limit (100).
+                    "limit": -1,
+                }
+            },
+        )
+        # A non-list envelope is a Directus error, not "no content": surface
+        # it instead of silently marking every conversation empty.
+        if not isinstance(content_rows, list):
+            raise HTTPException(
+                status_code=503,
+                detail="Could not check conversation content. Please try again.",
             )
-            # A non-list envelope is a Directus error, not "no content": surface
-            # it instead of silently marking every conversation empty.
-            if not isinstance(content_rows, list):
-                raise HTTPException(
-                    status_code=503,
-                    detail="Could not check conversation content. Please try again.",
-                )
-            for row in content_rows:
-                cid = row.get("conversation_id")
-                if cid and int((row.get("count") or {}).get("id") or 0) > 0:
-                    has_content_ids.add(cid)
+        for row in content_rows:
+            cid = row.get("conversation_id")
+            if cid and int((row.get("count") or {}).get("id") or 0) > 0:
+                has_content_ids.add(cid)
 
-        # Bulk token counts for candidates that could still be added.
+    # Bulk token counts for candidates that could still be added. Agentic
+    # never reads these, so don't pay for them.
+    token_counts_by_id: Dict[str, int] = {}
+    if enforce_budget:
         need_tokens = [
             c["id"]
-            for c in all_conversations
+            for c in candidates
             if c.get("id")
             and c["id"] not in existing_ids
             and c["id"] in has_content_ids
@@ -471,55 +437,54 @@ async def add_chat_context(
             need_tokens, auth, project_id=project_id
         )
 
-        added: List[SelectAllConversationResult] = []
-        skipped: List[SelectAllConversationResult] = []
-        context_limit_reached = False
-        to_attach: List[str] = []
+    added: List[SelectAllConversationResult] = []
+    skipped: List[SelectAllConversationResult] = list(extra_skipped or [])
+    context_limit_reached = False
+    to_attach: List[str] = []
 
-        for conversation in all_conversations:
-            conv_id = conversation.get("id")
-            participant_name = str(conversation.get("participant_name") or "Unknown")
+    for conversation in candidates:
+        conv_id = conversation.get("id")
+        participant_name = str(conversation.get("participant_name") or "Unknown")
 
-            if not conv_id:
-                continue
+        if not conv_id:
+            continue
 
-            if conversation_is_locked(conversation, workspace_tier):
-                skipped.append(
-                    SelectAllConversationResult(
-                        conversation_id=conv_id,
-                        participant_name=participant_name,
-                        success=False,
-                        reason="locked",
-                    )
+        if conversation_is_locked(conversation, workspace_tier):
+            skipped.append(
+                SelectAllConversationResult(
+                    conversation_id=conv_id,
+                    participant_name=participant_name,
+                    success=False,
+                    reason="locked",
                 )
-                continue
+            )
+            continue
 
-            # Skip if already in context
-            if conv_id in existing_ids:
-                skipped.append(
-                    SelectAllConversationResult(
-                        conversation_id=conv_id,
-                        participant_name=participant_name,
-                        success=False,
-                        reason="already_in_context",
-                    )
+        # Skip if already in context
+        if conv_id in existing_ids:
+            skipped.append(
+                SelectAllConversationResult(
+                    conversation_id=conv_id,
+                    participant_name=participant_name,
+                    success=False,
+                    reason="already_in_context",
                 )
-                continue
+            )
+            continue
 
-            # Check if conversation has content
-            has_content = conv_id in has_content_ids
-
-            if not has_content:
-                skipped.append(
-                    SelectAllConversationResult(
-                        conversation_id=conv_id,
-                        participant_name=participant_name,
-                        success=False,
-                        reason="empty",
-                    )
+        # Check if conversation has content
+        if conv_id not in has_content_ids:
+            skipped.append(
+                SelectAllConversationResult(
+                    conversation_id=conv_id,
+                    participant_name=participant_name,
+                    success=False,
+                    reason="empty",
                 )
-                continue
+            )
+            continue
 
+        if enforce_budget:
             # If context limit already reached, skip remaining conversations
             if context_limit_reached:
                 skipped.append(
@@ -544,7 +509,6 @@ async def add_chat_context(
                 )
                 continue
 
-            # Get token count for this conversation
             token_count = token_counts_by_id.get(conv_id, 0)
 
             # Check if single conversation is too long
@@ -573,51 +537,189 @@ async def add_chat_context(
                 )
                 continue
 
-            # Update tracking
             current_token_usage += conversation_usage
-            existing_ids.add(conv_id)
-            to_attach.append(conv_id)
 
-            added.append(
+        existing_ids.add(conv_id)
+        to_attach.append(conv_id)
+
+        added.append(
+            SelectAllConversationResult(
+                conversation_id=conv_id,
+                participant_name=participant_name,
+                success=True,
+                reason="added",
+            )
+        )
+
+    # Single bulk attach for everything accepted above.
+    if to_attach:
+        try:
+            await run_in_thread_pool(chat_svc.attach_conversations, chat_id, to_attach)
+        except Exception as exc:
+            logger.warning("Bulk attach failed for chat %s: %s", chat_id, exc)
+            added_snapshot = list(added)
+            attach_failed = set(to_attach)
+            added = [a for a in added if a.conversation_id not in attach_failed]
+            skipped.extend(
                 SelectAllConversationResult(
-                    conversation_id=conv_id,
-                    participant_name=participant_name,
-                    success=True,
-                    reason="added",
+                    conversation_id=cid,
+                    participant_name=next(
+                        (a.participant_name for a in added_snapshot if a.conversation_id == cid),
+                        "Unknown",
+                    ),
+                    success=False,
+                    reason="error",
                 )
+                for cid in to_attach
             )
 
-        # Single bulk attach for everything accepted above.
-        if to_attach:
-            try:
-                await run_in_thread_pool(chat_svc.attach_conversations, chat_id, to_attach)
-            except Exception as exc:
-                logger.warning("Bulk attach failed for chat %s: %s", chat_id, exc)
-                added_snapshot = list(added)
-                attach_failed = set(to_attach)
-                added = [a for a in added if a.conversation_id not in attach_failed]
-                skipped.extend(
-                    SelectAllConversationResult(
-                        conversation_id=cid,
-                        participant_name=next(
-                            (
-                                a.participant_name
-                                for a in added_snapshot
-                                if a.conversation_id == cid
-                            ),
-                            "Unknown",
-                        ),
-                        success=False,
-                        reason="error",
-                    )
-                    for cid in to_attach
-                )
+    return AddContextResponseSchema(
+        added=added,
+        skipped=skipped,
+        total_processed=len(candidates) + len(extra_skipped or []),
+        context_limit_reached=context_limit_reached,
+    )
 
-        return AddContextResponseSchema(
-            added=added,
-            skipped=skipped,
-            total_processed=len(all_conversations),
-            context_limit_reached=context_limit_reached,
+
+@ChatRouter.post("/{chat_id}/add-context", response_model=AddContextResponseSchema)
+async def add_chat_context(
+    chat_id: str,
+    body: ChatAddContextSchema,
+    auth: DependencyDirectusSession,
+) -> AddContextResponseSchema:
+    chat = await raise_if_chat_not_found_or_not_authorized(
+        chat_id,
+        auth,
+        include_used_conversations=True,
+    )
+    _raise_if_project_mismatch(chat, body.project_id)
+
+    chat_svc = chat_service
+    conversation_svc = conversation_service
+
+    project_id: Optional[str] = body.project_id or _chat_project_id(chat)
+
+    options_provided = sum(
+        [
+            body.conversation_id is not None,
+            body.conversation_ids is not None,
+            body.select_all is not None,
+        ]
+    )
+
+    if options_provided == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="One of conversation_id, conversation_ids or select_all is required",
+        )
+
+    if options_provided > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Only one of conversation_id, conversation_ids or select_all can be provided",
+        )
+
+    # Handle select_all
+    if body.select_all is True:
+        if not project_id:
+            raise HTTPException(
+                status_code=400,
+                detail="project_id is required when select_all is True",
+            )
+
+        try:
+            logger.info(
+                f"Select All: Fetching conversations - "
+                f"project_id={project_id}, tags={body.tag_ids}, verified={body.verified_only}, search='{body.search_text}'"
+            )
+
+            all_conversations = await run_in_thread_pool(
+                conversation_svc.list_by_project_with_filters,
+                project_id=project_id,
+                tag_ids=body.tag_ids,
+                verified_only=body.verified_only or False,
+                search_text=body.search_text,
+                sort="-created_at",
+                limit=MAX_ADD_CONTEXT_CONVERSATIONS,
+            )
+
+            logger.info(f"Select All: Fetched {len(all_conversations)} conversations")
+        except Exception as e:
+            logger.error(f"Failed to fetch conversations with filters: {e}")
+            raise
+
+        return await _attach_conversations_within_budget(
+            chat_id=chat_id,
+            chat=chat,
+            auth=auth,
+            project_id=project_id,
+            candidates=all_conversations,
+        )
+
+    # An explicit pick, e.g. the conversations chosen on the Ask screen before
+    # the chat existed. One request for the whole batch, so the token budget is
+    # walked once and accumulates, instead of N parallel requests that each
+    # read the same empty context and all pass.
+    if body.conversation_ids is not None:
+        if not project_id:
+            raise HTTPException(
+                status_code=400,
+                detail="project_id is required when conversation_ids is provided",
+            )
+
+        requested_ids: List[str] = []
+        for requested_id in body.conversation_ids:
+            if requested_id and requested_id not in requested_ids:
+                requested_ids.append(requested_id)
+
+        if not requested_ids:
+            raise HTTPException(
+                status_code=400,
+                detail="conversation_ids cannot be empty",
+            )
+
+        if len(requested_ids) > MAX_ADD_CONTEXT_CONVERSATIONS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Cannot add more than {MAX_ADD_CONTEXT_CONVERSATIONS} conversations at once",
+            )
+
+        found = await run_in_thread_pool(
+            conversation_svc.list_by_project_with_filters,
+            project_id=project_id,
+            conversation_ids=requested_ids,
+            limit=len(requested_ids),
+        )
+        # The lookup is scoped to the chat's project, so anything missing here
+        # belongs to another project or no longer exists. Report it instead of
+        # dropping it silently. Order follows the host's pick, which is the
+        # order the budget is then spent in.
+        found_by_id = {
+            conversation["id"]: conversation for conversation in found if conversation.get("id")
+        }
+        candidates = [
+            found_by_id[requested_id]
+            for requested_id in requested_ids
+            if requested_id in found_by_id
+        ]
+        not_found = [
+            SelectAllConversationResult(
+                conversation_id=requested_id,
+                participant_name="Unknown",
+                success=False,
+                reason="not_found",
+            )
+            for requested_id in requested_ids
+            if requested_id not in found_by_id
+        ]
+
+        return await _attach_conversations_within_budget(
+            chat_id=chat_id,
+            chat=chat,
+            auth=auth,
+            project_id=project_id,
+            candidates=candidates,
+            extra_skipped=not_found,
         )
 
     if body.conversation_id is not None:
@@ -1093,15 +1195,14 @@ async def post_chat(
         formatted_messages = await build_formatted_messages(chat_context.conversation_id_list)
 
         # Resolve a distinct_id (email) so this server event merges with the
-        # user's frontend person. This is the prod chat path (agentic is gated
-        # off), so the server-side response/error events live here, not only in
-        # the agentic worker.
+        # user's frontend person. This endpoint serves every non-agentic chat
+        # (overview, deep_dive, and chats that predate chat_mode), so their
+        # server-side response/error events live here. Agentic runs emit their
+        # own from the agentic worker.
         from dembrane.app_user import resolve_app_user
 
         _chat_user = await resolve_app_user(auth.user_id)
-        chat_distinct_id = (
-            (_chat_user or {}).get("email") or ""
-        ).lower() or auth.user_id
+        chat_distinct_id = ((_chat_user or {}).get("email") or "").lower() or auth.user_id
 
         async def stream_response_async(
             formatted: List[Dict[str, str]],

--- a/echo/server/dembrane/api/chat.py
+++ b/echo/server/dembrane/api/chat.py
@@ -641,21 +641,27 @@ async def add_chat_context(
         if body.conversation_id in existing_ids:
             raise HTTPException(status_code=400, detail="Conversation already in the chat")
 
-        token_count = await get_conversation_token_count(body.conversation_id, auth)
-        if token_count > MAX_CHAT_CONTEXT_LENGTH:
-            raise HTTPException(status_code=400, detail="Conversation is too long")
+        # The transcript token budget only makes sense for deep_dive, which
+        # preloads full transcripts into the context window. Agentic preloads
+        # nothing: the attached rows are just a focus hint the agent reads on
+        # demand, so gating them against MAX_CHAT_CONTEXT_LENGTH would reject
+        # perfectly fine selections for no reason.
+        if chat.get("chat_mode") != "agentic":
+            token_count = await get_conversation_token_count(body.conversation_id, auth)
+            if token_count > MAX_CHAT_CONTEXT_LENGTH:
+                raise HTTPException(status_code=400, detail="Conversation is too long")
 
-        chat_context = await get_chat_context(chat_id, auth)
-        chat_context_token_usage = sum(
-            conversation_entry.token_usage for conversation_entry in chat_context.conversations
-        )
-
-        conversation_to_add_usage = token_count / MAX_CHAT_CONTEXT_LENGTH
-        if chat_context_token_usage + conversation_to_add_usage > 1:
-            raise HTTPException(
-                status_code=400,
-                detail="Chat context is too long. Remove other conversations to proceed.",
+            chat_context = await get_chat_context(chat_id, auth)
+            chat_context_token_usage = sum(
+                conversation_entry.token_usage for conversation_entry in chat_context.conversations
             )
+
+            conversation_to_add_usage = token_count / MAX_CHAT_CONTEXT_LENGTH
+            if chat_context_token_usage + conversation_to_add_usage > 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Chat context is too long. Remove other conversations to proceed.",
+                )
 
         await run_in_thread_pool(
             chat_svc.attach_conversations,

--- a/echo/server/dembrane/service/conversation.py
+++ b/echo/server/dembrane/service/conversation.py
@@ -69,9 +69,7 @@ class ConversationService:
             with self._client_context() as client:
                 client.update_item("conversation", conversation_id, {"token_count": None})
         except Exception:
-            logger.warning(
-                "failed to clear token_count for %s", conversation_id, exc_info=True
-            )
+            logger.warning("failed to clear token_count for %s", conversation_id, exc_info=True)
         # Also drop the Redis layer so readers never see the pre-change count.
         try:
             from dembrane.cache_utils import cache_delete
@@ -79,9 +77,7 @@ class ConversationService:
 
             run_async_in_new_loop(cache_delete(f"tokcount:{conversation_id}"))
         except Exception:
-            logger.warning(
-                "failed to clear tokcount cache for %s", conversation_id, exc_info=True
-            )
+            logger.warning("failed to clear tokcount cache for %s", conversation_id, exc_info=True)
 
     @property
     def file_service(self) -> "FileService":
@@ -174,6 +170,7 @@ class ConversationService:
         search_text: Optional[str] = None,
         sort: str = "-created_at",
         limit: int = 1000,
+        conversation_ids: Optional[List[str]] = None,
     ) -> List[dict]:
         """
         List conversations for a project with advanced filtering options.
@@ -192,15 +189,26 @@ class ConversationService:
             search_text: Optional search text (uses Directus search)
             sort: Sort order (default: most recent first "-created_at")
             limit: Maximum number of conversations to return
+            conversation_ids: Optional explicit id list. Combined with the
+                project filter, so ids belonging to another project (or
+                already deleted) simply do not come back.
 
         Returns:
             List of conversation dicts with minimal fields for efficiency
         """
+        # An empty _in has historically degenerated into a full-table scan in
+        # Directus, so treat "asked for nothing" as "nothing".
+        if conversation_ids is not None and len(conversation_ids) == 0:
+            return []
+
         # Build filter query
         filter_query: dict[str, Any] = {
             "project_id": {"_eq": project_id},
             "deleted_at": {"_null": True},
         }
+
+        if conversation_ids:
+            filter_query["id"] = {"_in": conversation_ids}
 
         if tag_ids and len(tag_ids) > 0:
             filter_query["tags"] = {

--- a/echo/server/dembrane/settings.py
+++ b/echo/server/dembrane/settings.py
@@ -250,13 +250,6 @@ class FeatureFlagSettings(BaseSettings):
             "DISABLE_CHAT_TITLE_GENERATION", "FEATURE_FLAGS__DISABLE_CHAT_TITLE_GENERATION"
         ),
     )
-    enable_chat_select_all: bool = Field(
-        default=False,
-        alias="ENABLE_CHAT_SELECT_ALL",
-        validation_alias=AliasChoices(
-            "ENABLE_CHAT_SELECT_ALL", "FEATURE_FLAGS__ENABLE_CHAT_SELECT_ALL"
-        ),
-    )
     serve_api_docs: bool = Field(
         default=False,
         alias="SERVE_API_DOCS",

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -5,6 +5,7 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any, AsyncIterator
 from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient, ASGITransport
@@ -19,8 +20,9 @@ from dembrane.agentic_focus import (
     FOCUS_BLOCK_OPEN,
     FOCUS_BLOCK_CLOSE,
     FOCUS_BLOCK_PREAMBLE,
+    FOCUS_LIST_TOOL_NAME,
+    MAX_FOCUS_BLOCK_CHARS,
     MAX_FOCUS_LABEL_LENGTH,
-    MAX_FOCUSED_CONVERSATIONS,
     strip_focus_blocks,
 )
 from dembrane.service.agentic import AgenticRunService
@@ -655,17 +657,45 @@ def test_focus_block_clamps_long_participant_name() -> None:
     assert clamped in format_focus_block([{"id": "conv-1", "name": "A" * 500}])
 
 
-def test_focus_block_caps_conversation_count() -> None:
+def test_focus_block_respects_char_budget() -> None:
+    """The block is re-injected every turn, so its cost is its rendered size,
+    not its item count. Bound the size and page the rest."""
     from dembrane.agentic_focus import format_focus_block
 
-    focused = [{"id": f"conv-{index}", "name": f"P{index}"} for index in range(200)]
+    focused = [{"id": f"conv-{index}", "name": f"P{index}"} for index in range(500)]
     block = format_focus_block(focused)
 
-    assert block.count("- id: conv-") == MAX_FOCUSED_CONVERSATIONS
-    assert f"- id: conv-{MAX_FOCUSED_CONVERSATIONS}" not in block
-    assert f"truncated: {200 - MAX_FOCUSED_CONVERSATIONS} more selected" in block
-    # The old uncapped block measured ~11k chars on every turn.
-    assert len(block) < 6000
+    assert len(block) <= MAX_FOCUS_BLOCK_CHARS
+    listed = block.count("- id: conv-")
+    assert 0 < listed < 500
+
+
+def test_focus_block_truncation_line_states_the_real_total_and_a_callable_next_step() -> None:
+    """Every number in the truncation line has to be true, and the instruction
+    has to be one the agent can actually follow."""
+    from dembrane.agentic_focus import format_focus_block
+
+    focused = [{"id": f"conv-{index}", "name": f"P{index}"} for index in range(500)]
+    block = format_focus_block(focused)
+    listed = block.count("- id: conv-")
+
+    assert "truncated: 500 conversations are focused" in block
+    assert f"{listed} listed above" in block
+    # Names the tool and the exact offset to resume from, not a vague "use your
+    # conversation list tool" (which lists the project, not the selection).
+    assert f"{FOCUS_LIST_TOOL_NAME}(offset={listed})" in block
+    assert f"remaining {500 - listed}" in block
+    assert "conversation list tool" not in block
+
+
+def test_focus_block_small_selection_is_listed_in_full() -> None:
+    from dembrane.agentic_focus import format_focus_block
+
+    focused = [{"id": f"conv-{index}", "name": f"P{index}"} for index in range(5)]
+    block = format_focus_block(focused)
+
+    assert block.count("- id: conv-") == 5
+    assert "truncated" not in block
 
 
 def test_get_focused_conversations_maps_links(monkeypatch) -> None:
@@ -754,6 +784,159 @@ def test_get_focused_conversations_without_a_chat_is_empty(monkeypatch) -> None:
     monkeypatch.setattr(agentic_api, "chat_service", _FakeChatService())
 
     assert agentic_api._get_focused_conversations(None, project_id="project-1") == []
+
+
+def _agent_session() -> DirectusSession:
+    return DirectusSession(user_id="agent", is_admin=True, access_token="token-1")
+
+
+def _focus_chat(count: int, project_id: str = "project-1") -> dict[str, Any]:
+    return {
+        "id": "chat-1",
+        "project_id": {"id": project_id},
+        "used_conversations": [
+            {
+                "id": index,
+                "conversation_id": {"id": f"conv-{index}", "participant_name": f"P{index}"},
+            }
+            for index in range(count)
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_focused_conversations_for_agent_pages_the_selection(monkeypatch) -> None:
+    """This is what makes the truncation line true: the focused set is
+    reachable a page at a time, and has_more says when to stop."""
+    monkeypatch.setattr(
+        agentic_api, "chat_service", _FakeChatService(chats={"chat-1": _focus_chat(25)})
+    )
+    monkeypatch.setattr(agentic_api, "_require_agent_token", lambda _auth: None)
+    monkeypatch.setattr(agentic_api, "_assert_project_access", AsyncMock(return_value=None))
+
+    first = await agentic_api.list_focused_conversations_for_agent(
+        project_id="project-1",
+        auth=_agent_session(),
+        project_chat_id="chat-1",
+        limit=10,
+        offset=0,
+    )
+    assert first["total"] == 25
+    assert first["count"] == 10
+    assert first["has_more"] is True
+    assert [c["id"] for c in first["conversations"]] == [f"conv-{i}" for i in range(10)]
+
+    last = await agentic_api.list_focused_conversations_for_agent(
+        project_id="project-1",
+        auth=_agent_session(),
+        project_chat_id="chat-1",
+        limit=10,
+        offset=20,
+    )
+    assert last["count"] == 5
+    assert last["has_more"] is False
+    assert [c["id"] for c in last["conversations"]] == [f"conv-{i}" for i in range(20, 25)]
+
+
+@pytest.mark.asyncio
+async def test_list_focused_conversations_for_agent_rejects_a_foreign_chat(monkeypatch) -> None:
+    """Same binding #906 put on every other focus read: a chat from another
+    project must not become readable through this route."""
+    monkeypatch.setattr(
+        agentic_api,
+        "chat_service",
+        _FakeChatService(chats={"chat-1": _focus_chat(3, project_id="project-2")}),
+    )
+    monkeypatch.setattr(agentic_api, "_require_agent_token", lambda _auth: None)
+    monkeypatch.setattr(agentic_api, "_assert_project_access", AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await agentic_api.list_focused_conversations_for_agent(
+            project_id="project-1",
+            auth=_agent_session(),
+            project_chat_id="chat-1",
+            limit=10,
+            offset=0,
+        )
+
+    assert excinfo.value.status_code == 400
+
+
+class _RecordingDirectus:
+    """Captures the query so the offset/limit actually sent can be asserted."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.queries: list[dict[str, Any]] = []
+
+    def get_items(self, collection: str, payload: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: ARG002
+        query = payload["query"]
+        self.queries.append(query)
+        offset = int(query.get("offset") or 0)
+        limit = int(query.get("limit") or len(self.rows))
+        return self.rows[offset : offset + limit]
+
+
+def _conversation_rows(count: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": f"conv-{index}",
+            "project_id": "project-1",
+            "participant_name": f"P{index}",
+            "summary": None,
+            "is_finished": True,
+            "is_all_chunks_transcribed": True,
+            "created_at": "2026-07-01T00:00:00Z",
+            "updated_at": "2026-07-01T00:00:00Z",
+        }
+        for index in range(count)
+    ]
+
+
+def test_list_project_conversations_for_agent_pages_with_offset() -> None:
+    """Without offset the per-call cap was a ceiling: rows past it could not be
+    reached at all, which is what made "call the list tool for the rest" false."""
+    directus_client = _RecordingDirectus(_conversation_rows(250))
+
+    first = agentic_api._list_project_conversations_for_agent(
+        project_id="project-1",
+        limit=100,
+        offset=0,
+        directus_client=directus_client,
+    )
+    assert [c["conversation_id"] for c in first["conversations"]] == [
+        f"conv-{i}" for i in range(100)
+    ]
+    assert first["offset"] == 0
+    assert first["has_more"] is True
+
+    third = agentic_api._list_project_conversations_for_agent(
+        project_id="project-1",
+        limit=100,
+        offset=200,
+        directus_client=directus_client,
+    )
+    assert [c["conversation_id"] for c in third["conversations"]] == [
+        f"conv-{i}" for i in range(200, 250)
+    ]
+    assert third["offset"] == 200
+    assert third["has_more"] is False
+
+
+def test_list_project_conversations_for_agent_still_caps_each_call() -> None:
+    """Offset makes it pageable; it does not lift the per-call ceiling."""
+    directus_client = _RecordingDirectus(_conversation_rows(500))
+
+    result = agentic_api._list_project_conversations_for_agent(
+        project_id="project-1",
+        limit=5000,
+        offset=0,
+        directus_client=directus_client,
+    )
+
+    assert len(result["conversations"]) == 100
+    # +1 is the has_more probe row, not a wider page.
+    assert directus_client.queries[-1]["limit"] == 101
 
 
 def test_assert_chat_belongs_to_project_fails_closed_when_unreadable(

--- a/echo/server/tests/api/test_chat_add_context_mode_gate.py
+++ b/echo/server/tests/api/test_chat_add_context_mode_gate.py
@@ -1,8 +1,18 @@
 """The add-context token budget is correct for deep_dive (which preloads full
 transcripts into the prompt) but wrong for agentic (which preloads nothing and
 only uses the attached rows as a focus hint). Agentic must bypass the
-MAX_CHAT_CONTEXT_LENGTH gate; deep_dive must keep it exactly as before."""
+MAX_CHAT_CONTEXT_LENGTH gate; deep_dive must keep it exactly as before.
 
+chat_mode=None is the case the product actually produces: /v2/bff/chats creates
+a chat with no mode, so anything that attaches before initialize-mode runs sees
+NULL. It must be treated as deep_dive (gated), never as agentic.
+
+The batch path (conversation_ids) walks one running budget server-side and adds
+as much as fits, so the same rules apply to it and it reports a reason per
+conversation instead of failing the whole batch.
+"""
+
+from typing import Optional
 from unittest.mock import AsyncMock
 
 import pytest
@@ -37,7 +47,7 @@ async def _fake_run_in_thread_pool(func, *args, **kwargs):  # noqa: ANN001, ANN0
     return func(*args, **kwargs)
 
 
-def _chat_row(chat_mode: str) -> dict:
+def _chat_row(chat_mode: Optional[str]) -> dict:
     return {
         "id": "chat-1",
         "chat_mode": chat_mode,
@@ -116,3 +126,283 @@ async def test_add_context_agentic_skips_token_budget(monkeypatch) -> None:
     token_count_mock.assert_not_awaited()
     get_chat_context_mock.assert_not_awaited()
     assert fake_chat_service.attach_calls == [("chat-1", ["conv-1"])]
+
+
+class _FakeConversationServiceWithList(_FakeConversationService):
+    """Adds the id-scoped lookup the conversation_ids path uses."""
+
+    def __init__(self, conversations: list[dict]) -> None:
+        self.conversations = conversations
+        self.list_calls: list[dict] = []
+
+    def list_by_project_with_filters(self, **kwargs):  # noqa: ANN003, ANN201
+        self.list_calls.append(kwargs)
+        requested = kwargs.get("conversation_ids")
+        if requested is None:
+            return list(self.conversations)
+        wanted = set(requested)
+        return [c for c in self.conversations if c["id"] in wanted]
+
+
+def _conv(conv_id: str) -> dict:
+    return {"id": conv_id, "participant_name": f"P-{conv_id}", "is_over_cap": False}
+
+
+def _patch_batch_deps(
+    monkeypatch,
+    *,
+    chat_mode,
+    conversations: list[dict],
+    token_counts: dict,
+    existing_usage: float = 0.0,
+) -> _FakeChatService:
+    """Wire up everything _attach_conversations_within_budget touches."""
+
+    async def _fake_raise_if_chat_not_found_or_not_authorized(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return _chat_row(chat_mode)
+
+    monkeypatch.setattr(
+        chat_api,
+        "raise_if_chat_not_found_or_not_authorized",
+        _fake_raise_if_chat_not_found_or_not_authorized,
+    )
+    monkeypatch.setattr(
+        chat_api, "conversation_service", _FakeConversationServiceWithList(conversations)
+    )
+    fake_chat_service = _FakeChatService()
+    monkeypatch.setattr(chat_api, "chat_service", fake_chat_service)
+    monkeypatch.setattr(chat_api, "_resolve_workspace_tier", AsyncMock(return_value="innovator"))
+    # Every candidate has transcript content.
+    monkeypatch.setattr(
+        chat_api.async_directus,
+        "get_items",
+        AsyncMock(
+            return_value=[{"conversation_id": c["id"], "count": {"id": 1}} for c in conversations]
+        ),
+    )
+    monkeypatch.setattr(
+        chat_api,
+        "get_chat_context",
+        AsyncMock(
+            return_value=chat_api.ChatContextSchema(
+                conversations=[
+                    chat_api.ChatContextConversationSchema(
+                        conversation_id="already-there",
+                        conversation_participant_name="Existing",
+                        locked=False,
+                        token_usage=existing_usage,
+                    )
+                ]
+                if existing_usage
+                else [],
+                messages=[],
+                conversation_id_list=[],
+                locked_conversation_id_list=[],
+                chat_mode=chat_mode,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        chat_api, "get_conversation_token_counts_bulk", AsyncMock(return_value=token_counts)
+    )
+    return fake_chat_service
+
+
+@pytest.mark.asyncio
+async def test_add_context_mode_none_is_gated_like_deep_dive(monkeypatch) -> None:
+    """The product creates chats with chat_mode NULL and sets the mode after, so
+    NULL must fall on the gated side of the bypass, not the agentic side."""
+
+    async def _fake_raise_if_chat_not_found_or_not_authorized(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return _chat_row(None)
+
+    monkeypatch.setattr(
+        chat_api,
+        "raise_if_chat_not_found_or_not_authorized",
+        _fake_raise_if_chat_not_found_or_not_authorized,
+    )
+    token_count_mock = AsyncMock(return_value=chat_api.MAX_CHAT_CONTEXT_LENGTH + 1)
+    monkeypatch.setattr(chat_api, "get_conversation_token_count", token_count_mock)
+
+    with pytest.raises(HTTPException) as exc:
+        await chat_api.add_chat_context(
+            chat_id="chat-1",
+            body=chat_api.ChatAddContextSchema(
+                conversation_id="conv-1",
+                project_id="project-1",
+            ),
+            auth=_auth(),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Conversation is too long"
+    token_count_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_add_context_ids_agentic_skips_token_budget(monkeypatch) -> None:
+    """Agentic preloads nothing, so a batch that blows the budget several times
+    over still attaches in full and never costs a token count."""
+
+    conversations = [_conv("conv-1"), _conv("conv-2"), _conv("conv-3")]
+    token_counts_mock = AsyncMock(return_value={})
+    fake_chat_service = _patch_batch_deps(
+        monkeypatch,
+        chat_mode="agentic",
+        conversations=conversations,
+        token_counts={},
+    )
+    monkeypatch.setattr(chat_api, "get_conversation_token_counts_bulk", token_counts_mock)
+    get_chat_context_mock = AsyncMock()
+    monkeypatch.setattr(chat_api, "get_chat_context", get_chat_context_mock)
+
+    response = await chat_api.add_chat_context(
+        chat_id="chat-1",
+        body=chat_api.ChatAddContextSchema(
+            conversation_ids=["conv-1", "conv-2", "conv-3"],
+            project_id="project-1",
+        ),
+        auth=_auth(),
+    )
+
+    assert [item.conversation_id for item in (response.added or [])] == [
+        "conv-1",
+        "conv-2",
+        "conv-3",
+    ]
+    assert response.skipped == []
+    assert response.context_limit_reached is False
+    token_counts_mock.assert_not_awaited()
+    get_chat_context_mock.assert_not_awaited()
+    assert fake_chat_service.attach_calls == [("chat-1", ["conv-1", "conv-2", "conv-3"])]
+
+
+@pytest.mark.asyncio
+async def test_add_context_ids_deep_dive_accumulates_budget(monkeypatch) -> None:
+    """The whole point of batching: the budget accumulates across the batch, so
+    the run stops partway and says why instead of letting everything through."""
+
+    conversations = [_conv("conv-1"), _conv("conv-2"), _conv("conv-3")]
+    half = chat_api.MAX_CHAT_CONTEXT_LENGTH // 2
+    fake_chat_service = _patch_batch_deps(
+        monkeypatch,
+        chat_mode="deep_dive",
+        conversations=conversations,
+        # Each is well under the cap on its own; together they are not.
+        token_counts={"conv-1": half, "conv-2": half, "conv-3": half},
+    )
+
+    response = await chat_api.add_chat_context(
+        chat_id="chat-1",
+        body=chat_api.ChatAddContextSchema(
+            conversation_ids=["conv-1", "conv-2", "conv-3"],
+            project_id="project-1",
+        ),
+        auth=_auth(),
+    )
+
+    assert [item.conversation_id for item in (response.added or [])] == ["conv-1", "conv-2"]
+    assert [(item.conversation_id, item.reason) for item in (response.skipped or [])] == [
+        ("conv-3", "context_limit_reached")
+    ]
+    assert response.context_limit_reached is True
+    assert response.total_processed == 3
+    # Only what fit is actually attached, in one bulk write.
+    assert fake_chat_service.attach_calls == [("chat-1", ["conv-1", "conv-2"])]
+
+
+@pytest.mark.asyncio
+async def test_add_context_ids_reports_conversations_outside_the_project(monkeypatch) -> None:
+    """The lookup is scoped to the chat's project, so a foreign id comes back as
+    not_found rather than being attached or silently dropped."""
+
+    conversations = [_conv("conv-1")]
+    fake_chat_service = _patch_batch_deps(
+        monkeypatch,
+        chat_mode="deep_dive",
+        conversations=conversations,
+        token_counts={"conv-1": 10},
+    )
+
+    response = await chat_api.add_chat_context(
+        chat_id="chat-1",
+        body=chat_api.ChatAddContextSchema(
+            conversation_ids=["conv-1", "conv-from-another-project"],
+            project_id="project-1",
+        ),
+        auth=_auth(),
+    )
+
+    assert [item.conversation_id for item in (response.added or [])] == ["conv-1"]
+    assert [(item.conversation_id, item.reason) for item in (response.skipped or [])] == [
+        ("conv-from-another-project", "not_found")
+    ]
+    assert response.total_processed == 2
+    assert fake_chat_service.attach_calls == [("chat-1", ["conv-1"])]
+
+
+@pytest.mark.asyncio
+async def test_add_context_ids_mode_none_is_gated_like_deep_dive(monkeypatch) -> None:
+    """Same as the single-conversation case: a chat that has not picked a mode
+    yet keeps the budget, so an over-long batch is trimmed, not waved through."""
+
+    conversations = [_conv("conv-1"), _conv("conv-2")]
+    fake_chat_service = _patch_batch_deps(
+        monkeypatch,
+        chat_mode=None,
+        conversations=conversations,
+        token_counts={
+            "conv-1": chat_api.MAX_CHAT_CONTEXT_LENGTH,
+            "conv-2": chat_api.MAX_CHAT_CONTEXT_LENGTH,
+        },
+    )
+
+    response = await chat_api.add_chat_context(
+        chat_id="chat-1",
+        body=chat_api.ChatAddContextSchema(
+            conversation_ids=["conv-1", "conv-2"],
+            project_id="project-1",
+        ),
+        auth=_auth(),
+    )
+
+    assert [item.conversation_id for item in (response.added or [])] == ["conv-1"]
+    assert [(item.conversation_id, item.reason) for item in (response.skipped or [])] == [
+        ("conv-2", "context_limit_reached")
+    ]
+    assert fake_chat_service.attach_calls == [("chat-1", ["conv-1"])]
+
+
+@pytest.mark.asyncio
+async def test_add_context_rejects_more_than_one_option(monkeypatch) -> None:
+    """Exactly one of the three entry points, so a caller can never half-mean
+    two different things."""
+
+    async def _fake_raise_if_chat_not_found_or_not_authorized(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return _chat_row("deep_dive")
+
+    monkeypatch.setattr(
+        chat_api,
+        "raise_if_chat_not_found_or_not_authorized",
+        _fake_raise_if_chat_not_found_or_not_authorized,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await chat_api.add_chat_context(
+            chat_id="chat-1",
+            body=chat_api.ChatAddContextSchema(
+                conversation_id="conv-1",
+                conversation_ids=["conv-2"],
+                project_id="project-1",
+            ),
+            auth=_auth(),
+        )
+    assert exc.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc:
+        await chat_api.add_chat_context(
+            chat_id="chat-1",
+            body=chat_api.ChatAddContextSchema(project_id="project-1"),
+            auth=_auth(),
+        )
+    assert exc.value.status_code == 400

--- a/echo/server/tests/api/test_chat_add_context_mode_gate.py
+++ b/echo/server/tests/api/test_chat_add_context_mode_gate.py
@@ -1,0 +1,118 @@
+"""The add-context token budget is correct for deep_dive (which preloads full
+transcripts into the prompt) but wrong for agentic (which preloads nothing and
+only uses the attached rows as a focus hint). Agentic must bypass the
+MAX_CHAT_CONTEXT_LENGTH gate; deep_dive must keep it exactly as before."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+import dembrane.api.chat as chat_api
+from dembrane.api.dependency_auth import DirectusSession
+
+
+def _auth() -> DirectusSession:
+    return DirectusSession(
+        user_id="user-1",
+        is_admin=True,
+        access_token="token-1",
+    )
+
+
+class _FakeConversationService:
+    def get_by_id_or_raise(self, *_args, **_kwargs):  # noqa: ANN002, ANN003
+        return {"id": "conv-1"}
+
+
+class _FakeChatService:
+    def __init__(self) -> None:
+        self.attach_calls: list[tuple[str, list[str]]] = []
+
+    def attach_conversations(self, chat_id: str, conversation_ids: list[str]) -> None:
+        self.attach_calls.append((chat_id, conversation_ids))
+
+
+async def _fake_run_in_thread_pool(func, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+    return func(*args, **kwargs)
+
+
+def _chat_row(chat_mode: str) -> dict:
+    return {
+        "id": "chat-1",
+        "chat_mode": chat_mode,
+        "project_id": {"id": "project-1"},
+        "used_conversations": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _common_patches(monkeypatch):
+    monkeypatch.setattr(chat_api, "run_in_thread_pool", _fake_run_in_thread_pool)
+    monkeypatch.setattr(chat_api, "conversation_service", _FakeConversationService())
+    monkeypatch.setattr(chat_api.async_directus, "get_item", AsyncMock(return_value=None))
+
+
+@pytest.mark.asyncio
+async def test_add_context_deep_dive_rejects_over_budget_conversation(monkeypatch) -> None:
+    """Unchanged behaviour: deep_dive still gates on MAX_CHAT_CONTEXT_LENGTH."""
+
+    async def _fake_raise_if_chat_not_found_or_not_authorized(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return _chat_row("deep_dive")
+
+    monkeypatch.setattr(
+        chat_api,
+        "raise_if_chat_not_found_or_not_authorized",
+        _fake_raise_if_chat_not_found_or_not_authorized,
+    )
+    token_count_mock = AsyncMock(return_value=chat_api.MAX_CHAT_CONTEXT_LENGTH + 1)
+    monkeypatch.setattr(chat_api, "get_conversation_token_count", token_count_mock)
+
+    with pytest.raises(HTTPException) as exc:
+        await chat_api.add_chat_context(
+            chat_id="chat-1",
+            body=chat_api.ChatAddContextSchema(
+                conversation_id="conv-1",
+                project_id="project-1",
+            ),
+            auth=_auth(),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Conversation is too long"
+    token_count_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_add_context_agentic_skips_token_budget(monkeypatch) -> None:
+    """Agentic preloads nothing, so the same over-budget conversation must be
+    attached without ever touching the token-count check."""
+
+    async def _fake_raise_if_chat_not_found_or_not_authorized(*_args, **_kwargs):  # noqa: ANN002, ANN003
+        return _chat_row("agentic")
+
+    monkeypatch.setattr(
+        chat_api,
+        "raise_if_chat_not_found_or_not_authorized",
+        _fake_raise_if_chat_not_found_or_not_authorized,
+    )
+    token_count_mock = AsyncMock(return_value=chat_api.MAX_CHAT_CONTEXT_LENGTH + 1)
+    monkeypatch.setattr(chat_api, "get_conversation_token_count", token_count_mock)
+    get_chat_context_mock = AsyncMock()
+    monkeypatch.setattr(chat_api, "get_chat_context", get_chat_context_mock)
+    fake_chat_service = _FakeChatService()
+    monkeypatch.setattr(chat_api, "chat_service", fake_chat_service)
+
+    response = await chat_api.add_chat_context(
+        chat_id="chat-1",
+        body=chat_api.ChatAddContextSchema(
+            conversation_id="conv-1",
+            project_id="project-1",
+        ),
+        auth=_auth(),
+    )
+
+    assert isinstance(response, chat_api.AddContextResponseSchema)
+    token_count_mock.assert_not_awaited()
+    get_chat_context_mock.assert_not_awaited()
+    assert fake_chat_service.attach_calls == [("chat-1", ["conv-1"])]


### PR DESCRIPTION
## Summary

- Agentic chat is now available in every environment, including production, but is no longer the default. Hosts get Specific Details and opt in to Agentic from the Ask entry screen ("Try Agentic instead").
- `ENABLE_AGENTIC_CHAT` (availability) and `AGENTIC_CHAT_IS_DEFAULT` (default-ness) are now two separate constants, so existing `chat_mode="agentic"` chats never fall through to the legacy `/chats/{id}` path.
- Overview is dropped as a startable mode for new chats; existing `chat_mode="overview"` chats keep working unchanged (server validation, Directus, and rendering untouched).
- Hosts can pick conversations before a chat exists, from two places: the Ask entry screen ("Change") and a new "Select conversations" toggle on the project Conversations page ("Ask about these" navigates to the entry screen with the selection carried in router state).
- The picked conversations are attached to the chat (awaited) between chat creation and mode initialization, so the rows exist before the first turn runs.
- The server's add-context token budget (`MAX_CHAT_CONTEXT_LENGTH`) now skips agentic chats, which preload nothing and only use the attached rows as a focus hint; deep_dive keeps the existing gate unchanged, with a new test covering both branches.
- A typed question on the entry screen (`initialMessage`) is now wired through the legacy/deep_dive chat panel too (previously only the agentic panel consumed it), so it's never silently dropped now that Specific Details is the default path.

## Test plan

- [x] `corepack pnpm@10 install --frozen-lockfile`
- [x] `corepack pnpm@10 run lint` — no errors
- [x] `corepack pnpm@10 run build` — succeeds (tsc + vite build)
- [x] `corepack pnpm@10 vitest run` — 37 passed / 2 failed, both pre-existing and unrelated (env-only `useChunkAnchorScroll` DOM issue + orphaned Playwright specs picked up by vitest); confirmed identical failure set on unmodified `main`
- [x] Server: `uv run pytest tests/` with the `pr-testing.yml` unit-tests env block — 1209 passed / 46 failed; diffed the failure set against the same run on unmodified `main` and it's identical except the new test (fails without the fix, passes with it) and one unrelated timing-flaky thread test in `test_async_helpers.py`
- [x] `ruff check` and `ruff format --diff` on touched server files — clean (two pre-existing formatting diffs in `chat.py` left untouched, unrelated to this change)

## New user-facing strings for the translation pass

- `Where would you like to start?` — pre-existing, unchanged, just re-laid-out
- `Change`, `Beta`, `Select conversations` — reused existing msgids
- `Clear`
- `Try Agentic instead`
- `Using {n} conversations`
- `Focusing on {n} conversations`
- `{conversationCount} selected` — reuses `ChatModeBanner`'s existing catalog entry by naming the variable the same
- `Ask about these`
- `Cancel selection`
- `Select conversation` (aria-label, singular)
- `Chat created` (replaces an untranslated `toast.success("Chat created successfully")`)
- `Could not add {failed} of {total} conversations to this chat`

No `messages:extract`/`messages:compile` run and nothing under `src/locales/` touched, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)