### PR TITLE
docs: the sidebar toggle is no longer a chevron

### DIFF
--- a/docs/users/host/getting-started.md
+++ b/docs/users/host/getting-started.md
@@ -26,7 +26,7 @@ recommended, not required.)
 
 Once signed in, you will see your main dashboard:
 - *The sidebar* - The sidebar on the left lets you quickly navigate between your Organisation, Workspaces, and Projects.
-- *Sidebar collapse* - To give yourself more screen space when reading transcripts or analysing data, you can collapse the sidebar entirely. Look for the *Sidebar Toggle* (the left-pointing chevron) in the sidebar header, top-right by the logo, to slide it closed. Clicking the toggle again expands it back.
+- *Sidebar collapse* - To give yourself more screen space when reading transcripts or analysing data, you can collapse the sidebar entirely. Look for the *Sidebar Toggle* (the sidebar icon) in the sidebar header, top-right by the logo, to slide it closed. Clicking the toggle again expands it back.
 - *Collapse persistence* - The collapsed state persists (saved in your browser's local storage), so the sidebar stays exactly how you left it when you return or sign in again.
 
 ## 2. Create a project


### PR DESCRIPTION
#910 changed the sidebar collapse icon from `CaretLeft` to `SidebarSimple`. `docs/users/host/getting-started.md` still described it as "the left-pointing chevron", which #897 added earlier today, so the docs and the UI would have shipped contradicting each other in the same release.

Describes the control by name and position rather than by glyph, so the next icon change does not invalidate it again.

Caught while reviewing #910: docs.dembrane.com now publishes on every merge to main, so a stale sentence goes live immediately rather than waiting for a release.