### PR TITLE
docs(brand): reconcile STYLE_GUIDE with skills/brand-guidelines.md

### DIFF
--- a/echo/brand/STYLE_GUIDE.md
+++ b/echo/brand/STYLE_GUIDE.md
@@ -6,6 +6,14 @@ Use your gut. If something serves the brand better by bending a guideline, bend 
 
 When in doubt, ask: Does this feel approachable, grounded, and human? Does it invite people in?
 
+### Which guide wins
+
+Three files carry brand rules. When they disagree:
+
+1. `skills/brand-guidelines.md` (repo root) is the broader brand authority: the name, voice, claims and positioning, palette, type.
+2. `docs/_authoring/STYLE.md` (repo root) is the authority for pages in the published docs corpus.
+3. This file is the older, narrower one. It goes deepest on UI copy, components, and localisation. Where it contradicts either file above, they win, and this file should be corrected.
+
 ---
 
 ## Brand foundation
@@ -42,9 +50,11 @@ Always lowercase. Even at the start of a sentence.
 - "Dembrane helps groups..." (incorrect)
 - "DEMBRANE" (never)
 
-### ECHO
+### ECHO (legacy)
 
-The platform feature. Not the brand. Use sparingly in external contexts.
+"ECHO" is a legacy platform name. The platform is "dembrane", or "the dashboard" / "the portal" / "the recorder" when you mean a part of it. Older documents and emails show "Dembrane" and "ECHO"; that is drift, not the standard.
+
+One live exception: the participant record button is still labelled ECHO in the portal UI. Copy that describes that button matches the label the participant sees.
 
 ### Vocabulary
 
@@ -315,7 +325,8 @@ Logo files live in `logos/`. SVG preferred.
 
 ### Core rules
 
-- Use "je/jij/jou" - never "u/uw" (always informal)
+- Use "je/jij/jou" - never "u/uw" (always informal). Formal "u/uw" is always wrong in dembrane copy; if you find it on an existing page, flag it as drift
+- Within the informal register, use the stressed possessive *jouw* when the sentence is about the reader's own thing and wants to lean on that ("jouw evenementen", "jouw gekozen rechtsgrondslag"); use plain *je* for unstressed subjects and throwaway possessives
 - Natural phrasing, not word-for-word translation
 - Compound words: audiobestand (not "audio bestand")
 - Keep English terms when they sound better: Dashboard, Upload, Chat
@@ -343,6 +354,9 @@ Logo files live in `logos/`. SVG preferred.
 
 - Bad: "We zijn verheugd u te informeren dat de functionaliteit hersteld is"
 - Good: "Chat doet het weer"
+
+- Unstressed possessive: "Upload je bestand"
+- Stressed possessive: "jouw evenementen", "jouw gekozen rechtsgrondslag"
 
 ---
 
@@ -401,7 +415,7 @@ Target reading level: A2 (general public, basic Italian). Short sentences, commo
 
 ## Platform context
 
-ECHO is event-driven, not daily-use software. Hosts run discrete engagement sessions: workshops, consultations, civic forums, employee feedback rounds.
+dembrane is event-driven, not daily-use software. Hosts run discrete engagement sessions: workshops, consultations, civic forums, employee feedback rounds.
 
 Typical flow: Prepare event > Run session > Analyze conversations > Generate report > Return for next event
 


### PR DESCRIPTION
`echo/brand/STYLE_GUIDE.md` predates `skills/brand-guidelines.md` (#873) and still teaches the old name, so it will keep re-seeding "ECHO" into new copy. This is a naming-only reconciliation, kept separate from #913 so brand copy can be reviewed on its own.

Scope: `echo/brand/STYLE_GUIDE.md`, one file.

## What changed

1. **The `### ECHO` section** now restates the skill verbatim: *"ECHO" is a legacy platform name. The platform is "dembrane", or "the dashboard" / "the portal" / "the recorder" when you mean a part of it. Older documents and emails show "Dembrane" and "ECHO"; that is drift, not the standard.* Plus the one live exception: the participant record button is still labelled ECHO in the portal UI (`participant.button.echo` in `en-US.po`), so copy describing that button matches what the participant sees.

2. **Line 404, "Platform context"**, now reads *"dembrane is event-driven, not daily-use software."* The positioning claim underneath is untouched. Only the name it hangs on changed. See the open question below.

3. **An authority order near the top**, so the next person knows which file wins: `skills/brand-guidelines.md` is the broader brand authority, `docs/_authoring/STYLE.md` is the authority for docs pages, this file is the older narrower one and should be corrected when it disagrees.

4. **The Dutch section** gains the *jouw* vs *je* nuance, quoted from the skill: use the stressed possessive *jouw* when the sentence is about the reader's own thing and wants to lean on that ("jouw evenementen", "jouw gekozen rechtsgrondslag"); use plain *je* for unstressed subjects and throwaway possessives. The existing "u/uw is always wrong, flag it as drift" line came along with it, and two example lines were added.

## Open question for a human, not decided here

"dembrane is event-driven, not daily-use software" is now a load-bearing claim that shapes product decisions ("don't add friction to infrequent tasks", "celebrate completed analyses, not login streaks"). It may no longer be true: dembrane go is a daily-carry recording app, and the SMART loop direction (sessions to artifacts, the Library) points at something people return to between events. I have preserved the claim exactly as written. Whether it still holds is Jorim's call, not mine.

## Other contradictions found, deliberately NOT fixed

All of these are positioning, design spec, or language rules rather than naming, so they are reported rather than changed:

- **Type weight.** STYLE_GUIDE's hierarchy table says every level is "Regular". The skill says body weight is 300, not 400, and calls it "the single biggest undocumented convention". Direct contradiction.
- **Border radius.** The skill says radius 0 by default, with the `9999px` pill reserved for primary action buttons and nothing in between. STYLE_GUIDE's Buttons section says primary buttons have "rounded corners".
- **Colour token names.** Same hexes, different names: Royal Blue vs institution blue, Lime Cream vs lime yellow. The skill also carries a `hairline #E6E3DF` token that STYLE_GUIDE lacks.
- **Type scale.** The skill specifies a perfect fourth (ratio 1.333); STYLE_GUIDE gives px ranges with no ratio.
- **"AI".** STYLE_GUIDE's "Words we use carefully" says *"AI" is fine in general context*. The skill is stricter: say "language model" rather than "AI".
- **British spelling.** The skill and `docs/_authoring/STYLE.md` both mandate British English. STYLE_GUIDE uses "Analyzing...", "Analyze conversations", "anonymized", "recognizable", and "localization" headings. Some of those are literal UI copy examples, so changing them could put the guide out of step with the shipped strings. Worth a deliberate pass.
- **Missing from STYLE_GUIDE entirely**: the em dash rule (avoid, aim for zero), the no violent or martial language rule, and the whole claims-and-positioning section (claims stop at the record, "holds up under pressure" belongs to the participant, never use "incorruptible", the model never pre-writes what a room must author).

Happy to open follow-ups for any of these once someone rules on them.