### PR TITLE
feat(monitor): grid-only view, recording-page column, consistent tag styling (ECHO-899)

### DIFF
--- a/echo/frontend/src/components/conversation/FunnelCanvas.tsx
+++ b/echo/frontend/src/components/conversation/FunnelCanvas.tsx
@@ -5,10 +5,10 @@ import type {
 	FunnelVisitor,
 	MonitorConversation,
 } from "@/hooks/useConversationMonitor";
-import { isOnRecordingPage } from "./monitorGrouping";
+import { isFinishedSession, isOnRecordingPage } from "./monitorGrouping";
 
 // A particle funnel that scales to thousands of dots: one pile per stage
-// column (Scanned -> Setting up -> recording page -> live), each a pile like a
+// column (scanned -> setting up -> recording page -> live -> finished), a pile like a
 // gravity machine. Dots lerp toward their target slot, so a participant
 // visibly flows to the next column when their stage changes. Drawing is
 // batched by colour (one fill per colour per frame), so a few thousand dots
@@ -20,6 +20,7 @@ import { isOnRecordingPage } from "./monitorGrouping";
 const FALLBACK_COLORS = {
 	backgrounded: "#868e96",
 	blocked: "#fa5252",
+	finished: "#868e96",
 	recording: "#fa5252",
 	// Matches the yellow StatePill for paused / away / left.
 	recordingPage: "#fab005",
@@ -50,6 +51,7 @@ const resolveColors = (): typeof FALLBACK_COLORS => {
 			FALLBACK_COLORS.backgrounded,
 		),
 		blocked: readCssVar("--mantine-color-red-6", FALLBACK_COLORS.blocked),
+		finished: readCssVar("--mantine-color-gray-6", FALLBACK_COLORS.finished),
 		recording: readCssVar("--mantine-color-red-6", FALLBACK_COLORS.recording),
 		recordingPage: readCssVar(
 			"--mantine-color-yellow-6",
@@ -88,6 +90,14 @@ const colorOf = (node: NodeDatum): string => {
 	const colors = resolveColors();
 	if (node.kind === "conversation") {
 		if (isOnRecordingPage(node.data)) return colors.recordingPage;
+		// The finished column holds two outcomes. One count reads fine, but the
+		// dot keeps the state pill's colour, so a session that just stopped is
+		// still legible inside the column at no extra cost.
+		if (isFinishedSession(node.data)) {
+			return node.data.state === "left"
+				? colors.recordingPage
+				: colors.finished;
+		}
 		if (node.data.recording_health === "stalled") return colors.stalled;
 		if (node.data.recording_health === "backgrounded")
 			return colors.backgrounded;
@@ -101,7 +111,7 @@ const colorOf = (node: NodeDatum): string => {
 export const FunnelCanvas = ({
 	nodes,
 	height = 150,
-	weights = [1, 1, 1, 1],
+	weights = [1, 1, 1, 1, 1],
 	onSelect,
 	onHover,
 }: {
@@ -347,7 +357,7 @@ export const FunnelCanvas = ({
 			<canvas
 				ref={canvasRef}
 				role="img"
-				aria-label={t`Live participant funnel: scanned, setting up, on recording page, and live counts`}
+				aria-label={t`Live participant funnel: scanned, setting up, on recording page, live, and finished counts`}
 				onClick={(event) => {
 					const { x, y } = mouseXY(event);
 					const node = nearest(x, y);

--- a/echo/frontend/src/components/conversation/FunnelCanvas.tsx
+++ b/echo/frontend/src/components/conversation/FunnelCanvas.tsx
@@ -5,9 +5,10 @@ import type {
 	FunnelVisitor,
 	MonitorConversation,
 } from "@/hooks/useConversationMonitor";
+import { isOnRecordingPage } from "./monitorGrouping";
 
-// A particle funnel that scales to thousands of dots: three stage columns
-// (Scanned -> Setting up -> Recording), each a bottom-packed pile like a
+// A particle funnel that scales to thousands of dots: one pile per stage
+// column (Scanned -> Setting up -> recording page -> live), each a pile like a
 // gravity machine. Dots lerp toward their target slot, so a participant
 // visibly flows to the next column when their stage changes. Drawing is
 // batched by colour (one fill per colour per frame), so a few thousand dots
@@ -20,6 +21,8 @@ const FALLBACK_COLORS = {
 	backgrounded: "#868e96",
 	blocked: "#fa5252",
 	recording: "#fa5252",
+	// Matches the yellow StatePill for paused / away / left.
+	recordingPage: "#fab005",
 	scanned: "#adb5bd",
 	setup: "#4169e1",
 	stalled: "#e8590c",
@@ -48,6 +51,10 @@ const resolveColors = (): typeof FALLBACK_COLORS => {
 		),
 		blocked: readCssVar("--mantine-color-red-6", FALLBACK_COLORS.blocked),
 		recording: readCssVar("--mantine-color-red-6", FALLBACK_COLORS.recording),
+		recordingPage: readCssVar(
+			"--mantine-color-yellow-6",
+			FALLBACK_COLORS.recordingPage,
+		),
 		scanned: readCssVar("--mantine-color-gray-5", FALLBACK_COLORS.scanned),
 		setup: readCssVar("--mantine-color-primary-6", FALLBACK_COLORS.setup),
 		stalled: readCssVar("--mantine-color-orange-7", FALLBACK_COLORS.stalled),
@@ -56,14 +63,16 @@ const resolveColors = (): typeof FALLBACK_COLORS => {
 	return colors;
 };
 
+/** `column` is the stage column this node piles into, assigned by the caller
+ * (the canvas stays agnostic about what the stages mean). */
 export type NodeDatum =
-	| { kind: "visitor"; data: FunnelVisitor }
-	| { kind: "conversation"; data: MonitorConversation };
+	| { kind: "visitor"; data: FunnelVisitor; column: number }
+	| { kind: "conversation"; data: MonitorConversation; column: number };
 
 type Particle = {
 	id: string;
 	kind: "visitor" | "conversation";
-	col: number; // 0,1,2
+	col: number;
 	color: string;
 	pulse: boolean;
 	x: number;
@@ -75,14 +84,10 @@ type Particle = {
 	dead: boolean;
 };
 
-const columnOf = (node: NodeDatum): number => {
-	if (node.kind === "conversation") return 2;
-	return node.data.stage === "scanned" ? 0 : 1;
-};
-
 const colorOf = (node: NodeDatum): string => {
 	const colors = resolveColors();
 	if (node.kind === "conversation") {
+		if (isOnRecordingPage(node.data)) return colors.recordingPage;
 		if (node.data.recording_health === "stalled") return colors.stalled;
 		if (node.data.recording_health === "backgrounded")
 			return colors.backgrounded;
@@ -96,15 +101,15 @@ const colorOf = (node: NodeDatum): string => {
 export const FunnelCanvas = ({
 	nodes,
 	height = 150,
-	weights = [1, 1, 1],
+	weights = [1, 1, 1, 1],
 	onSelect,
 	onHover,
 }: {
 	nodes: NodeDatum[];
 	height?: number;
-	/** Relative widths of the three columns, so empty stages shrink and the
-	 * busy ones grow (e.g. only-recording -> ~25/25/50). */
-	weights?: [number, number, number];
+	/** Relative width per column, so empty stages shrink and busy ones grow.
+	 * Its length defines how many columns the canvas draws. */
+	weights?: number[];
 	onSelect: (node: NodeDatum) => void;
 	onHover?: (node: NodeDatum | null) => void;
 }) => {
@@ -112,7 +117,7 @@ export const FunnelCanvas = ({
 	const wrapRef = useRef<HTMLDivElement | null>(null);
 	const particles = useRef<Map<string, Particle>>(new Map());
 	const nodesRef = useRef<NodeDatum[]>(nodes);
-	const weightsRef = useRef<[number, number, number]>(weights);
+	const weightsRef = useRef<number[]>(weights);
 	const sizeRef = useRef<{ w: number; h: number }>({ h: height, w: 0 });
 	const lastHitTestRef = useRef(0);
 	nodesRef.current = nodes;
@@ -148,16 +153,22 @@ export const FunnelCanvas = ({
 			const { w, h } = sizeRef.current;
 			// Weighted columns: empty stages shrink, busy ones grow.
 			const wts = weightsRef.current;
-			const wtTotal = wts[0] + wts[1] + wts[2] || 1;
-			const colX = [
-				0,
-				(wts[0] / wtTotal) * w,
-				((wts[0] + wts[1]) / wtTotal) * w,
-			];
+			const wtTotal = wts.reduce((sum, weight) => sum + weight, 0) || 1;
+			// Running left edge of each column.
+			let cursor = 0;
+			const colX = wts.map((weight) => {
+				const x = cursor;
+				cursor += (weight / wtTotal) * w;
+				return x;
+			});
 			const colWArr = wts.map((weight) => (weight / wtTotal) * w);
 			// Group current nodes by column and assign a slot.
-			const byCol: NodeDatum[][] = [[], [], []];
-			for (const node of nodesRef.current) byCol[columnOf(node)].push(node);
+			const byCol: NodeDatum[][] = wts.map(() => []);
+			for (const node of nodesRef.current) {
+				// Clamp so a caller can never index off the end of the canvas.
+				const col = Math.min(Math.max(node.column, 0), byCol.length - 1);
+				byCol[col].push(node);
+			}
 			const live = new Set<string>();
 
 			byCol.forEach((colNodes, col) => {
@@ -235,7 +246,7 @@ export const FunnelCanvas = ({
 		// animation frame. `nodes`/`weights` are memoized upstream, so a
 		// reference check is enough to catch real changes cheaply.
 		let dirtyNodes: NodeDatum[] | null = null;
-		let dirtyWeights: [number, number, number] | null = null;
+		let dirtyWeights: number[] | null = null;
 		let dirtyW = -1;
 		let dirtyH = -1;
 
@@ -336,7 +347,7 @@ export const FunnelCanvas = ({
 			<canvas
 				ref={canvasRef}
 				role="img"
-				aria-label={t`Live participant funnel: scanned, setting up, and recording counts`}
+				aria-label={t`Live participant funnel: scanned, setting up, on recording page, and live counts`}
 				onClick={(event) => {
 					const { x, y } = mouseXY(event);
 					const node = nearest(x, y);

--- a/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
@@ -15,7 +15,11 @@ import {
 import { ConversationDrilldownModal } from "./ConversationDrilldownModal";
 import { FunnelCanvas, type NodeDatum } from "./FunnelCanvas";
 import { MonitorBadge } from "./MonitorBadge";
-import { isLiveRecording, isOnRecordingPage } from "./monitorGrouping";
+import {
+	isFinishedSession,
+	isLiveRecording,
+	isOnRecordingPage,
+} from "./monitorGrouping";
 
 const weakNetwork = (
 	network: { online?: boolean; effective_type?: string } | null,
@@ -168,10 +172,12 @@ export const LiveFunnelSection = ({
 		conversations.find((c) => c.id === selectedConversationId) ?? null;
 
 	const { nodes, counts, weights } = useMemo(() => {
-		// Two conversation columns: on the recording page (paused, away, left,
-		// waiting) and actually live. Finished and offline stay out of the funnel.
+		// Three conversation columns: on the recording page (waiting, paused,
+		// away), actually live, then finished (finished cleanly, or left without
+		// finishing). Offline is the one status with no column; see monitorGrouping.
 		const onPage = conversations.filter(isOnRecordingPage);
 		const live = conversations.filter(isLiveRecording);
+		const finished = conversations.filter(isFinishedSession);
 		const visitorNodes: NodeDatum[] = funnel.visitors.map((data) => ({
 			column: data.stage === "scanned" ? 0 : 1,
 			data,
@@ -187,16 +193,22 @@ export const LiveFunnelSection = ({
 			data,
 			kind: "conversation",
 		}));
+		const finishedNodes: NodeDatum[] = finished.map((data) => ({
+			column: 4,
+			data,
+			kind: "conversation",
+		}));
 		const scanned = funnel.visitors.filter((v) => v.stage === "scanned").length;
 		const setup = funnel.visitors.length - scanned;
 		return {
 			counts: {
+				finished: finished.length,
 				live: live.length,
 				onPage: onPage.length,
 				scanned,
 				setup,
 			},
-			nodes: [...visitorNodes, ...onPageNodes, ...liveNodes],
+			nodes: [...visitorNodes, ...onPageNodes, ...liveNodes, ...finishedNodes],
 			// Empty stages shrink; live carries extra weight so an all-recording
 			// view still gives the live column the most room.
 			weights: [
@@ -204,6 +216,7 @@ export const LiveFunnelSection = ({
 				Math.max(1, setup),
 				Math.max(1, onPage.length),
 				Math.max(2, live.length),
+				Math.max(1, finished.length),
 			],
 		};
 	}, [funnel.visitors, conversations]);
@@ -252,6 +265,11 @@ export const LiveFunnelSection = ({
 							label={t`Live`}
 							count={counts.live}
 							weight={weights[3]}
+						/>
+						<StageLabel
+							label={t`Finished`}
+							count={counts.finished}
+							weight={weights[4]}
 						/>
 					</Group>
 					<FunnelCanvas

--- a/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveFunnelSection.tsx
@@ -15,6 +15,7 @@ import {
 import { ConversationDrilldownModal } from "./ConversationDrilldownModal";
 import { FunnelCanvas, type NodeDatum } from "./FunnelCanvas";
 import { MonitorBadge } from "./MonitorBadge";
+import { isLiveRecording, isOnRecordingPage } from "./monitorGrouping";
 
 const weakNetwork = (
 	network: { online?: boolean; effective_type?: string } | null,
@@ -167,27 +168,43 @@ export const LiveFunnelSection = ({
 		conversations.find((c) => c.id === selectedConversationId) ?? null;
 
 	const { nodes, counts, weights } = useMemo(() => {
-		const recording = conversations.filter((c) => c.is_live);
+		// Two conversation columns: on the recording page (paused, away, left,
+		// waiting) and actually live. Finished and offline stay out of the funnel.
+		const onPage = conversations.filter(isOnRecordingPage);
+		const live = conversations.filter(isLiveRecording);
 		const visitorNodes: NodeDatum[] = funnel.visitors.map((data) => ({
+			column: data.stage === "scanned" ? 0 : 1,
 			data,
 			kind: "visitor",
 		}));
-		const recordingNodes: NodeDatum[] = recording.map((data) => ({
+		const onPageNodes: NodeDatum[] = onPage.map((data) => ({
+			column: 2,
+			data,
+			kind: "conversation",
+		}));
+		const liveNodes: NodeDatum[] = live.map((data) => ({
+			column: 3,
 			data,
 			kind: "conversation",
 		}));
 		const scanned = funnel.visitors.filter((v) => v.stage === "scanned").length;
 		const setup = funnel.visitors.length - scanned;
 		return {
-			counts: { recording: recording.length, scanned, setup },
-			nodes: [...visitorNodes, ...recordingNodes],
-			// Empty stages shrink; recording carries extra weight so an
-			// all-recording view reads ~25/25/50.
+			counts: {
+				live: live.length,
+				onPage: onPage.length,
+				scanned,
+				setup,
+			},
+			nodes: [...visitorNodes, ...onPageNodes, ...liveNodes],
+			// Empty stages shrink; live carries extra weight so an all-recording
+			// view still gives the live column the most room.
 			weights: [
 				Math.max(1, scanned),
 				Math.max(1, setup),
-				Math.max(2, recording.length),
-			] as [number, number, number],
+				Math.max(1, onPage.length),
+				Math.max(2, live.length),
+			],
 		};
 	}, [funnel.visitors, conversations]);
 
@@ -227,9 +244,14 @@ export const LiveFunnelSection = ({
 							weight={weights[1]}
 						/>
 						<StageLabel
-							label={t`Recording`}
-							count={counts.recording}
+							label={t`Recording page`}
+							count={counts.onPage}
 							weight={weights[2]}
+						/>
+						<StageLabel
+							label={t`Live`}
+							count={counts.live}
+							weight={weights[3]}
 						/>
 					</Group>
 					<FunnelCanvas

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.test.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.test.tsx
@@ -10,8 +10,14 @@ import type {
 	MonitorConversation,
 	ParticipantState,
 } from "@/hooks/useConversationMonitor";
-import { LiveMonitorSection } from "./LiveMonitorSection";
-import { isProblemState, StatePill } from "./StatePill";
+import { groupByStatus, LiveMonitorSection } from "./LiveMonitorSection";
+import {
+	isLiveRecording,
+	isOnRecordingPage,
+	monitorStatusGroup,
+	settleStatusGroups,
+} from "./monitorGrouping";
+import { isProblemState, StatePill, stateColor } from "./StatePill";
 
 const captureMock = vi.hoisted(() => vi.fn());
 vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
@@ -118,9 +124,24 @@ describe("StatePill", () => {
 		expect(getByText("Left")).toBeTruthy();
 	});
 
+	it("renders On recording page for the waiting state", () => {
+		const { getByText } = renderPill("waiting");
+		expect(getByText("On recording page")).toBeTruthy();
+	});
+
 	it("renders Idle for an unknown/idle state", () => {
 		const { getByText } = renderPill("idle");
 		expect(getByText("Idle")).toBeTruthy();
+	});
+
+	it("puts left, backgrounded and away on yellow alongside paused", () => {
+		expect(stateColor("paused")).toBe("yellow");
+		expect(stateColor("left")).toBe("yellow");
+		expect(stateColor("backgrounded")).toBe("yellow");
+	});
+
+	it("keeps waiting grey", () => {
+		expect(stateColor("waiting")).toBe("gray");
 	});
 });
 
@@ -230,16 +251,15 @@ describe("LiveMonitorSection click-through", () => {
 		);
 	});
 
-	it("opens the drilldown modal from the row pencil without navigating", async () => {
+	it("opens the drilldown from the keyboard, so tiles are not mouse-only", async () => {
 		captureMock.mockClear();
 		mockConversations = [baseConversation({ id: "c1", label: "Ada" })];
-		const { getByTestId } = renderSection();
-		fireEvent.click(getByTestId("monitor-row-edit"));
-		// Modal is open (its Delete action is visible) and the row didn't navigate.
+		const { getByLabelText } = renderSection();
+		fireEvent.keyDown(getByLabelText("Open Ada"), { key: "Enter" });
 		expect(await screen.findByText("Delete")).toBeTruthy();
-		expect(captureMock).not.toHaveBeenCalledWith(
-			"monitor_conversation_opened",
-			expect.anything(),
+		expect(captureMock).toHaveBeenCalledWith(
+			"monitor_drilldown_opened",
+			expect.objectContaining({ entity_type: "recording", project_id: "p1" }),
 		);
 	});
 });
@@ -274,15 +294,119 @@ describe("LiveMonitorSection row ordering", () => {
 	});
 });
 
-describe("LiveMonitorSection click-filtering", () => {
-	it("filters conversations list when badges are clicked, and clears filters properly", async () => {
+describe("monitor status grouping", () => {
+	it("puts paused, away, left and waiting on the recording page", () => {
+		for (const state of [
+			"paused",
+			"backgrounded",
+			"left",
+			"waiting",
+		] as const) {
+			const conversation = baseConversation({
+				state,
+				is_live: state !== "left",
+			});
+			expect(monitorStatusGroup(conversation)).toBe("recording_page");
+			expect(isOnRecordingPage(conversation)).toBe(true);
+			expect(isLiveRecording(conversation)).toBe(false);
+		}
+	});
+
+	it("keeps an actively recording conversation in the live group", () => {
+		const conversation = baseConversation({
+			state: "recording",
+			is_live: true,
+		});
+		expect(monitorStatusGroup(conversation)).toBe("live");
+		expect(isLiveRecording(conversation)).toBe(true);
+		expect(isOnRecordingPage(conversation)).toBe(false);
+	});
+
+	it("separates offline and finished from both funnel columns", () => {
+		const offline = baseConversation({ state: "offline", is_live: false });
+		const finished = baseConversation({ is_finished: true, is_live: false });
+		expect(monitorStatusGroup(offline)).toBe("offline");
+		expect(monitorStatusGroup(finished)).toBe("finished");
+		for (const conversation of [offline, finished]) {
+			expect(isOnRecordingPage(conversation)).toBe(false);
+			expect(isLiveRecording(conversation)).toBe(false);
+		}
+	});
+
+	it("orders status groups by the fixed order, never by count", () => {
+		const groups = groupByStatus(
+			[
+				baseConversation({ id: "a", label: "Ada" }),
+				baseConversation({ id: "b", label: "Bob" }),
+				baseConversation({ id: "c", label: "Cy" }),
+			],
+			(conversation) => (conversation.id === "a" ? "live" : "recording_page"),
+		);
+		expect(groups.map((group) => group.key)).toEqual([
+			"live",
+			"recording_page",
+		]);
+		// The bigger bucket does not jump to the front.
+		expect(groups[1].items).toHaveLength(2);
+	});
+});
+
+describe("settleStatusGroups", () => {
+	const recording = baseConversation({ id: "c1", state: "recording" });
+	const paused = baseConversation({ id: "c1", state: "paused" });
+
+	it("adopts a status immediately on first sighting", () => {
+		const settled = settleStatusGroups(new Map(), [recording], 0);
+		expect(settled.get("c1")?.group).toBe("live");
+	});
+
+	it("holds a tile in place until the new status has settled", () => {
+		let settled = settleStatusGroups(new Map(), [recording], 0);
+		settled = settleStatusGroups(settled, [paused], 1000);
+		// Still rendered under live: the change has not held long enough yet.
+		expect(settled.get("c1")?.group).toBe("live");
+		expect(settled.get("c1")?.pending).toBe("recording_page");
+
+		settled = settleStatusGroups(settled, [paused], 5000);
+		expect(settled.get("c1")?.group).toBe("recording_page");
+	});
+
+	it("cancels a pending move when the status flaps back", () => {
+		let settled = settleStatusGroups(new Map(), [recording], 0);
+		settled = settleStatusGroups(settled, [paused], 1000);
+		settled = settleStatusGroups(settled, [recording], 2000);
+		expect(settled.get("c1")?.group).toBe("live");
+		expect(settled.get("c1")?.pending).toBeNull();
+
+		// And the settle clock restarts, so the flap buys no head start.
+		settled = settleStatusGroups(settled, [paused], 3000);
+		settled = settleStatusGroups(settled, [paused], 6000);
+		expect(settled.get("c1")?.group).toBe("live");
+	});
+
+	it("forgets conversations that dropped out of the snapshot", () => {
+		const settled = settleStatusGroups(
+			settleStatusGroups(new Map(), [recording], 0),
+			[],
+			1000,
+		);
+		expect(settled.size).toBe(0);
+	});
+});
+
+describe("LiveMonitorSection grid-only view", () => {
+	it("has no view toggle and writes no view-mode preference", () => {
+		localStorage.removeItem("echo_monitor_view_mode");
+		mockConversations = [baseConversation({ id: "c1", label: "Ada" })];
+		const { queryByText } = renderSection();
+		expect(queryByText("Detailed")).toBeNull();
+		expect(queryByText("Compressed")).toBeNull();
+		expect(localStorage.getItem("echo_monitor_view_mode")).toBeNull();
+	});
+
+	it("renders the summary badges as informational, not filters", () => {
 		mockConversations = [
-			baseConversation({
-				id: "c1",
-				label: "Ada",
-				is_live: true,
-				has_error: false,
-			}),
+			baseConversation({ id: "c1", label: "Ada", is_live: true }),
 			baseConversation({
 				id: "c2",
 				label: "Bob",
@@ -290,71 +414,47 @@ describe("LiveMonitorSection click-filtering", () => {
 				has_error: true,
 			}),
 		];
-		const { getByRole, getByText, queryByText } = renderSection();
-		// Query the summary badges by role: a tag group renders its own "N live"
-		// badge with identical text, so getByText would be ambiguous.
-		const liveBadge = () => getByRole("button", { name: "1 live" });
-		const errorBadge = () => getByRole("button", { name: "1 with errors" });
-
-		// Initially, both Ada and Bob are visible
-		expect(getByText("Ada")).toBeTruthy();
-		expect(getByText("Bob")).toBeTruthy();
-		expect(liveBadge().getAttribute("aria-pressed")).toBe("false");
-
-		// Click the "live" badge: only the live conversation survives
-		fireEvent.click(liveBadge());
-		expect(getByText("Ada")).toBeTruthy();
-		expect(queryByText("Bob")).toBeNull();
-		expect(liveBadge().getAttribute("aria-pressed")).toBe("true");
-
-		// Clicking the same badge again toggles the filter back off
-		fireEvent.click(liveBadge());
-		expect(getByText("Ada")).toBeTruthy();
-		expect(getByText("Bob")).toBeTruthy();
-
-		// Switching to the errors badge swaps the filter rather than stacking it
-		fireEvent.click(errorBadge());
-		expect(queryByText("Ada")).toBeNull();
-		expect(getByText("Bob")).toBeTruthy();
-
-		// The banner's "Clear filter" resets everything
-		fireEvent.click(getByRole("button", { name: "Clear filter" }));
+		const { getByText, queryByRole } = renderSection();
+		// The badges are no longer buttons, and nothing gets filtered out.
+		expect(queryByRole("button", { name: "1 live" })).toBeNull();
+		expect(queryByRole("button", { name: "1 with errors" })).toBeNull();
 		expect(getByText("Ada")).toBeTruthy();
 		expect(getByText("Bob")).toBeTruthy();
 	});
+});
 
-	it("filters from the keyboard, so badges are not mouse-only", () => {
+describe("LiveMonitorSection grouping dimension", () => {
+	it("regroups by status and reports the change once", () => {
+		captureMock.mockClear();
 		mockConversations = [
-			baseConversation({ id: "c1", label: "Ada", is_live: true }),
-			baseConversation({ id: "c2", label: "Bob", is_live: false }),
+			baseConversation({
+				created_at: "2026-07-02T12:00:02Z",
+				id: "c2",
+				is_live: true,
+				label: "Bob",
+				state: "paused",
+			}),
+			baseConversation({
+				created_at: "2026-07-02T12:00:01Z",
+				id: "c1",
+				is_live: true,
+				label: "Ada",
+				state: "recording",
+			}),
 		];
-		const { getByRole, getByText, queryByText } = renderSection();
-		const liveBadge = () => getByRole("button", { name: "1 live" });
+		const { getByText } = renderSection();
+		fireEvent.click(getByText("By status"));
 
-		fireEvent.keyDown(liveBadge(), { key: "Enter" });
-		expect(getByText("Ada")).toBeTruthy();
-		expect(queryByText("Bob")).toBeNull();
+		expect(captureMock).toHaveBeenCalledWith("monitor_grouping_changed", {
+			group_by: "status",
+			project_id: "p1",
+		});
 
-		fireEvent.keyDown(liveBadge(), { key: " " });
-		expect(getByText("Ada")).toBeTruthy();
-		expect(getByText("Bob")).toBeTruthy();
-	});
-
-	it("keeps the compressed grid toggle in localStorage", () => {
-		mockConversations = [baseConversation({ id: "c1", label: "Ada" })];
-		const { getByText, unmount } = renderSection();
-
-		fireEvent.click(getByText("Compressed"));
-		expect(localStorage.getItem("echo_monitor_view_mode")).toBe("compressed");
-
-		// A fresh mount reads the saved preference back.
-		unmount();
-		const second = renderSection();
+		// Live group first, recording-page group second, whatever the counts.
+		const ada = getByText("Ada");
+		const bob = getByText("Bob");
 		expect(
-			second
-				.getByRole("radio", { name: "Compressed" })
-				.getAttribute("checked") !== null ||
-				localStorage.getItem("echo_monitor_view_mode") === "compressed",
-		).toBe(true);
+			ada.compareDocumentPosition(bob) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
 	});
 });

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.test.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.test.tsx
@@ -12,10 +12,12 @@ import type {
 } from "@/hooks/useConversationMonitor";
 import { groupByStatus, LiveMonitorSection } from "./LiveMonitorSection";
 import {
+	isFinishedSession,
 	isLiveRecording,
 	isOnRecordingPage,
 	monitorStatusGroup,
 	settleStatusGroups,
+	STATUS_GROUP_ORDER,
 } from "./monitorGrouping";
 import { isProblemState, StatePill, stateColor } from "./StatePill";
 
@@ -295,21 +297,31 @@ describe("LiveMonitorSection row ordering", () => {
 });
 
 describe("monitor status grouping", () => {
-	it("puts paused, away, left and waiting on the recording page", () => {
-		for (const state of [
-			"paused",
-			"backgrounded",
-			"left",
-			"waiting",
-		] as const) {
-			const conversation = baseConversation({
-				state,
-				is_live: state !== "left",
-			});
+	it("puts paused, away and waiting on the recording page", () => {
+		for (const state of ["paused", "backgrounded", "waiting"] as const) {
+			const conversation = baseConversation({ state, is_live: true });
 			expect(monitorStatusGroup(conversation)).toBe("recording_page");
 			expect(isOnRecordingPage(conversation)).toBe(true);
 			expect(isLiveRecording(conversation)).toBe(false);
+			expect(isFinishedSession(conversation)).toBe(false);
 		}
+	});
+
+	it("groups left with finished, not with the recording page", () => {
+		// Closing the tab is terminal. Saying someone is on the recording page
+		// when they navigated away would be a lie to the host.
+		const left = baseConversation({ state: "left", is_live: false });
+		expect(monitorStatusGroup(left)).toBe("finished");
+		expect(isFinishedSession(left)).toBe(true);
+		expect(isOnRecordingPage(left)).toBe(false);
+		expect(isLiveRecording(left)).toBe(false);
+	});
+
+	it("puts a cleanly finished session in the same group as left", () => {
+		const finished = baseConversation({ is_finished: true, is_live: false });
+		const left = baseConversation({ state: "left", is_live: false });
+		expect(monitorStatusGroup(finished)).toBe(monitorStatusGroup(left));
+		expect(isFinishedSession(finished)).toBe(true);
 	});
 
 	it("keeps an actively recording conversation in the live group", () => {
@@ -322,15 +334,12 @@ describe("monitor status grouping", () => {
 		expect(isOnRecordingPage(conversation)).toBe(false);
 	});
 
-	it("separates offline and finished from both funnel columns", () => {
+	it("keeps offline out of every funnel column", () => {
 		const offline = baseConversation({ state: "offline", is_live: false });
-		const finished = baseConversation({ is_finished: true, is_live: false });
 		expect(monitorStatusGroup(offline)).toBe("offline");
-		expect(monitorStatusGroup(finished)).toBe("finished");
-		for (const conversation of [offline, finished]) {
-			expect(isOnRecordingPage(conversation)).toBe(false);
-			expect(isLiveRecording(conversation)).toBe(false);
-		}
+		expect(isOnRecordingPage(offline)).toBe(false);
+		expect(isLiveRecording(offline)).toBe(false);
+		expect(isFinishedSession(offline)).toBe(false);
 	});
 
 	it("orders status groups by the fixed order, never by count", () => {
@@ -340,11 +349,11 @@ describe("monitor status grouping", () => {
 				baseConversation({ id: "b", label: "Bob" }),
 				baseConversation({ id: "c", label: "Cy" }),
 			],
-			(conversation) => (conversation.id === "a" ? "live" : "recording_page"),
+			(conversation) => (conversation.id === "a" ? "recording_page" : "live"),
 		);
 		expect(groups.map((group) => group.key)).toEqual([
-			"live",
 			"recording_page",
+			"live",
 		]);
 		// The bigger bucket does not jump to the front.
 		expect(groups[1].items).toHaveLength(2);
@@ -450,11 +459,20 @@ describe("LiveMonitorSection grouping dimension", () => {
 			project_id: "p1",
 		});
 
-		// Live group first, recording-page group second, whatever the counts.
+		// Recording-page group first, live group second, whatever the counts.
+		// Same left-to-right progression as the funnel above the grid.
 		const ada = getByText("Ada");
 		const bob = getByText("Bob");
 		expect(
-			ada.compareDocumentPosition(bob) & Node.DOCUMENT_POSITION_FOLLOWING,
+			bob.compareDocumentPosition(ada) & Node.DOCUMENT_POSITION_FOLLOWING,
 		).toBeTruthy();
+	});
+
+	it("orders grid groups the same way the funnel orders its columns", () => {
+		// The funnel reads scanned -> setting up -> recording page -> live ->
+		// finished. The grid has no visitor stages, but over the three statuses
+		// they share it must not contradict the funnel.
+		const shared = STATUS_GROUP_ORDER.filter((group) => group !== "offline");
+		expect(shared).toEqual(["recording_page", "live", "finished"]);
 	});
 });

--- a/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
+++ b/echo/frontend/src/components/conversation/LiveMonitorSection.tsx
@@ -19,17 +19,13 @@ import {
 	BroadcastIcon,
 	CaretRightIcon,
 	MicrophoneIcon,
-	PencilSimpleIcon,
 	WarningCircleIcon,
 	WifiSlashIcon,
 } from "@phosphor-icons/react";
-import { formatDistanceToNow } from "date-fns";
 import posthog from "posthog-js";
-import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router";
 import DembraneLoadingSpinner from "@/components/common/DembraneLoadingSpinner";
-import { RedactedText } from "@/components/common/RedactedText";
-import { LockedTranscriptOverlay } from "@/components/conversation/LockedTranscriptOverlay";
 import { UpgradeModal } from "@/components/workspace/FeatureGate";
 import {
 	type MonitorConversation,
@@ -39,38 +35,25 @@ import { useWorkspace } from "@/hooks/useWorkspace";
 import { SELLABLE_TIER, type Tier } from "@/lib/tiers";
 import { ConversationDrilldownModal } from "./ConversationDrilldownModal";
 import { MonitorBadge } from "./MonitorBadge";
+import {
+	type MonitorStatusGroup,
+	monitorStatusGroup,
+	type SettledStatus,
+	settleStatusGroups,
+	STATUS_GROUP_ORDER,
+	statusGroupLabel,
+} from "./monitorGrouping";
 import { StatePill, stateColor } from "./StatePill";
 
-// How many rows to render per tag group before collapsing the rest behind a
-// "show more" — keeps the page calm and bounded even for a busy tag.
+// How many tiles to render per group before collapsing the rest behind a
+// "show more" — keeps the page calm and bounded even for a busy group.
 const MAX_ROWS_PER_GROUP = 25;
 
-type ViewMode = "detailed" | "compressed";
+/** The dimension the host groups the grid by. */
+type GroupBy = "tag" | "status";
 
-// Hosts running a big event keep the compressed grid on across page loads.
-const VIEW_MODE_STORAGE_KEY = "echo_monitor_view_mode";
-
-type MonitorFilter =
-	| "live"
-	| "offline"
-	| "not_receiving"
-	| "transcribing"
-	| "with_errors";
-
-// One source of truth for the clickable summary badges. Each predicate mirrors
-// the matching server counter in api/v2/bff/conversations.py, so a badge count
-// and the rows it filters down to can't drift apart.
-const FILTER_PREDICATES: Record<
-	MonitorFilter,
-	(conversation: MonitorConversation) => boolean
-> = {
-	live: (conversation) => conversation.is_live,
-	offline: (conversation) => conversation.recording_health === "offline",
-	not_receiving: (conversation) => conversation.recording_health === "stalled",
-	transcribing: (conversation) =>
-		conversation.transcription_status === "transcribing",
-	with_errors: (conversation) => conversation.has_error,
-};
+// How often the settle clock is re-evaluated while grouping by status.
+const SETTLE_TICK_MS = 1000;
 
 // Stable keys for the meter segments (index drives the fill).
 const METER_SEGMENTS = ["s1", "s2", "s3", "s4", "s5"];
@@ -119,32 +102,6 @@ const AudioLevelMeter = ({ level }: { level: number }) => {
 				</Group>
 			</Group>
 		</Tooltip>
-	);
-};
-
-/** The latest transcript line, crossfading whenever it updates. */
-const FadingTranscript = ({ text }: { text: string }) => {
-	const [shown, setShown] = useState(text);
-	const [visible, setVisible] = useState(true);
-
-	useEffect(() => {
-		if (text === shown) return;
-		setVisible(false);
-		const timer = setTimeout(() => {
-			setShown(text);
-			setVisible(true);
-		}, 180);
-		return () => clearTimeout(timer);
-	}, [text, shown]);
-
-	return (
-		<Text
-			size="sm"
-			lineClamp={2}
-			style={{ opacity: visible ? 1 : 0, transition: "opacity 180ms ease" }}
-		>
-			<RedactedText>{shown}</RedactedText>
-		</Text>
 	);
 };
 
@@ -244,284 +201,116 @@ const catchUpLabel = (seconds: number): string | null => {
 	return bucket ? `~${bucket} min` : "~30+ min";
 };
 
-const lastActivityLabel = (conversation: MonitorConversation): string => {
-	const stamp = conversation.last_seen_at ?? conversation.last_chunk_at;
-	if (!stamp) return t`No activity yet`;
-	try {
-		return formatDistanceToNow(new Date(stamp), { addSuffix: true });
-	} catch {
-		return stamp;
-	}
-};
-
-const TranscriptionBadge = ({
-	conversation,
-}: {
-	conversation: MonitorConversation;
-}) => {
-	// A failing conversation already shows a red Error badge; don't double up.
-	if (conversation.transcription_status === "failing") return null;
-	if (conversation.transcription_status === "transcribing") {
-		return (
-			<MonitorBadge size="xs" color="primary" variant="light">
-				<Plural
-					value={conversation.pending_transcription}
-					one="Transcribing # clip"
-					other="Transcribing # clips"
-				/>
-			</MonitorBadge>
-		);
-	}
-	if (
-		conversation.transcription_status === "up_to_date" &&
-		conversation.chunk_count > 0
-	) {
-		return (
-			<MonitorBadge size="xs" color="green" variant="light">
-				<Trans>Transcribed</Trans>
-			</MonitorBadge>
-		);
-	}
-	return null;
-};
-
-const MonitorRow = ({
+/** One grid tile. The grid is the only view, so this is a compact square: state
+ * pill, name, recorded time, and the handful of at-a-glance warnings. Anything
+ * deeper lives one click away in the drilldown modal. */
+const MonitorTile = ({
 	conversation,
 	highlighted,
 	onLockedClick,
 	onEdit,
-	viewMode = "detailed",
 }: {
 	conversation: MonitorConversation;
 	highlighted?: boolean;
 	onLockedClick?: () => void;
 	onEdit?: () => void;
-	viewMode?: "detailed" | "compressed";
 }) => {
 	const label = conversation.label?.trim() || t`Anonymous participant`;
 	const weakNetwork = isWeakNetwork(conversation);
 	const lowBattery = isLowBattery(conversation);
 	const isLocked = conversation.locked;
-	// Locked rows open the upgrade modal; unlocked rows open the edit modal.
+	// Locked tiles open the upgrade modal; unlocked tiles open the edit modal.
 	const clickable = isLocked || !!onEdit;
 
-	const card =
-		viewMode === "compressed" ? (
-			<Card
-				withBorder
-				p="xs"
-				radius="sm"
-				className={`transition-colors h-full ${clickable ? "hover:!border-primary-400 cursor-pointer" : ""} ${highlighted ? "!border-primary-500 ring-2 ring-primary-200" : ""}`}
+	const card = (
+		<Card
+			withBorder
+			p="xs"
+			radius="sm"
+			className={`transition-colors h-full ${clickable ? "hover:!border-primary-400 cursor-pointer" : ""} ${highlighted ? "!border-primary-500 ring-2 ring-primary-200" : ""}`}
+		>
+			<Stack
+				gap={6}
+				justify="space-between"
+				style={{ height: "100%", minWidth: 0 }}
 			>
-				<Stack
-					gap={6}
-					justify="space-between"
-					style={{ height: "100%", minWidth: 0 }}
-				>
-					<Group justify="space-between" align="center" wrap="nowrap" gap={4}>
-						<StatePill state={conversation.state} />
-						<Group gap={4} align="center" wrap="nowrap">
-							{conversation.recording_health === "receiving" &&
-								typeof conversation.audio_level === "number" && (
-									<AudioLevelMeter level={conversation.audio_level} />
-								)}
-							{conversation.recording_health === "stalled" && (
-								<Tooltip
-									label={t`Audio was coming in but stopped — they may have lost connection or locked their phone.`}
-									multiline
-									maw={280}
-									withArrow
-								>
-									<span>
-										<WarningCircleIcon size={14} className="text-orange-500" />
-									</span>
-								</Tooltip>
+				<Group justify="space-between" align="center" wrap="nowrap" gap={4}>
+					<StatePill state={conversation.state} />
+					<Group gap={4} align="center" wrap="nowrap">
+						{conversation.recording_health === "receiving" &&
+							typeof conversation.audio_level === "number" && (
+								<AudioLevelMeter level={conversation.audio_level} />
 							)}
-							{conversation.recording_health === "backgrounded" && (
-								<Tooltip
-									label={t`Their screen is locked or the tab is hidden — recording pauses until they come back.`}
-									multiline
-									maw={280}
-									withArrow
-								>
-									<Text span size="xs" fw={600}>
-										{t`Away`}
-									</Text>
-								</Tooltip>
-							)}
-							{conversation.has_error && (
-								<Tooltip label={t`Error`} withArrow>
-									<span>
-										<WarningCircleIcon
-											size={14}
-											className="text-red-500 animate-pulse"
-										/>
-									</span>
-								</Tooltip>
-							)}
-						</Group>
+						{conversation.recording_health === "stalled" && (
+							<Tooltip
+								label={t`Audio was coming in but stopped. They may have lost connection or locked their phone.`}
+								multiline
+								maw={280}
+								withArrow
+							>
+								<span>
+									<WarningCircleIcon size={14} className="text-orange-500" />
+								</span>
+							</Tooltip>
+						)}
+						{conversation.recording_health === "backgrounded" && (
+							<Tooltip
+								label={t`Their screen is locked or the tab is hidden. Recording pauses until they come back.`}
+								multiline
+								maw={280}
+								withArrow
+							>
+								<Text span size="xs" fw={600}>
+									{t`Away`}
+								</Text>
+							</Tooltip>
+						)}
+						{conversation.has_error && (
+							<Tooltip label={t`Error`} withArrow>
+								<span>
+									<WarningCircleIcon
+										size={14}
+										className="text-red-500 animate-pulse"
+									/>
+								</span>
+							</Tooltip>
+						)}
 					</Group>
+				</Group>
 
-					<Text size="sm" fw={600} truncate title={label}>
-						{label}
-					</Text>
+				<Text size="sm" fw={600} truncate title={label}>
+					{label}
+				</Text>
 
-					<Group justify="space-between" align="center" wrap="nowrap" gap={4}>
-						<LiveDuration conversation={conversation} />
-						<Group gap={4} align="center" wrap="nowrap">
-							{weakNetwork && (
-								<Tooltip label={t`Weak network`} withArrow>
-									<WifiSlashIcon size={14} className="text-orange-500" />
-								</Tooltip>
-							)}
-							{lowBattery && (
-								<Tooltip label={t`Low battery`} withArrow>
-									<BatteryLowIcon size={14} className="text-orange-500" />
-								</Tooltip>
-							)}
-						</Group>
+				<Group justify="space-between" align="center" wrap="nowrap" gap={4}>
+					<LiveDuration conversation={conversation} />
+					<Group gap={4} align="center" wrap="nowrap">
+						{weakNetwork && (
+							<Tooltip label={t`Weak network`} withArrow>
+								<WifiSlashIcon size={14} className="text-orange-500" />
+							</Tooltip>
+						)}
+						{lowBattery && (
+							<Tooltip label={t`Low battery`} withArrow>
+								<BatteryLowIcon size={14} className="text-orange-500" />
+							</Tooltip>
+						)}
 					</Group>
-				</Stack>
-			</Card>
-		) : (
-			<Card
-				withBorder
-				p="sm"
-				radius="sm"
-				className={`transition-colors ${clickable ? "hover:!border-primary-400 cursor-pointer" : ""} ${highlighted ? "!border-primary-500 ring-2 ring-primary-200" : ""}`}
-			>
-				<Stack gap={8}>
-					<Group justify="space-between" align="center" wrap="nowrap">
-						<Group gap="xs" align="center" style={{ minWidth: 0 }}>
-							<StatePill state={conversation.state} />
-							<Text size="sm" fw={500} truncate>
-								{label}
-							</Text>
-							{!isLocked && onEdit && (
-								<Tooltip label={t`Edit`} withArrow>
-									{/* Visual affordance only; the tile is the accessible
-								    control, and clicks here bubble to it. */}
-									<ActionIcon
-										component="div"
-										variant="subtle"
-										color="gray"
-										size="sm"
-										ml="xs"
-										aria-hidden
-										tabIndex={-1}
-										data-testid="monitor-row-edit"
-									>
-										<PencilSimpleIcon size={14} color="var(--app-text)" />
-									</ActionIcon>
-								</Tooltip>
-							)}
-						</Group>
-						<Group gap={6} align="center" wrap="nowrap">
-							{conversation.recording_health === "receiving" &&
-								typeof conversation.audio_level === "number" && (
-									<AudioLevelMeter level={conversation.audio_level} />
-								)}
-							{conversation.recording_health === "stalled" && (
-								<Tooltip
-									label={t`Audio was coming in but stopped — they may have lost connection or locked their phone.`}
-									multiline
-									maw={280}
-									withArrow
-								>
-									<MonitorBadge
-										size="xs"
-										color="orange"
-										variant="filled"
-										leftSection={<WarningCircleIcon size={12} />}
-									>
-										<Trans>Audio stopped?</Trans>
-									</MonitorBadge>
-								</Tooltip>
-							)}
-							{conversation.recording_health === "backgrounded" && (
-								<Tooltip
-									label={t`Their screen is locked or the tab is hidden — recording pauses until they come back.`}
-									multiline
-									maw={280}
-									withArrow
-								>
-									<MonitorBadge size="xs" color="gray" variant="light">
-										<Trans>Screen locked</Trans>
-									</MonitorBadge>
-								</Tooltip>
-							)}
-							{conversation.language && (
-								<MonitorBadge
-									size="xs"
-									color="gray"
-									variant="light"
-									tt="uppercase"
-								>
-									{conversation.language}
-								</MonitorBadge>
-							)}
-							{weakNetwork && (
-								<Tooltip label={t`Weak network`} withArrow>
-									<WifiSlashIcon size={15} className="text-orange-500" />
-								</Tooltip>
-							)}
-							{lowBattery && (
-								<Tooltip label={t`Low battery`} withArrow>
-									<BatteryLowIcon size={16} className="text-orange-500" />
-								</Tooltip>
-							)}
-							<TranscriptionBadge conversation={conversation} />
-							{conversation.has_error && (
-								<MonitorBadge
-									size="xs"
-									color="red"
-									variant="filled"
-									leftSection={<WarningCircleIcon size={12} />}
-								>
-									<Trans>Error</Trans>
-								</MonitorBadge>
-							)}
-						</Group>
-					</Group>
+				</Group>
+			</Stack>
+		</Card>
+	);
 
-					{isLocked ? (
-						<LockedTranscriptOverlay compact variant="transcript" />
-					) : (
-						conversation.latest_transcript && (
-							<FadingTranscript text={conversation.latest_transcript} />
-						)
-					)}
+	// The wrapper is the grid item, so it must carry the height for the card's
+	// h-full to resolve against, else the squares come out ragged.
 
-					<Group gap="md" align="center">
-						<Text size="xs">
-							<Trans>Last activity {lastActivityLabel(conversation)}</Trans>
-						</Text>
-						<LiveDuration conversation={conversation} />
-					</Group>
-
-					{conversation.has_error && (
-						<Text size="xs" c="red.7">
-							<Trans>
-								Some of the recent audio couldn't be transcribed. The recording
-								is saved.
-							</Trans>
-						</Text>
-					)}
-				</Stack>
-			</Card>
-		);
-
-	// In the grid the wrapper is the grid item, so it must carry the height for
-	// the card's h-full to resolve against, else the squares come out ragged.
-	const wrapperClass = viewMode === "compressed" ? "block h-full" : "block";
-
-	// Locked rows open the upgrade modal instead of the (also-gated) detail view.
+	// Locked tiles open the upgrade modal instead of the (also-gated) detail view.
 	if (isLocked) {
 		return (
 			<Box
 				role="button"
 				tabIndex={0}
-				className={wrapperClass}
+				className="block h-full"
 				aria-label={t`Locked conversation, upgrade to view`}
 				onClick={onLockedClick}
 				onKeyDown={(event) => {
@@ -541,7 +330,7 @@ const MonitorRow = ({
 		<Box
 			role="button"
 			tabIndex={0}
-			className={wrapperClass}
+			className="block h-full"
 			aria-label={t`Open ${label}`}
 			onClick={onEdit}
 			onKeyDown={(event) => {
@@ -558,7 +347,7 @@ const MonitorRow = ({
 
 const UNTAGGED = "__untagged__";
 
-type TagGroup = {
+type MonitorGroup = {
 	key: string;
 	label: string;
 	items: MonitorConversation[];
@@ -572,12 +361,17 @@ const createdAtMs = (conversation: MonitorConversation): number => {
 	return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
 };
 
-const groupByTag = (conversations: MonitorConversation[]): TagGroup[] => {
-	const groups = new Map<string, TagGroup>();
+// Tiles are always ordered by created_at, never by anything that changes live,
+// so a tile holds its place inside its group as its state changes.
+const sortItems = (items: MonitorConversation[]): MonitorConversation[] =>
+	[...items].sort((a, b) => createdAtMs(a) - createdAtMs(b));
+
+const groupByTag = (conversations: MonitorConversation[]): MonitorGroup[] => {
+	const groups = new Map<string, MonitorGroup>();
 	const order: string[] = [];
 	for (const conversation of conversations) {
 		// A conversation lives under its first tag (or an Untagged bucket), so
-		// each row appears once. Grouping keeps a busy project scannable.
+		// each tile appears once. Grouping keeps a busy project scannable.
 		const tag = conversation.tags[0]?.trim() || UNTAGGED;
 		let group = groups.get(tag);
 		if (!group) {
@@ -593,15 +387,14 @@ const groupByTag = (conversations: MonitorConversation[]): TagGroup[] => {
 		group.items.push(conversation);
 		if (conversation.is_live) group.liveCount += 1;
 	}
-	// Sort rows by created_at so they hold their place as state changes.
 	for (const group of groups.values()) {
-		group.items.sort((a, b) => createdAtMs(a) - createdAtMs(b));
+		group.items = sortItems(group.items);
 	}
 	// Group order by first-seen; Untagged sinks to the end.
-	const firstSeen = (group: TagGroup): number =>
+	const firstSeen = (group: MonitorGroup): number =>
 		group.items.length ? createdAtMs(group.items[0]) : Number.POSITIVE_INFINITY;
 	return order
-		.map((tag) => groups.get(tag) as TagGroup)
+		.map((tag) => groups.get(tag) as MonitorGroup)
 		.sort((a, b) => {
 			if ((a.key === UNTAGGED) !== (b.key === UNTAGGED)) {
 				return a.key === UNTAGGED ? 1 : -1;
@@ -610,18 +403,95 @@ const groupByTag = (conversations: MonitorConversation[]): TagGroup[] => {
 		});
 };
 
-const TagGroupSection = ({
+/** Group by status, using the settled status per conversation so a one-second
+ * blip doesn't throw a tile across the page. Section order is the fixed
+ * STATUS_GROUP_ORDER, never count-driven, so the sections themselves never
+ * reshuffle underneath the host. */
+export const groupByStatus = (
+	conversations: MonitorConversation[],
+	statusOf: (conversation: MonitorConversation) => MonitorStatusGroup,
+): MonitorGroup[] => {
+	const buckets = new Map<MonitorStatusGroup, MonitorConversation[]>();
+	for (const conversation of conversations) {
+		const status = statusOf(conversation);
+		const bucket = buckets.get(status);
+		if (bucket) bucket.push(conversation);
+		else buckets.set(status, [conversation]);
+	}
+	return STATUS_GROUP_ORDER.filter((status) => buckets.get(status)?.length).map(
+		(status) => {
+			const items = sortItems(buckets.get(status) ?? []);
+			return {
+				items,
+				key: status,
+				label: statusGroupLabel(status),
+				liveCount: items.filter((conversation) => conversation.is_live).length,
+			};
+		},
+	);
+};
+
+/** True when two id -> group maps would render identically. */
+const sameGroups = (
+	a: ReadonlyMap<string, MonitorStatusGroup>,
+	b: ReadonlyMap<string, MonitorStatusGroup>,
+): boolean => {
+	if (a.size !== b.size) return false;
+	for (const [id, group] of a) if (b.get(id) !== group) return false;
+	return true;
+};
+
+/** Committed status per conversation. The settle clock lives in a ref, so only
+ * a status that actually changes group triggers a re-render. */
+const useSettledStatuses = (
+	conversations: MonitorConversation[],
+	enabled: boolean,
+): ReadonlyMap<string, MonitorStatusGroup> => {
+	const settledRef = useRef<Map<string, SettledStatus>>(new Map());
+	const conversationsRef = useRef(conversations);
+	const [groups, setGroups] = useState<ReadonlyMap<string, MonitorStatusGroup>>(
+		new Map(),
+	);
+
+	const tick = useCallback(() => {
+		settledRef.current = settleStatusGroups(
+			settledRef.current,
+			conversationsRef.current,
+			Date.now(),
+		);
+		const next = new Map<string, MonitorStatusGroup>();
+		for (const [id, settled] of settledRef.current) next.set(id, settled.group);
+		setGroups((previous) => (sameGroups(previous, next) ? previous : next));
+	}, []);
+
+	// Re-settle as soon as a new snapshot lands.
+	useEffect(() => {
+		conversationsRef.current = conversations;
+		if (enabled) tick();
+	}, [conversations, enabled, tick]);
+
+	// A slow clock so a pending change still matures when the snapshot stream
+	// goes quiet. Kept separate from the snapshot effect so a busy stream can't
+	// restart the interval faster than it fires.
+	useEffect(() => {
+		if (!enabled) return;
+		const id = setInterval(tick, SETTLE_TICK_MS);
+		return () => clearInterval(id);
+	}, [enabled, tick]);
+
+	return groups;
+};
+
+const MonitorGroupSection = ({
 	group,
 	highlightedConversationId,
 	onLockedClick,
 	onEdit,
-	viewMode = "detailed",
 }: {
-	group: TagGroup;
+	group: MonitorGroup;
 	highlightedConversationId?: string | null;
 	onLockedClick?: (conversation: MonitorConversation) => void;
 	onEdit?: (conversation: MonitorConversation) => void;
-	viewMode?: "detailed" | "compressed";
 }) => {
 	const [opened, { toggle }] = useDisclosure(true);
 	const [expanded, setExpanded] = useState(false);
@@ -661,78 +531,45 @@ const TagGroupSection = ({
 				</Text>
 				<Text size="xs">{group.items.length}</Text>
 				{group.liveCount > 0 && (
-					<MonitorBadge size="xs" color="primary" variant="light">
+					<MonitorBadge size="xs" color="gray" variant="outline">
 						<Plural value={group.liveCount} one="# live" other="# live" />
 					</MonitorBadge>
 				)}
 			</Group>
 			<Collapse in={opened}>
-				{viewMode === "compressed" ? (
-					<Stack gap="xs">
-						<SimpleGrid
-							cols={{ base: 2, sm: 3, md: 4, lg: 5, xl: 6 }}
-							spacing="xs"
-						>
-							{visible.map((conversation) => (
-								<MonitorRow
-									key={conversation.id}
-									conversation={conversation}
-									viewMode="compressed"
-									highlighted={conversation.id === highlightedConversationId}
-									onLockedClick={() => onLockedClick?.(conversation)}
-									onEdit={onEdit ? () => onEdit(conversation) : undefined}
-								/>
-							))}
-						</SimpleGrid>
-						{overflow > 0 && (
-							<Text
-								size="xs"
-								role="button"
-								tabIndex={0}
-								className="cursor-pointer select-none pl-1 hover:underline"
-								onClick={() => setExpanded(true)}
-								onKeyDown={(event) => {
-									if (event.key === "Enter" || event.key === " ") {
-										if (event.key === " ") event.preventDefault();
-										setExpanded(true);
-									}
-								}}
-							>
-								<Trans>Show {overflow} more</Trans>
-							</Text>
-						)}
-					</Stack>
-				) : (
-					<Stack gap="xs">
+				<Stack gap="xs">
+					<SimpleGrid
+						cols={{ base: 2, sm: 3, md: 4, lg: 5, xl: 6 }}
+						spacing="xs"
+					>
 						{visible.map((conversation) => (
-							<MonitorRow
+							<MonitorTile
 								key={conversation.id}
 								conversation={conversation}
-								viewMode="detailed"
 								highlighted={conversation.id === highlightedConversationId}
 								onLockedClick={() => onLockedClick?.(conversation)}
 								onEdit={onEdit ? () => onEdit(conversation) : undefined}
 							/>
 						))}
-						{overflow > 0 && (
-							<Text
-								size="xs"
-								role="button"
-								tabIndex={0}
-								className="cursor-pointer select-none pl-1 hover:underline"
-								onClick={() => setExpanded(true)}
-								onKeyDown={(event) => {
-									if (event.key === "Enter" || event.key === " ") {
-										if (event.key === " ") event.preventDefault();
-										setExpanded(true);
-									}
-								}}
-							>
-								<Trans>Show {overflow} more</Trans>
-							</Text>
-						)}
-					</Stack>
-				)}
+					</SimpleGrid>
+					{overflow > 0 && (
+						<Text
+							size="xs"
+							role="button"
+							tabIndex={0}
+							className="cursor-pointer select-none pl-1 hover:underline"
+							onClick={() => setExpanded(true)}
+							onKeyDown={(event) => {
+								if (event.key === "Enter" || event.key === " ") {
+									if (event.key === " ") event.preventDefault();
+									setExpanded(true);
+								}
+							}}
+						>
+							<Trans>Show {overflow} more</Trans>
+						</Text>
+					)}
+				</Stack>
 			</Collapse>
 		</Stack>
 	);
@@ -748,7 +585,7 @@ export const LiveMonitorSection = ({
 	/** On the dedicated Monitor page, show an empty state instead of
 	 * collapsing to nothing when there is no recent activity. */
 	standalone?: boolean;
-	/** Row to highlight (hovered from the funnel above). */
+	/** Tile to highlight (hovered from the funnel above). */
 	highlightedConversationId?: string | null;
 	/** Suppress the internal "Live monitoring" header + chips (when embedded
 	 * under a shared section header, e.g. the project home). */
@@ -758,81 +595,45 @@ export const LiveMonitorSection = ({
 	const { workspace } = useWorkspace();
 	const [upgradeOpened, upgradeHandlers] = useDisclosure(false);
 	// Drilldown selection by id, so the open modal keeps reading fresh snapshots
-	// (and closes on its own once the row is deleted / ages out).
+	// (and closes on its own once the tile is deleted / ages out).
 	const [selectedId, setSelectedId] = useState<string | null>(null);
 
-	const [viewMode, setViewMode] = useState<ViewMode>(() => {
-		try {
-			const saved = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
-			return saved === "compressed" || saved === "detailed"
-				? saved
-				: "detailed";
-		} catch {
-			// Private mode / blocked storage: fall back to the calm default.
-			return "detailed";
-		}
-	});
-
-	const handleViewModeChange = (value: string) => {
-		if (value !== "compressed" && value !== "detailed") return;
-		setViewMode(value);
-		try {
-			localStorage.setItem(VIEW_MODE_STORAGE_KEY, value);
-		} catch {
-			// Preference just won't persist; not worth surfacing.
-		}
-	};
-
-	const [activeFilter, setActiveFilter] = useState<MonitorFilter | null>(null);
+	const [groupBy, setGroupBy] = useState<GroupBy>("tag");
 
 	const { conversations, summary, isLoading, error, isStreaming } =
 		useConversationMonitor(projectId);
 
-	const filteredConversations = useMemo(() => {
-		if (!activeFilter) return conversations;
-		return conversations.filter(FILTER_PREDICATES[activeFilter]);
-	}, [conversations, activeFilter]);
-
-	const groups = useMemo(
-		() => groupByTag(filteredConversations),
-		[filteredConversations],
+	const settledStatuses = useSettledStatuses(
+		conversations,
+		groupBy === "status",
 	);
+
+	const groups = useMemo(() => {
+		if (groupBy === "tag") return groupByTag(conversations);
+		return groupByStatus(
+			conversations,
+			// Fall back to the raw status for a conversation the settle clock has
+			// not seen yet (first frame after it appears).
+			(conversation) =>
+				settledStatuses.get(conversation.id) ??
+				monitorStatusGroup(conversation),
+		);
+	}, [conversations, groupBy, settledStatuses]);
+
 	const selected =
 		conversations.find((conversation) => conversation.id === selectedId) ??
 		null;
-	// Rows link to the conversation detail page when we know the workspace.
+	// Tiles link to the conversation detail page when we know the workspace.
 	const base =
 		workspaceId && projectId ? `/w/${workspaceId}/projects/${projectId}` : null;
 
-	const toggleFilter = (filter: MonitorFilter) =>
-		setActiveFilter((current) => (current === filter ? null : filter));
-
-	// Shared across the summary badges: click, keyboard, and the dim-the-rest
-	// treatment all live here so a new badge can't forget them.
-	const filterProps = (filter: MonitorFilter) => ({
-		role: "button",
-		tabIndex: 0,
-		"aria-pressed": activeFilter === filter,
-		style: {
-			cursor: "pointer",
-			transition: "opacity 0.2s",
-			opacity: activeFilter && activeFilter !== filter ? 0.4 : 1,
-		},
-		onClick: () => toggleFilter(filter),
-		onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
-			if (event.key === "Enter" || event.key === " ") {
-				event.preventDefault();
-				toggleFilter(filter);
-			}
-		},
-	});
-
-	const filterLabels: Record<MonitorFilter, string> = {
-		live: t`Live`,
-		offline: t`Offline`,
-		not_receiving: t`Audio stopped`,
-		transcribing: t`Transcribing`,
-		with_errors: t`With errors`,
+	const handleGroupByChange = (value: string) => {
+		if (value !== "tag" && value !== "status") return;
+		setGroupBy(value);
+		posthog.capture("monitor_grouping_changed", {
+			group_by: value,
+			project_id: projectId,
+		});
 	};
 
 	// First load: spinner on the dedicated page, nothing when embedded (no flicker).
@@ -899,32 +700,28 @@ export const LiveMonitorSection = ({
 						<Group gap="xs" align="center">
 							<SegmentedControl
 								size="xs"
-								value={viewMode}
-								onChange={handleViewModeChange}
+								value={groupBy}
+								onChange={handleGroupByChange}
+								aria-label={t`Group by`}
 								data={[
-									{ label: t`Detailed`, value: "detailed" },
-									{ label: t`Compressed`, value: "compressed" },
+									{ label: t`By tag`, value: "tag" },
+									{ label: t`By status`, value: "status" },
 								]}
 								mr="xs"
 							/>
 
+							{/* Informational only. All of these read the same: grey border,
+							    charcoal text, matching the "catch up" tag. */}
 							<Group gap="xs" align="center">
-								<MonitorBadge
-									size="sm"
-									color="primary"
-									variant={activeFilter === "live" ? "filled" : "light"}
-									{...filterProps("live")}
-								>
+								<MonitorBadge size="sm" color="gray" variant="outline">
 									<Plural value={summary.live} one="# live" other="# live" />
 								</MonitorBadge>
 								{summary.offline > 0 && (
 									<MonitorBadge
 										size="sm"
-										color="mauve"
-										variant="filled"
-										styles={{ section: { color: "var(--app-text)" } }}
+										color="gray"
+										variant="outline"
 										leftSection={<WifiSlashIcon size={12} />}
-										{...filterProps("offline")}
 									>
 										<Plural
 											value={summary.offline}
@@ -936,10 +733,9 @@ export const LiveMonitorSection = ({
 								{summary.not_receiving > 0 && (
 									<MonitorBadge
 										size="sm"
-										color="orange"
-										variant="filled"
+										color="gray"
+										variant="outline"
 										leftSection={<WarningCircleIcon size={12} />}
-										{...filterProps("not_receiving")}
 									>
 										<Plural
 											value={summary.not_receiving}
@@ -949,14 +745,7 @@ export const LiveMonitorSection = ({
 									</MonitorBadge>
 								)}
 								{summary.transcribing > 0 && (
-									<MonitorBadge
-										size="sm"
-										color="primary"
-										variant={
-											activeFilter === "transcribing" ? "filled" : "light"
-										}
-										{...filterProps("transcribing")}
-									>
+									<MonitorBadge size="sm" color="gray" variant="outline">
 										<Plural
 											value={summary.transcribing}
 											one="# transcribing"
@@ -967,11 +756,9 @@ export const LiveMonitorSection = ({
 								{summary.with_errors > 0 && (
 									<MonitorBadge
 										size="sm"
-										color="red"
-										variant={
-											activeFilter === "with_errors" ? "filled" : "light"
-										}
-										{...filterProps("with_errors")}
+										color="gray"
+										variant="outline"
+										leftSection={<WarningCircleIcon size={12} />}
 									>
 										<Plural
 											value={summary.with_errors}
@@ -1014,81 +801,28 @@ export const LiveMonitorSection = ({
 					</Group>
 				)}
 
-				{activeFilter && (
-					<Card withBorder p="xs" px="sm" radius="sm">
-						<Group justify="space-between" gap="xs">
-							<Text size="xs">
-								<Trans>Filtering by {filterLabels[activeFilter]}</Trans>
-							</Text>
-							<Text
-								size="xs"
-								c="primary"
-								role="button"
-								tabIndex={0}
-								className="cursor-pointer hover:underline"
-								onClick={() => setActiveFilter(null)}
-								onKeyDown={(event) => {
-									if (event.key === "Enter" || event.key === " ") {
-										event.preventDefault();
-										setActiveFilter(null);
-									}
-								}}
-							>
-								<Trans>Clear filter</Trans>
-							</Text>
-						</Group>
-					</Card>
-				)}
-
-				{groups.length === 0 ? (
-					<Card withBorder p="lg" radius="sm">
-						<Stack gap="xs" align="center" py="md">
-							<Text size="sm" fw={500} ta="center">
-								<Trans>No conversations match this filter</Trans>
-							</Text>
-							<Text
-								size="xs"
-								c="primary"
-								role="button"
-								tabIndex={0}
-								className="cursor-pointer hover:underline"
-								onClick={() => setActiveFilter(null)}
-								onKeyDown={(event) => {
-									if (event.key === "Enter" || event.key === " ") {
-										event.preventDefault();
-										setActiveFilter(null);
-									}
-								}}
-							>
-								<Trans>Clear filter</Trans>
-							</Text>
-						</Stack>
-					</Card>
-				) : (
-					groups.map((group) => (
-						<TagGroupSection
-							key={group.key}
-							group={group}
-							viewMode={viewMode}
-							highlightedConversationId={highlightedConversationId}
-							onLockedClick={(conversation) => {
-								posthog.capture("monitor_locked_row_clicked", {
-									conversation_id: conversation.id,
-									project_id: projectId,
-								});
-								upgradeHandlers.open();
-							}}
-							onEdit={(conversation) => {
-								posthog.capture("monitor_drilldown_opened", {
-									entity_type: "recording",
-									project_id: projectId,
-									stage_or_state: conversation.state,
-								});
-								setSelectedId(conversation.id);
-							}}
-						/>
-					))
-				)}
+				{groups.map((group) => (
+					<MonitorGroupSection
+						key={group.key}
+						group={group}
+						highlightedConversationId={highlightedConversationId}
+						onLockedClick={(conversation) => {
+							posthog.capture("monitor_locked_row_clicked", {
+								conversation_id: conversation.id,
+								project_id: projectId,
+							});
+							upgradeHandlers.open();
+						}}
+						onEdit={(conversation) => {
+							posthog.capture("monitor_drilldown_opened", {
+								entity_type: "recording",
+								project_id: projectId,
+								stage_or_state: conversation.state,
+							});
+							setSelectedId(conversation.id);
+						}}
+					/>
+				))}
 			</Stack>
 			<ConversationDrilldownModal
 				conversation={selected}

--- a/echo/frontend/src/components/conversation/MonitorBadge.tsx
+++ b/echo/frontend/src/components/conversation/MonitorBadge.tsx
@@ -1,11 +1,11 @@
 import { Badge, type BadgeProps, type ElementProps } from "@mantine/core";
 
-/** A monitor status tag: keeps its color as the background/dot but renders the
- * label in graphite (app text), on-brand instead of a saturated tint.
+/** A monitor status tag. Label and any left icon render in graphite (app text)
+ * rather than a saturated tint, so every informational tag on the monitor reads
+ * the same: grey border, charcoal text.
  *
  * Mantine's Badge is polymorphic and forwards unknown props to its root, so the
- * wrapper takes the div element props too. Without them a caller can't attach
- * onClick / keyboard handlers, which is what the filterable badges need. */
+ * wrapper takes the div element props too. */
 export const MonitorBadge = ({
 	styles,
 	...props
@@ -13,10 +13,16 @@ export const MonitorBadge = ({
 	const base = typeof styles === "object" && styles ? styles : {};
 	const label =
 		"label" in base ? (base as { label?: object }).label : undefined;
+	const section =
+		"section" in base ? (base as { section?: object }).section : undefined;
 	return (
 		<Badge
 			{...props}
-			styles={{ ...base, label: { color: "var(--app-text)", ...label } }}
+			styles={{
+				...base,
+				label: { color: "var(--app-text)", ...label },
+				section: { color: "var(--app-text)", ...section },
+			}}
 		/>
 	);
 };

--- a/echo/frontend/src/components/conversation/StatePill.tsx
+++ b/echo/frontend/src/components/conversation/StatePill.tsx
@@ -29,17 +29,22 @@ const stateMeta = (state: ParticipantState): StateMeta => {
 			return { color: "primary", label: t`Finishing` };
 		case "finished":
 			return { color: "primary", label: t`Finished` };
+		// On the recording page but not capturing yet. Grey: nothing to act on.
 		case "waiting":
-			return { color: "gray", label: t`Waiting` };
+			return { color: "gray", label: t`On recording page` };
 		case "initiated":
 			return { color: "gray", label: t`Just started` };
 		// Solid fill so offline stands out (mauve's light tint is near-white).
 		case "offline":
 			return { color: "mauve", label: t`Offline`, variant: "filled" };
+		// left / backgrounded (away) join paused on yellow: the participant
+		// reached the recording page but audio is not flowing, so a host may want
+		// to walk over. This follows the existing `paused` treatment rather than
+		// introducing a new colour; accents stay decorative everywhere else.
 		case "left":
-			return { color: "gray", label: t`Left` };
+			return { color: "yellow", label: t`Left` };
 		case "backgrounded":
-			return { color: "gray", label: t`Away` };
+			return { color: "yellow", label: t`Away` };
 		default:
 			return { color: "gray", label: t`Idle` };
 	}

--- a/echo/frontend/src/components/conversation/monitorGrouping.ts
+++ b/echo/frontend/src/components/conversation/monitorGrouping.ts
@@ -14,23 +14,33 @@ export type MonitorStatusGroup =
 	| "offline"
 	| "finished";
 
-/** States that mean "the participant reached the recording page but audio is
- * not flowing right now": waiting to start, paused, screen locked (away), or
- * the tab closed without finishing. They sit apart from the active `live`
- * column so a host can see at a glance who might need a nudge. */
+/** States that mean "the participant is on the recording page right now, but
+ * audio is not flowing": waiting to start, paused, or screen locked (away).
+ * They sit apart from the active `live` column so a host can see at a glance
+ * who might need a nudge.
+ *
+ * `left` is deliberately not here. It means the tab was closed or the page was
+ * navigated away from without finishing, which is terminal: that participant is
+ * not still sitting on the recording page. It groups under `finished` instead,
+ * so a host can see how many sessions ended cleanly next to how many just
+ * stopped, without either being implied to be still present or hidden. */
 const RECORDING_PAGE_STATES: ReadonlySet<ParticipantState> = new Set([
 	"waiting",
 	"initiated",
 	"idle",
 	"paused",
 	"backgrounded",
-	"left",
 ]);
 
 export const monitorStatusGroup = (
 	conversation: MonitorConversation,
 ): MonitorStatusGroup => {
-	if (conversation.is_finished || conversation.state === "finished") {
+	if (
+		conversation.is_finished ||
+		conversation.state === "finished" ||
+		// Ended without finishing. A different outcome, but the same ending.
+		conversation.state === "left"
+	) {
 		return "finished";
 	}
 	// Contact lost mid-recording. The alarm, and its own bucket.
@@ -43,10 +53,15 @@ export const monitorStatusGroup = (
 };
 
 /** Fixed order. Group order never depends on counts or on live state, so the
- * sections themselves hold their place while conversations move between them. */
+ * sections themselves hold their place while conversations move between them.
+ *
+ * This follows the funnel's left-to-right progression (recording page -> live
+ * -> finished) so the grid below never contradicts the funnel above. `offline`
+ * has no funnel column of its own; it sits after `live` because that is what an
+ * offline session was a moment ago. */
 export const STATUS_GROUP_ORDER: MonitorStatusGroup[] = [
-	"live",
 	"recording_page",
+	"live",
 	"offline",
 	"finished",
 ];
@@ -64,13 +79,18 @@ export const statusGroupLabel = (group: MonitorStatusGroup): string => {
 	}
 };
 
-/** The two conversation columns of the live funnel. Finished and offline
- * conversations stay out of the funnel, same as before. */
+/** The three conversation columns of the live funnel: on the recording page,
+ * live, then finished. Offline is the one status with no column of its own; a
+ * dropped connection is not a stage of the journey, and it is already loud in
+ * the summary badges and the state pill. */
 export const isOnRecordingPage = (conversation: MonitorConversation): boolean =>
 	monitorStatusGroup(conversation) === "recording_page";
 
 export const isLiveRecording = (conversation: MonitorConversation): boolean =>
 	monitorStatusGroup(conversation) === "live";
+
+export const isFinishedSession = (conversation: MonitorConversation): boolean =>
+	monitorStatusGroup(conversation) === "finished";
 
 // ── Settling ──────────────────────────────────────────────────────────────
 //

--- a/echo/frontend/src/components/conversation/monitorGrouping.ts
+++ b/echo/frontend/src/components/conversation/monitorGrouping.ts
@@ -1,0 +1,135 @@
+import { t } from "@lingui/core/macro";
+
+import type {
+	MonitorConversation,
+	ParticipantState,
+} from "@/hooks/useConversationMonitor";
+
+/** The host-facing buckets a conversation can sit in. These drive both the
+ * funnel columns and the "group by status" dimension in the monitor grid, so a
+ * column count and the rows under it can't disagree. */
+export type MonitorStatusGroup =
+	| "live"
+	| "recording_page"
+	| "offline"
+	| "finished";
+
+/** States that mean "the participant reached the recording page but audio is
+ * not flowing right now": waiting to start, paused, screen locked (away), or
+ * the tab closed without finishing. They sit apart from the active `live`
+ * column so a host can see at a glance who might need a nudge. */
+const RECORDING_PAGE_STATES: ReadonlySet<ParticipantState> = new Set([
+	"waiting",
+	"initiated",
+	"idle",
+	"paused",
+	"backgrounded",
+	"left",
+]);
+
+export const monitorStatusGroup = (
+	conversation: MonitorConversation,
+): MonitorStatusGroup => {
+	if (conversation.is_finished || conversation.state === "finished") {
+		return "finished";
+	}
+	// Contact lost mid-recording. The alarm, and its own bucket.
+	if (conversation.state === "offline") return "offline";
+	if (RECORDING_PAGE_STATES.has(conversation.state)) return "recording_page";
+	if (conversation.is_live) return "live";
+	// Not live, not finished, not offline: treat as still on the page rather
+	// than claiming it is recording.
+	return "recording_page";
+};
+
+/** Fixed order. Group order never depends on counts or on live state, so the
+ * sections themselves hold their place while conversations move between them. */
+export const STATUS_GROUP_ORDER: MonitorStatusGroup[] = [
+	"live",
+	"recording_page",
+	"offline",
+	"finished",
+];
+
+export const statusGroupLabel = (group: MonitorStatusGroup): string => {
+	switch (group) {
+		case "live":
+			return t`Live`;
+		case "recording_page":
+			return t`On recording page`;
+		case "offline":
+			return t`Offline`;
+		default:
+			return t`Finished`;
+	}
+};
+
+/** The two conversation columns of the live funnel. Finished and offline
+ * conversations stay out of the funnel, same as before. */
+export const isOnRecordingPage = (conversation: MonitorConversation): boolean =>
+	monitorStatusGroup(conversation) === "recording_page";
+
+export const isLiveRecording = (conversation: MonitorConversation): boolean =>
+	monitorStatusGroup(conversation) === "live";
+
+// ── Settling ──────────────────────────────────────────────────────────────
+//
+// Status is live data, so grouping by it would otherwise let a card jump to
+// another section on every transient blip (a pause that lasts a second, a
+// screen that locks while someone reads a notification). We commit a status
+// change only once the new status has held for SETTLE_MS, so the grid moves
+// when something really changed and stays put when it didn't.
+
+export const STATUS_SETTLE_MS = 4000;
+
+export type SettledStatus = {
+	/** The group the card is rendered under right now. */
+	group: MonitorStatusGroup;
+	/** A different group observed but not yet committed. */
+	pending: MonitorStatusGroup | null;
+	/** When `pending` was first observed (epoch ms). */
+	since: number;
+};
+
+export type SettledStatusMap = ReadonlyMap<string, SettledStatus>;
+
+/** Pure reducer: fold the latest snapshot into the committed status map.
+ * Conversations that dropped out of the snapshot are forgotten. */
+export const settleStatusGroups = (
+	previous: SettledStatusMap,
+	conversations: MonitorConversation[],
+	now: number,
+	delayMs: number = STATUS_SETTLE_MS,
+): Map<string, SettledStatus> => {
+	const next = new Map<string, SettledStatus>();
+	for (const conversation of conversations) {
+		const current = monitorStatusGroup(conversation);
+		const prior = previous.get(conversation.id);
+		// First sighting: adopt immediately, there is nothing to settle against.
+		if (!prior) {
+			next.set(conversation.id, { group: current, pending: null, since: now });
+			continue;
+		}
+		// Back to (or still on) the committed group: cancel any pending change.
+		if (prior.group === current) {
+			next.set(conversation.id, {
+				group: current,
+				pending: null,
+				since: prior.since,
+			});
+			continue;
+		}
+		// A different group, held long enough: commit it.
+		if (prior.pending === current && now - prior.since >= delayMs) {
+			next.set(conversation.id, { group: current, pending: null, since: now });
+			continue;
+		}
+		next.set(conversation.id, {
+			group: prior.group,
+			// Restart the clock when the observed group itself changes.
+			pending: current,
+			since: prior.pending === current ? prior.since : now,
+		});
+	}
+	return next;
+};


### PR DESCRIPTION
Closes ECHO-899.

## Two places I followed the recording over the ticket

The ticket text has two errors. Where it disagreed with the original conversation transcript, I followed the transcript.

1. **Column name.** The ticket says the new column is "on recording page". The transcript shows the call being made the other way: *"should we do on recording page or just recording page? Yeah, recording page is fine."* So the funnel column is **"recording page"**, and the per-conversation state text that used to read "waiting" becomes **"On recording page"**. Two different labels, deliberately.
2. **Scope of item 4.** The ticket says "remove the live button filter on transcripts". The transcript is about the badge click-to-filter that shipped in #902 on the Monitor page: *"if I click on the live button, it shows an ugly dark blue... All filters need to go."* The "ugly dark blue" is the `variant="filled"` active state on `MonitorBadge`. So the badge filtering is removed entirely and the badges are informational again. Nothing on the transcript view was touched.

## What changed

**1. State colours.** `StatePill.tsx:39-46`. `left` and `backgrounded` (away) move to yellow, matching `paused`, using the identical treatment rather than a new colour. `waiting` stays grey. The funnel dots follow (`FunnelCanvas.tsx:22,52`).

**2. Funnel columns.** `LiveFunnelSection.tsx:174-222,249-273`. "recording" is renamed "live", a "recording page" column is inserted before it, and a "finished" column closes the flow. Final order: **scanned -> setting up -> recording page -> live -> finished**. `FunnelCanvas` was hard-wired to three columns; it now takes an N-length `weights` array and each node carries its own `column` (`FunnelCanvas.tsx:68-72,111-125,162-182`). Confirmed: the fifth column needed no further rework, just a fifth weight and a `column: 4`.

I traced the stages server-side first. `conversations.py` computes `state`, `recording_health` and `is_live` per conversation, but `_FUNNEL_STAGES` (`conversations.py:1094`) covers visitor stages only. The conversation columns have always been derived in the frontend, so **no server change was needed** and there is no server test in this PR.

The grouping lives in one new pure module, `monitorGrouping.ts`, so the funnel columns and the status grouping below can't drift apart. "recording page" = `waiting`, `initiated`, `idle`, `paused`, `backgrounded`: on the page right now, audio not flowing. "live" = actually capturing. "finished" = `finished` **and `left`**.

**Why `left` sits under finished.** `left` means the tab was closed or the page was navigated away from without finishing. That is terminal, not someone still sitting on the recording page. Putting it under "recording page" would imply they are still there; excluding it from the funnel would hide sessions that ended badly. Under "finished" a host can see at a glance how many sessions ended cleanly versus how many just stopped. The column carries **one count**: the two outcomes are already distinguishable because each dot keeps its state-pill colour (`left` yellow, `finished` grey), which costs nothing extra (`FunnelCanvas.tsx:89-109`).

`offline` is the one status with no funnel column. A dropped connection is not a stage of the journey, and it is already loud in the summary badges and the state pill.

**Funnel and grid grouping are consistent.** `STATUS_GROUP_ORDER` is recording page -> live -> offline -> finished (`monitorGrouping.ts:62-67`), which matches the funnel's left-to-right progression over the three statuses they share. They cannot be *identical*: the funnel has `scanned` and `setting up` stages that come from visitor sessions and have no conversations to group, and the grid has an `offline` group with no funnel column. There is a test asserting the shared subset stays in funnel order.

**3. Grid-only.** `LiveMonitorSection.tsx`. The detailed view, the `SegmentedControl` toggle, the `viewMode` prop threading and the `echo_monitor_view_mode` localStorage key are all deleted. `MonitorRow` became `MonitorTile` (`LiveMonitorSection.tsx:200-320`) and keeps `role="button"`, `tabIndex={0}` and Enter/Space, so tiles still open the drilldown from the keyboard. There is a test for that.

**4. Grouping by status.** `LiveMonitorSection.tsx:352-380,394-434`. A "By tag / By status" control; tag remains the default.

On the rows-jumping concern from the recording (*"if we sort by status, then it can move around a lot"*), three mitigations:

- **Settling.** A status change is only committed once it has held for four seconds (`monitorGrouping.ts:78-136`). A one-second pause or a screen that locks while someone reads a notification never moves a tile. `settleStatusGroups` is a pure reducer, so it is unit-tested directly rather than through timers.
- **Fixed section order.** `STATUS_GROUP_ORDER` is live, recording page, offline, finished, always. Group order never depends on counts, so the sections themselves never reshuffle.
- **Stable order within a group.** Tiles sort by `created_at`, same as the tag grouping, never by anything live.

The settle clock lives in a ref and only re-renders when a tile actually changes group, so the one-second tick is free when nothing is moving.

**5. Tag styling.** `LiveMonitorSection.tsx:565-640`. `live`, `offline`, `audio stopped`, `transcribing`, `with errors` and the group-header `N live` badge all become `color="gray" variant="outline"`, exactly matching the `catch up` and `Reconnecting` tags. `MonitorBadge` now forces the left icon to charcoal as well as the label (`MonitorBadge.tsx:20-25`), so an icon can't reintroduce a saturated tint. Per the ticket, brand guidelines beat the earlier "grey background" feedback.

**6. PostHog.** One new event: `monitor_grouping_changed` with `group_by` (`LiveMonitorSection.tsx:496-502`). The two events proposed before this ticket are moot: there is no view toggle and there are no filters. Grid item opens were already covered by the existing `monitor_drilldown_opened`, which is unchanged.

## Tests

`corepack pnpm@10 vitest run`, before and after, on the same machine:

- Before: 7 files failed, 7 passed. 2 tests failed, 48 passed (50).
- After: 7 files failed, 7 passed. 2 tests failed, 62 passed (64).

The two failures and the seven failing files are pre-existing and untouched by this PR: the Playwright e2e specs get collected by vitest and throw, and `useChunkAnchorScroll.test.tsx` hits `ReferenceError: Element is not defined`.

`LiveMonitorSection.test.tsx` goes 17 -> 31 tests.

Deleted, because the feature is gone:
- `filters conversations list when badges are clicked, and clears filters properly`
- `filters from the keyboard, so badges are not mouse-only`
- `keeps the compressed grid toggle in localStorage`
- `opens the drilldown modal from the row pencil without navigating` (the pencil affordance only existed in the detailed view)

Added: the waiting pill label, the yellow/grey `stateColor` assertions, the status grouping helpers, four `settleStatusGroups` cases, "no view toggle and no view-mode preference written", "summary badges are informational, not filters", "regroups by status and reports the change once", and a keyboard replacement for the deleted pencil test.

Added in the follow-up commit: "groups left with finished, not with the recording page", "puts a cleanly finished session in the same group as left", and "orders grid groups the same way the funnel orders its columns". The recording-page case dropped `left`, the old "separates offline and finished from both funnel columns" case became "keeps offline out of every funnel column", and the two group-order assertions flipped to the new recording-page-first order.

Also green: `pnpm lint`, `pnpm build`, and `biome format` on every changed file.

## Translations

Per instruction I did **not** run `messages:extract` / `messages:compile` and did not touch `src/locales/`. New strings are wrapped in `t` / `Trans` for a later pass. Full list in the handover notes. The follow-up adds `Finished` (funnel column, already present as a status-group label) and rewords the canvas aria-label again to include the finished stage.

## Out of scope

The deleted-conversation recording bug (the `deleted_at` soft-delete check) is untouched. Usama has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
