### PR TITLE
chore: chat and related fixes

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -20,7 +20,6 @@ import {
 	UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { ChatCircleTextIcon } from "@phosphor-icons/react";
 import {
 	IconAlertCircle,
 	IconChevronDown,
@@ -40,12 +39,17 @@ import {
 } from "react";
 import { useLocation } from "react-router";
 import {
+	ChatComposerShell,
+	ConversationFocusChips,
+	ConversationPickerButton,
+} from "@/components/chat/ChatComposer";
+import {
 	useChatHistory,
 	useProjectChatContext,
 	useUpdateChatMutation,
 } from "@/components/chat/hooks";
-import { InsertTemplateMenu } from "@/components/chat/InsertTemplateMenu";
 import { consumeChatPrefill } from "@/components/chat/prefill";
+import { useStickToBottom } from "@/components/common/useStickToBottom";
 import { ConversationLinks } from "@/components/conversation/ConversationLinks";
 import {
 	useClearChatContextMutation,
@@ -54,8 +58,6 @@ import {
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { GoalSuggestionCard } from "@/components/goal/GoalSuggestionCard";
-import { useElementOnScreen } from "@/hooks/useElementOnScreen";
-import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
@@ -96,6 +98,7 @@ import {
 import { CanvasSuggestionCard } from "./CanvasSuggestionCard";
 import { ChatAccordionItemMenu } from "./ChatAccordion";
 import { ChatHistoryMessage } from "./ChatHistoryMessage";
+import { ChatTemplatesMenuConnected } from "./ChatTemplatesMenuConnected";
 import { CustomVerificationTopicSuggestionCard } from "./CustomVerificationTopicSuggestionCard";
 import { formatMessage } from "./chatUtils";
 import { ChatTurnLimitCard, ChatUpgradeModal } from "./FreeTierChatGate";
@@ -564,14 +567,14 @@ const ToolActivityGroup = ({
 					}
 					onClick={isSingle ? undefined : onToggle}
 				>
-					<Group justify="space-between" gap="xs" wrap="nowrap">
-						<Group gap={8} wrap="nowrap" className="min-w-0 flex-1">
+					<Group justify="flex-start" gap="lg" wrap="nowrap">
+						<Group gap={8} wrap="nowrap" className="min-w-0">
 							<Box
 								aria-hidden="true"
 								className={`h-1.5 w-1.5 shrink-0 rounded-full ${running ? "animate-pulse" : ""}`}
 								style={{ backgroundColor: dotColor }}
 							/>
-							<Text size="xs" fs="italic" className="min-w-0 flex-1 truncate">
+							<Text size="xs" fs="italic" className="min-w-0 truncate">
 								{summary}
 							</Text>
 						</Group>
@@ -616,7 +619,6 @@ export const AgenticChatPanel = ({
 	const { iso639_1, language } = useLanguage();
 	const { workspace, workspaceId } = useWorkspace();
 	const location = useLocation();
-	const navigate = useI18nNavigate();
 	// Seed question from the Ask home page (router state), consumed exactly once.
 	const initialMessageRef = useRef<string | null>(
 		typeof (location.state as { initialMessage?: unknown } | null)
@@ -665,11 +667,9 @@ export const AgenticChatPanel = ({
 	const stopArmedRunIdRef = useRef<string | null>(null);
 	const requestedStreamKeyRef = useRef<string | null>(null);
 	const currentRunIdRef = useRef<string | null>(null);
-	const [scrollTargetRef, isVisible] = useElementOnScreen({
-		root: null,
-		rootMargin: "-83px",
-		threshold: 0.1,
-	});
+	const threadScrollRef = useRef<HTMLDivElement>(null);
+	const { isAtBottomRef, scrollToBottom, showScrollButton } =
+		useStickToBottom(threadScrollRef);
 
 	useEffect(() => {
 		currentRunIdRef.current = runId;
@@ -1180,18 +1180,6 @@ export const AgenticChatPanel = ({
 		}
 	}, [runStatus, stopStream]);
 
-	const scrollToBottom = useCallback(
-		(behavior: ScrollBehavior = "smooth") => {
-			window.requestAnimationFrame(() => {
-				scrollTargetRef.current?.scrollIntoView({
-					behavior,
-					block: "end",
-				});
-			});
-		},
-		[scrollTargetRef],
-	);
-
 	// Stick to the bottom only when the reader is already there (or just sent a
 	// message). Someone scrolled up to read must never be yanked back down by a
 	// streaming event; the scroll-to-bottom button is their way back. Bottomness
@@ -1200,10 +1188,6 @@ export const AgenticChatPanel = ({
 	// bounced against the stream.
 	const hasScrolledInitiallyRef = useRef(false);
 	const forceNextScrollRef = useRef(false);
-	const isAtBottomRef = useRef(true);
-	useEffect(() => {
-		isAtBottomRef.current = isVisible;
-	}, [isVisible]);
 	// biome-ignore lint/correctness/useExhaustiveDependencies: chatId is the trigger, not a read — switching chats re-arms the initial jump
 	useEffect(() => {
 		hasScrolledInitiallyRef.current = false;
@@ -1466,29 +1450,11 @@ export const AgenticChatPanel = ({
 						</ErrorBoundary>
 					</Group>
 				</Group>
-				<Group justify="flex-end" gap="sm">
-					<Tooltip
-						label={<Trans>This is the new chat experience</Trans>}
-						openDelay={300}
-					>
-						<Button
-							variant="subtle"
-							size="xs"
-							onClick={() =>
-								navigate(`/w/${workspaceId}/projects/${projectId}/chats/new`, {
-									state: { preferMode: "deep_dive" },
-								})
-							}
-						>
-							<Trans>Open the old chat experience</Trans>
-						</Button>
-					</Tooltip>
-				</Group>
 				<Divider />
 			</Stack>
 
-			<Box className="min-h-0 flex-1 overflow-y-auto">
-				<Stack py="sm" pb="xl" className="relative min-h-full w-full">
+			<Box className="min-h-0 flex-1 overflow-y-auto" ref={threadScrollRef}>
+				<Stack className="relative min-h-full w-full pt-3 pb-6">
 					{error && (
 						<Alert
 							color="red"
@@ -1750,7 +1716,6 @@ export const AgenticChatPanel = ({
 							</div>
 						)}
 				</Stack>
-				<div ref={scrollTargetRef} aria-hidden="true" />
 			</Box>
 
 			<Box
@@ -1763,63 +1728,75 @@ export const AgenticChatPanel = ({
 						className="absolute bottom-[105%] right-4 z-50 hidden md:flex"
 					>
 						<ScrollToBottomButton
-							elementRef={scrollTargetRef}
-							isVisible={isVisible}
+							visible={showScrollButton}
+							onClick={() => scrollToBottom("smooth")}
 						/>
 					</Group>
 
 					{isRunInFlight && (
-						<Paper
-							className="self-start rounded-full px-3 py-1.5 shadow-none"
-							style={{ borderColor: "var(--mantine-color-primary-light)" }}
-							{...testId("agentic-run-indicator")}
-						>
-							<Group gap={8} wrap="nowrap">
-								<Box className="relative h-2 w-2 shrink-0">
-									<Box
-										className="absolute inset-0 rounded-full animate-ping"
-										style={{
-											backgroundColor:
-												"var(--agentic-tool-status-running-ping-dot)",
+						<Group justify="flex-start">
+							<Paper
+								className="rounded-full px-3 py-1.5 shadow-none"
+								style={{
+									borderColor: "var(--mantine-color-primary-light)",
+								}}
+								{...testId("agentic-run-indicator")}
+							>
+								<Group gap={8} wrap="nowrap">
+									<Box className="relative h-2 w-2 shrink-0">
+										<Box
+											className="absolute inset-0 rounded-full animate-ping"
+											style={{
+												backgroundColor:
+													"var(--agentic-tool-status-running-ping-dot)",
+											}}
+										/>
+										<Box
+											className="relative h-2 w-2 rounded-full"
+											style={{
+												backgroundColor:
+													"var(--agentic-tool-status-running-dot)",
+											}}
+										/>
+									</Box>
+									<Text
+										size="xs"
+										fw={500}
+										className="max-w-[min(70vw,32rem)] truncate"
+									>
+										{liveRunStatusText}
+									</Text>
+									<Button
+										type="button"
+										size="compact-xs"
+										radius="xl"
+										variant="subtle"
+										color="red"
+										aria-label={t`Cancel current run`}
+										onPointerDown={armStopControl}
+										onKeyDown={(event) => {
+											if (event.key === "Enter" || event.key === " ") {
+												armStopControl();
+											}
 										}}
-									/>
-									<Box
-										className="relative h-2 w-2 rounded-full"
-										style={{
-											backgroundColor: "var(--agentic-tool-status-running-dot)",
-										}}
-									/>
-								</Box>
-								<Text
-									size="xs"
-									fw={500}
-									className="max-w-[min(70vw,32rem)] truncate"
-								>
-									{liveRunStatusText}
-								</Text>
-								<Button
-									type="button"
-									size="compact-xs"
-									radius="xl"
-									variant="subtle"
-									color="red"
-									aria-label={t`Cancel current run`}
-									onPointerDown={armStopControl}
-									onKeyDown={(event) => {
-										if (event.key === "Enter" || event.key === " ") {
-											armStopControl();
-										}
-									}}
-									onClick={() => void handleStop()}
-									disabled={isStopping}
-									leftSection={isStopping ? <Loader size={12} /> : undefined}
-									{...testId("chat-stop-button")}
-								>
-									<Trans>Cancel</Trans>
-								</Button>
-							</Group>
-						</Paper>
+										onClick={() => void handleStop()}
+										disabled={isStopping}
+										leftSection={isStopping ? <Loader size={12} /> : undefined}
+										{...testId("chat-stop-button")}
+									>
+										<Trans>Cancel</Trans>
+									</Button>
+								</Group>
+							</Paper>
+						</Group>
 					)}
+
+					<ChatTemplatesMenuConnected
+						chatId={chatId}
+						chatMode="agentic"
+						projectId={projectId}
+						onTemplateSelect={({ content }) => setInput(content)}
+					/>
 
 					{atTurnLimit && (
 						<ChatTurnLimitCard onUpgrade={upgradeHandlers.open} />
@@ -1830,47 +1807,20 @@ export const AgenticChatPanel = ({
 							void handleSubmit();
 						}}
 					>
-						<Box
-							className="rounded-xl border px-3 pb-2 pt-2 shadow-sm transition-colors"
-							style={{
-								backgroundColor: "var(--app-background)",
-								borderColor: "var(--mantine-color-primary-light)",
-							}}
-						>
-							{focusedContextConversations.length > 0 && (
-								<Group
-									gap="xs"
-									align="baseline"
-									wrap="wrap"
-									className="mb-2 border-0 border-b border-solid pb-2 italic"
-									style={{ borderColor: "var(--mantine-color-primary-light)" }}
-								>
-									<Text size="xs" c="dimmed" fw={500}>
-										<Plural
-											value={focusedContextConversations.length}
-											one="Focusing on # conversation:"
-											other="Focusing on # conversations:"
-										/>
-									</Text>
-									{focusedContextConversations.length <= FOCUS_CHIP_LIMIT ? (
-										<ConversationLinks
-											conversations={
-												focusedContextConversations as unknown as Conversation[]
-											}
-										/>
-									) : (
-										<Text size="xs">
-											<Trans>
-												Too many to list here. The assistant reads through them
-												in batches.
-											</Trans>
-										</Text>
-									)}
-									<Button
-										variant="subtle"
-										size="compact-xs"
-										className="not-italic"
-										onClick={() =>
+						<ChatComposerShell
+							chips={
+								focusedContextConversations.length > 0 ? (
+									<ConversationFocusChips
+										conversations={focusedContextConversations}
+										isClearing={clearChatContextMutation.isPending}
+										label={
+											<Plural
+												value={focusedContextConversations.length}
+												one="Focusing on # conversation:"
+												other="Focusing on # conversations:"
+											/>
+										}
+										onClearAll={() =>
 											clearChatContextMutation.mutate({
 												chatId,
 												conversationIds: focusedContextConversations.map(
@@ -1878,16 +1828,47 @@ export const AgenticChatPanel = ({
 												),
 											})
 										}
-										loading={clearChatContextMutation.isPending}
-										{...testId("agentic-clear-focus-button")}
-									>
-										<Trans>Clear all</Trans>
-									</Button>
-								</Group>
-							)}
+										overflowNotice={
+											focusedContextConversations.length > FOCUS_CHIP_LIMIT ? (
+												<Trans>
+													Too many to list here. The assistant reads through
+													them in batches.
+												</Trans>
+											) : undefined
+										}
+									/>
+								) : undefined
+							}
+							footerLeft={
+								<ConversationPickerButton
+									ariaLabel={t`Focus on conversations`}
+									label={<Trans>Focus on conversations</Trans>}
+									onClick={conversationPickerHandlers.open}
+									testId="agentic-select-conversations-button"
+								/>
+							}
+							footerRight={
+								<Button
+									type="submit"
+									size="sm"
+									radius="md"
+									leftSection={
+										isSubmitting ? <Loader size={14} /> : <IconSend size={14} />
+									}
+									disabled={
+										isSubmitting || input.trim().length === 0 || atTurnLimit
+									}
+									{...testId("chat-send-button")}
+								>
+									<Trans>Send</Trans>
+								</Button>
+							}
+						>
 							<Textarea
 								variant="unstyled"
-								styles={{ input: { backgroundColor: "transparent" } }}
+								styles={{
+									input: { backgroundColor: "transparent", resize: "none" },
+								}}
 								autosize
 								minRows={2}
 								maxRows={10}
@@ -1903,47 +1884,7 @@ export const AgenticChatPanel = ({
 								}}
 								{...testId("chat-input-textarea")}
 							/>
-							<Group justify="space-between" align="center" gap="xs">
-								<Group gap="xs">
-									<InsertTemplateMenu
-										workspaceId={workspaceId}
-										onInsert={(content) => setInput(content)}
-									/>
-									<Button
-										variant="subtle"
-										size="compact-xs"
-										aria-label={t`Select conversations`}
-										onClick={conversationPickerHandlers.open}
-										{...testId("agentic-select-conversations-button")}
-									>
-										<ChatCircleTextIcon size={14} />
-										<span className="ms-1.5 hidden md:inline">
-											<Trans>Select conversations</Trans>
-										</span>
-									</Button>
-								</Group>
-								<Group gap="xs" wrap="nowrap">
-									<Button
-										type="submit"
-										size="sm"
-										radius="md"
-										leftSection={
-											isSubmitting ? (
-												<Loader size={14} />
-											) : (
-												<IconSend size={14} />
-											)
-										}
-										disabled={
-											isSubmitting || input.trim().length === 0 || atTurnLimit
-										}
-										{...testId("chat-send-button")}
-									>
-										<Trans>Send</Trans>
-									</Button>
-								</Group>
-							</Group>
-						</Box>
+						</ChatComposerShell>
 						<Group
 							justify="space-between"
 							gap="sm"
@@ -1964,7 +1905,7 @@ export const AgenticChatPanel = ({
 				<Modal
 					opened={conversationPickerOpened}
 					onClose={conversationPickerHandlers.close}
-					title={t`Select conversations`}
+					title={t`Focus on conversations`}
 					size="xl"
 					padding="lg"
 				>

--- a/echo/frontend/src/components/chat/AgenticIntroModal.tsx
+++ b/echo/frontend/src/components/chat/AgenticIntroModal.tsx
@@ -1,0 +1,90 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { Badge, Button, Group, List, Modal, Stack, Text } from "@mantine/core";
+import { IconSparkles } from "@tabler/icons-react";
+import { MODE_COLORS } from "@/components/chat/ChatModeSelector";
+import { testId } from "@/lib/testUtils";
+
+export const AgenticIntroModal = ({
+	onClose,
+	onConfirm,
+	opened,
+}: {
+	onClose: () => void;
+	onConfirm: () => void;
+	opened: boolean;
+}) => (
+	<Modal
+		opened={opened}
+		onClose={onClose}
+		title={
+			<Group gap="xs" align="center">
+				<Text size="lg">
+					<Trans>Agentic chat</Trans>
+				</Text>
+				<Badge size="sm" color="mauve" c="graphite">
+					<Trans>Beta</Trans>
+				</Badge>
+			</Group>
+		}
+		size="md"
+		padding="lg"
+		{...testId("agentic-intro-modal")}
+	>
+		<Stack gap="md">
+			<List
+				spacing="md"
+				size="sm"
+				icon={<IconSparkles size={14} color={MODE_COLORS.agentic.primary} />}
+				styles={{ itemWrapper: { alignItems: "baseline" } }}
+			>
+				<List.Item>
+					<Stack gap={2}>
+						<Text size="sm" fw={500}>
+							<Trans>Multi-step analysis.</Trans>
+						</Text>
+						<Text size="xs">
+							<Trans>
+								Plans, gathers, and checks its work across many conversations.
+							</Trans>
+						</Text>
+					</Stack>
+				</List.Item>
+				<List.Item>
+					<Stack gap={2}>
+						<Text size="sm" fw={500}>
+							<Trans>Help setting up your project.</Trans>
+						</Text>
+						<Text size="xs">
+							<Trans>Walks you through setup and suggests next steps.</Trans>
+						</Text>
+					</Stack>
+				</List.Item>
+				<List.Item>
+					<Stack gap={2}>
+						<Text size="sm" fw={500}>
+							<Trans>Ask about the app.</Trans>
+						</Text>
+						<Text size="xs">
+							<Trans>
+								Questions about how dembrane works, not only about your data.
+							</Trans>
+						</Text>
+					</Stack>
+				</List.Item>
+			</List>
+			<Group justify="flex-end" gap="sm">
+				<Button variant="subtle" onClick={onClose}>
+					<Trans>Not now</Trans>
+				</Button>
+				<Button
+					onClick={onConfirm}
+					aria-label={t`Switch to Agentic`}
+					{...testId("agentic-intro-modal-confirm")}
+				>
+					<Trans>Switch to Agentic</Trans>
+				</Button>
+			</Group>
+		</Stack>
+	</Modal>
+);

--- a/echo/frontend/src/components/chat/ChatComposer.test.tsx
+++ b/echo/frontend/src/components/chat/ChatComposer.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { MantineProvider } from "@mantine/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeAll, expect, it, vi } from "vitest";
+import {
+	ChatComposerShell,
+	ConversationFocusChips,
+	ConversationPickerButton,
+} from "./ChatComposer";
+
+beforeAll(() => {
+	i18n.load("en", {});
+	i18n.activate("en");
+
+	// MantineProvider reads the OS color scheme on mount; jsdom has no
+	// matchMedia, so stub a minimal (always non-matching) implementation.
+	window.matchMedia =
+		window.matchMedia ||
+		((query: string) => ({
+			addEventListener: () => {},
+			addListener: () => {},
+			dispatchEvent: () => false,
+			matches: false,
+			media: query,
+			onchange: null,
+			removeEventListener: () => {},
+			removeListener: () => {},
+		}));
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+const renderWithProviders = (ui: React.ReactNode) =>
+	render(
+		<I18nProvider i18n={i18n}>
+			<MantineProvider>
+				<MemoryRouter>{ui}</MemoryRouter>
+			</MantineProvider>
+		</I18nProvider>,
+	);
+
+it("renders the textarea slot with the footer controls around it", () => {
+	renderWithProviders(
+		<ChatComposerShell
+			chips={<span>chips</span>}
+			footerLeft={<span>left</span>}
+			footerRight={<span>right</span>}
+		>
+			<textarea aria-label="message" />
+		</ChatComposerShell>,
+	);
+	expect(screen.getByLabelText("message")).toBeTruthy();
+	expect(screen.getByText("chips")).toBeTruthy();
+	expect(screen.getByText("left")).toBeTruthy();
+	expect(screen.getByText("right")).toBeTruthy();
+});
+
+it("omits the chips row when no chips are passed", () => {
+	renderWithProviders(
+		<ChatComposerShell>
+			<textarea aria-label="message" />
+		</ChatComposerShell>,
+	);
+	expect(screen.queryByTestId("chat-composer-chips")).toBeNull();
+});
+
+it("clears every conversation from one control", () => {
+	const onClearAll = vi.fn();
+	renderWithProviders(
+		<ConversationFocusChips
+			conversations={[
+				{ id: "a", participant_name: "Ada" },
+				{ id: "b", participant_name: "Bo" },
+			]}
+			label="Focusing on 2 conversations:"
+			onClearAll={onClearAll}
+		/>,
+	);
+	fireEvent.click(screen.getByTestId("chat-composer-clear-focus"));
+	expect(onClearAll).toHaveBeenCalledTimes(1);
+});
+
+it("renders no clear control when clearing is not available", () => {
+	renderWithProviders(
+		<ConversationFocusChips
+			conversations={[{ id: "a", participant_name: "Ada" }]}
+			label="Using 1 conversation:"
+		/>,
+	);
+	expect(screen.queryByTestId("chat-composer-clear-focus")).toBeNull();
+});
+
+it("shows the overflow notice instead of chips when one is given", () => {
+	renderWithProviders(
+		<ConversationFocusChips
+			conversations={[{ id: "a", participant_name: "Ada" }]}
+			label="Focusing on 1 conversation:"
+			onClearAll={() => {}}
+			overflowNotice={<span>too many to list</span>}
+		/>,
+	);
+	expect(screen.getByText("too many to list")).toBeTruthy();
+	expect(screen.queryByText("Ada")).toBeNull();
+});
+
+it("renders nothing when count is zero and no conversations are given", () => {
+	renderWithProviders(
+		<ConversationFocusChips count={0} label="Using 0 conversations:" />,
+	);
+	expect(screen.queryByText("Using 0 conversations:")).toBeNull();
+});
+
+it("renders the label without ConversationLinks in count-only mode", () => {
+	renderWithProviders(
+		<ConversationFocusChips count={3} label="Using 3 conversations:" />,
+	);
+	expect(screen.getByText("Using 3 conversations:")).toBeTruthy();
+	// No conversation objects given, so ConversationLinks has nothing to render.
+	expect(screen.queryByRole("link")).toBeNull();
+});
+
+it("disables the clear button independently of the clearing spinner", () => {
+	const onClearAll = vi.fn();
+	renderWithProviders(
+		<ConversationFocusChips
+			count={2}
+			disabled
+			label="Using 2 conversations:"
+			onClearAll={onClearAll}
+		/>,
+	);
+	const button = screen.getByTestId("chat-composer-clear-focus");
+	expect(button.hasAttribute("data-disabled")).toBe(true);
+	fireEvent.click(button);
+	expect(onClearAll).not.toHaveBeenCalled();
+});
+
+it("prefers conversations over count when both are given", () => {
+	renderWithProviders(
+		<ConversationFocusChips
+			conversations={[{ id: "a", participant_name: "Ada" }]}
+			count={99}
+			label="Using 1 conversation:"
+		/>,
+	);
+	// Real conversation list renders, not the unrelated `count` value.
+	expect(screen.getByText("Ada")).toBeTruthy();
+});
+
+it("prefers the overflow notice over ConversationLinks even in count-only mode", () => {
+	renderWithProviders(
+		<ConversationFocusChips
+			count={50}
+			label="Using 50 conversations:"
+			overflowNotice={<span>too many to list</span>}
+		/>,
+	);
+	expect(screen.getByText("too many to list")).toBeTruthy();
+});
+
+it("labels the picker button from its prop", () => {
+	const onClick = vi.fn();
+	renderWithProviders(
+		<ConversationPickerButton
+			ariaLabel="Focus on conversations"
+			label="Focus on conversations"
+			onClick={onClick}
+			testId="agentic-select-conversations-button"
+		/>,
+	);
+	const button = screen.getByTestId("agentic-select-conversations-button");
+	expect(button.textContent).toContain("Focus on conversations");
+	expect(button.getAttribute("aria-label")).toBe("Focus on conversations");
+	fireEvent.click(button);
+	expect(onClick).toHaveBeenCalledTimes(1);
+});

--- a/echo/frontend/src/components/chat/ChatComposer.tsx
+++ b/echo/frontend/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,126 @@
+import { Trans } from "@lingui/react/macro";
+import { Box, Button, Group, Text } from "@mantine/core";
+import { ChatCircleText as ChatCircleTextIcon } from "@phosphor-icons/react";
+import { ConversationLinks } from "@/components/conversation/ConversationLinks";
+import { testId } from "@/lib/testUtils";
+
+/** The one owner of composer appearance. Every chat surface renders through
+ * this so the three bottom bars cannot drift apart again. */
+export const ChatComposerShell = ({
+	children,
+	chips,
+	footerLeft,
+	footerRight,
+}: {
+	children: React.ReactNode;
+	chips?: React.ReactNode;
+	footerLeft?: React.ReactNode;
+	footerRight?: React.ReactNode;
+}) => (
+	<Box
+		className="rounded-xl border px-3 pb-2 pt-2 shadow-sm transition-colors"
+		style={{
+			backgroundColor: "var(--app-background)",
+			borderColor: "var(--mantine-color-primary-light)",
+		}}
+	>
+		{chips && <Box {...testId("chat-composer-chips")}>{chips}</Box>}
+		{children}
+		<Group justify="space-between" align="center" gap="xs">
+			<Group gap="xs">{footerLeft}</Group>
+			<Group gap="xs" wrap="nowrap">
+				{footerRight}
+			</Group>
+		</Group>
+	</Box>
+);
+
+export const ConversationFocusChips = ({
+	conversations,
+	count,
+	disabled,
+	isClearing,
+	label,
+	onClearAll,
+	overflowNotice,
+}: {
+	/** Omit if only a count is known (e.g. before the chat exists); use `count`. */
+	conversations?: Array<{ id: string; participant_name?: string | null }>;
+	/** Count-only mode: same shell, no `ConversationLinks`. */
+	count?: number;
+	/** Disables "Clear all" for reasons unrelated to clearing (unlike
+	 * `isClearing`, which is the clear action's own loading state). */
+	disabled?: boolean;
+	isClearing?: boolean;
+	label: React.ReactNode;
+	/** Absent means this surface has no way to clear, so no control renders.
+	 * Never wire this to something that opens a picker; "Clear all" must clear. */
+	onClearAll?: () => void;
+	overflowNotice?: React.ReactNode;
+}) => {
+	const resolvedCount = conversations ? conversations.length : (count ?? 0);
+	if (resolvedCount === 0) return null;
+	return (
+		<Group
+			gap="xs"
+			align="baseline"
+			wrap="wrap"
+			className="mb-2 border-0 border-b border-solid pb-2 italic"
+			style={{ borderColor: "var(--mantine-color-primary-light)" }}
+		>
+			<Text size="xs" fw={500}>
+				{label}
+			</Text>
+			{overflowNotice ? (
+				<Text size="xs">{overflowNotice}</Text>
+			) : conversations ? (
+				<ConversationLinks
+					conversations={
+						conversations as unknown as Parameters<
+							typeof ConversationLinks
+						>[0]["conversations"]
+					}
+				/>
+			) : null}
+			{onClearAll && (
+				<Button
+					variant="subtle"
+					size="compact-xs"
+					className="not-italic"
+					onClick={onClearAll}
+					disabled={disabled}
+					loading={isClearing}
+					{...testId("chat-composer-clear-focus")}
+				>
+					<Trans>Clear all</Trans>
+				</Button>
+			)}
+		</Group>
+	);
+};
+
+export const ConversationPickerButton = ({
+	ariaLabel,
+	disabled,
+	label,
+	onClick,
+	testId: id,
+}: {
+	ariaLabel: string;
+	disabled?: boolean;
+	label: React.ReactNode;
+	onClick: () => void;
+	testId?: string;
+}) => (
+	<Button
+		variant="subtle"
+		size="compact-xs"
+		disabled={disabled}
+		onClick={onClick}
+		aria-label={ariaLabel}
+		{...(id ? testId(id) : {})}
+	>
+		<ChatCircleTextIcon size={14} />
+		<span className="ms-1.5 hidden md:inline">{label}</span>
+	</Button>
+);

--- a/echo/frontend/src/components/chat/ChatTemplatesMenu.tsx
+++ b/echo/frontend/src/components/chat/ChatTemplatesMenu.tsx
@@ -23,11 +23,7 @@ import {
 	encodeTemplateKey,
 	type QuickAccessItem,
 } from "./templateKey";
-import {
-	agenticQuickAccessTemplates,
-	quickAccessTemplates,
-	Templates,
-} from "./templates";
+import { quickAccessTemplates, Templates } from "./templates";
 
 // Map icon names from API to Phosphor icons
 const SUGGESTION_ICONS: Record<string, Icon> = {
@@ -107,8 +103,6 @@ const TemplatePill = ({
 	testIdSuffix: string;
 }) => {
 	const colors = chatMode ? MODE_COLORS[chatMode] : null;
-	const isOverview = chatMode === "overview";
-	const isDeepDive = chatMode === "deep_dive";
 
 	return (
 		<Tooltip label={label} openDelay={500} disabled={label.length < 25}>
@@ -122,19 +116,15 @@ const TemplatePill = ({
 				style={{
 					alignItems: "center",
 					backgroundColor: isSelected ? undefined : "var(--app-background)",
-					borderColor: isOverview
-						? MODE_COLORS.overview.primary
-						: isDeepDive
-							? MODE_COLORS.deep_dive.primary
-							: undefined,
-					borderWidth: isOverview || isDeepDive ? 1 : undefined,
+					borderColor: colors ? colors.primary : undefined,
+					borderWidth: colors ? 1 : undefined,
 					display: "flex",
 					maxWidth: 160,
 				}}
 				onClick={onClick}
 				{...testId(`chat-template-${testIdSuffix}`)}
 			>
-				<Group gap={4} wrap="nowrap" align="flex-start">
+				<Group gap={4} wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
 					{IconComponent && (
 						<IconComponent
 							size={12}
@@ -147,6 +137,7 @@ const TemplatePill = ({
 						fw={500}
 						c={colors ? MODE_COLORS.graphite : undefined}
 						truncate
+						style={{ minWidth: 0 }}
 					>
 						{label}
 					</Text>
@@ -195,8 +186,6 @@ export const ChatTemplatesMenu = ({
 
 	// Resolve quick-access templates from quickAccessItems (already resolved by parent)
 	const resolvedQuickAccessTemplates = useMemo(() => {
-		if (chatMode === "agentic") return agenticQuickAccessTemplates;
-
 		if (quickAccessItems.length === 0) {
 			return quickAccessTemplates;
 		}
@@ -224,7 +213,7 @@ export const ChatTemplatesMenu = ({
 			}
 		}
 		return resolved.length > 0 ? resolved : quickAccessTemplates;
-	}, [chatMode, quickAccessItems, userTemplates]);
+	}, [quickAccessItems, userTemplates]);
 
 	const handleTemplateSelect = (
 		template: { content: string; key: string },

--- a/echo/frontend/src/components/chat/ChatTemplatesMenuConnected.tsx
+++ b/echo/frontend/src/components/chat/ChatTemplatesMenuConnected.tsx
@@ -1,0 +1,213 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+import { useCurrentUser } from "@/components/auth/hooks";
+import { useProjectById } from "@/components/project/hooks";
+import { useLanguage } from "@/hooks/useLanguage";
+import type { ChatMode } from "@/lib/api";
+import { ChatTemplatesMenu } from "./ChatTemplatesMenu";
+import { useChatSuggestions, useProjectChatContext } from "./hooks";
+import {
+	useCreateUserTemplate,
+	useDeleteUserTemplate,
+	useQuickAccessPreferences,
+	useSaveQuickAccessPreferences,
+	useToggleAiSuggestions,
+	useUpdateUserTemplate,
+	useUserTemplates,
+} from "./hooks/useUserTemplates";
+import type { QuickAccessItem } from "./templateKey";
+import { Templates } from "./templates";
+
+/** Shared hook wiring for ChatTemplatesMenu so classic and agentic render it identically. */
+export const ChatTemplatesMenuConnected = ({
+	chatId,
+	chatMode,
+	projectId,
+	selectedTemplateKey,
+	externalOpen,
+	onExternalClose,
+	onTemplateSelect,
+	saveAsTemplateContent,
+	onClearSaveAsTemplate,
+	refetchSuggestionsKey,
+}: {
+	chatId?: string;
+	chatMode?: ChatMode | null;
+	projectId?: string;
+	selectedTemplateKey?: string | null;
+	externalOpen?: boolean;
+	onExternalClose?: () => void;
+	onTemplateSelect: (args: { content: string; key: string }) => void;
+	saveAsTemplateContent?: string | null;
+	onClearSaveAsTemplate?: () => void;
+	/** Change to trigger a suggestions refetch; omit to skip that behavior. */
+	refetchSuggestionsKey?: unknown;
+}) => {
+	const { language } = useLanguage();
+	const queryClient = useQueryClient();
+
+	const chatContextQuery = useProjectChatContext(chatId ?? "");
+
+	// Fetch the project's workspace_id so templates hook can return BOTH
+	// personal (scope='user') and workspace-shared (scope='workspace')
+	// templates for this workspace.
+	const projectForWorkspace = useProjectById({
+		projectId: projectId ?? "",
+		query: { fields: ["id", "workspace_id"] },
+	});
+	const projectWorkspaceId =
+		(projectForWorkspace.data as { workspace_id?: string | null } | undefined)
+			?.workspace_id ?? null;
+
+	const currentUserQuery = useCurrentUser();
+	const userTemplatesQuery = useUserTemplates(projectWorkspaceId);
+	const createUserTemplateMutation = useCreateUserTemplate(projectWorkspaceId);
+	const updateUserTemplateMutation = useUpdateUserTemplate(projectWorkspaceId);
+	const deleteUserTemplateMutation = useDeleteUserTemplate(projectWorkspaceId);
+	const quickAccessQuery = useQuickAccessPreferences();
+	const saveQuickAccessMutation = useSaveQuickAccessPreferences();
+	const toggleAiSuggestionsMutation = useToggleAiSuggestions();
+
+	const hideAiSuggestions = currentUserQuery.data?.hide_ai_suggestions ?? false;
+
+	// Resolve quick access items - default to first 3 built-in templates
+	const quickAccessItems: QuickAccessItem[] = useMemo(() => {
+		if (!quickAccessQuery.data || quickAccessQuery.data.length === 0)
+			return Templates.slice(0, 3).map((t) => ({
+				id: t.id,
+				title: t.title,
+				type: "static" as const,
+			}));
+		return quickAccessQuery.data
+			.map((pref) => {
+				if (pref.type === "static") {
+					const found = Templates.find((t) => t.id === pref.id);
+					if (found)
+						return {
+							id: found.id,
+							title: found.title,
+							type: "static" as const,
+						};
+				} else if (pref.type === "user") {
+					const found = userTemplatesQuery.data?.find((t) => t.id === pref.id);
+					if (found)
+						return {
+							id: found.id,
+							title: found.title,
+							type: "user" as const,
+						};
+				}
+				return null;
+			})
+			.filter(Boolean) as QuickAccessItem[];
+	}, [quickAccessQuery.data, userTemplatesQuery.data]);
+
+	const handleSaveQuickAccess = (items: QuickAccessItem[]) => {
+		saveQuickAccessMutation.mutate(
+			items.map((item) => ({
+				id: item.id,
+				type: item.type,
+			})),
+		);
+	};
+
+	const isModeSelected = chatMode !== null && chatMode !== undefined;
+	const isDeepDiveMode = chatMode === "deep_dive";
+	const isAgenticMode = chatMode === "agentic";
+	const conversationCount = chatContextQuery.data?.conversations?.length ?? 0;
+	const prevConversationCountRef = useRef<number | null>(null);
+
+	// Fetch suggestions:
+	// - Overview mode: Fetch immediately when mode is selected
+	// - Deep dive mode: Only fetch after conversations are added (not on initial load)
+	// - Agentic: never (isAgenticMode always excludes it)
+	const shouldFetchSuggestions =
+		isModeSelected &&
+		!isAgenticMode &&
+		!hideAiSuggestions &&
+		(!isDeepDiveMode || conversationCount > 0);
+
+	const suggestionsQuery = useChatSuggestions(chatId ?? "", {
+		enabled: shouldFetchSuggestions,
+		language,
+	});
+
+	// Refetch suggestions when conversation context changes in deep_dive mode.
+	// Cancel previous query and start a new one.
+	useEffect(() => {
+		if (!isDeepDiveMode || !chatId) return;
+
+		// Skip on initial mount
+		if (prevConversationCountRef.current === null) {
+			prevConversationCountRef.current = conversationCount;
+			return;
+		}
+
+		// Only refetch if count actually changed
+		if (prevConversationCountRef.current !== conversationCount) {
+			prevConversationCountRef.current = conversationCount;
+
+			queryClient.cancelQueries({
+				queryKey: ["chats", chatId, "suggestions", language],
+			});
+
+			if (conversationCount > 0) {
+				suggestionsQuery.refetch();
+			}
+		}
+	}, [
+		conversationCount,
+		isDeepDiveMode,
+		chatId,
+		language,
+		queryClient,
+		suggestionsQuery,
+	]);
+
+	// Refetch suggestions when the caller signals the assistant just finished
+	// responding (classic refetches on the isLoading -> false transition).
+	const prevRefetchKeyRef = useRef<unknown>(refetchSuggestionsKey);
+	const isFirstRefetchKeyRenderRef = useRef(true);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: suggestionsQuery identity changes per render; only refetchSuggestionsKey should retrigger this
+	useEffect(() => {
+		if (isFirstRefetchKeyRenderRef.current) {
+			isFirstRefetchKeyRenderRef.current = false;
+			prevRefetchKeyRef.current = refetchSuggestionsKey;
+			return;
+		}
+		if (prevRefetchKeyRef.current !== refetchSuggestionsKey) {
+			prevRefetchKeyRef.current = refetchSuggestionsKey;
+			suggestionsQuery.refetch();
+		}
+	}, [refetchSuggestionsKey]);
+
+	return (
+		<ChatTemplatesMenu
+			externalOpen={externalOpen}
+			onExternalClose={onExternalClose}
+			onTemplateSelect={onTemplateSelect}
+			selectedTemplateKey={selectedTemplateKey}
+			suggestions={hideAiSuggestions ? [] : suggestionsQuery.data?.suggestions}
+			chatMode={chatMode}
+			userTemplates={userTemplatesQuery.data ?? []}
+			canCreateWorkspaceTemplate={Boolean(projectWorkspaceId)}
+			onCreateUserTemplate={(payload) =>
+				createUserTemplateMutation.mutateAsync(payload)
+			}
+			onUpdateUserTemplate={(payload) =>
+				updateUserTemplateMutation.mutateAsync(payload)
+			}
+			onDeleteUserTemplate={(id) => deleteUserTemplateMutation.mutateAsync(id)}
+			isCreatingTemplate={createUserTemplateMutation.isPending}
+			isUpdatingTemplate={updateUserTemplateMutation.isPending}
+			isDeletingTemplate={deleteUserTemplateMutation.isPending}
+			quickAccessItems={quickAccessItems}
+			onSaveQuickAccess={handleSaveQuickAccess}
+			isSavingQuickAccess={saveQuickAccessMutation.isPending}
+			hideAiSuggestions={hideAiSuggestions}
+			onToggleAiSuggestions={(hide) => toggleAiSuggestionsMutation.mutate(hide)}
+			saveAsTemplateContent={saveAsTemplateContent}
+			onClearSaveAsTemplate={onClearSaveAsTemplate}
+		/>
+	);
+};

--- a/echo/frontend/src/components/chat/hooks/index.ts
+++ b/echo/frontend/src/components/chat/hooks/index.ts
@@ -1,6 +1,7 @@
 import type { Query } from "@directus/sdk";
 import { t } from "@lingui/core/macro";
 import {
+	keepPreviousData,
 	useMutation,
 	useQuery,
 	useQueryClient,
@@ -65,6 +66,9 @@ export const useDeleteChatMutation = () => {
 	return useMutation({
 		mutationFn: (payload: { chatId: string; projectId: string }) =>
 			deleteChatById(payload.chatId),
+		onError: (error: Error) => {
+			toast.error(error.message || t`Failed to delete chat`);
+		},
 		onSuccess: (_, vars) => {
 			posthog.capture("chat_deleted", {
 				chat_id: vars.chatId,
@@ -77,9 +81,6 @@ export const useDeleteChatMutation = () => {
 				queryKey: ["chats", vars.chatId],
 			});
 			toast.success(t`Chat deleted`);
-		},
-		onError: (error: Error) => {
-			toast.error(error.message || t`Failed to delete chat`);
 		},
 	});
 };
@@ -166,7 +167,7 @@ export const useProjectChats = (
 			void query; // advanced query filter not forwarded to BFF
 			const { chats } = await bff.get<{ chats: ProjectChat[]; total: number }>(
 				"/chats",
-				{ project_id: projectId, limit: 200 },
+				{ limit: 200, project_id: projectId },
 			);
 			return chats;
 		},
@@ -193,17 +194,16 @@ export const useInfiniteProjectChats = (
 			const { chats } = await bff.get<{ chats: ProjectChat[]; total: number }>(
 				"/chats",
 				{
-					project_id: projectId,
 					limit: initialLimit,
 					offset: pageParam * initialLimit,
+					project_id: projectId,
 					...(hasMessages ? { has_messages: true } : {}),
 				},
 			);
 
 			return {
 				chats,
-				nextOffset:
-					chats.length === initialLimit ? pageParam + 1 : undefined,
+				nextOffset: chats.length === initialLimit ? pageParam + 1 : undefined,
 			};
 		},
 		queryKey: [
@@ -211,7 +211,7 @@ export const useInfiniteProjectChats = (
 			projectId,
 			"chats",
 			"infinite",
-			{ query, hasMessages },
+			{ hasMessages, query },
 		],
 		refetchInterval: 30000,
 	});
@@ -222,25 +222,25 @@ const projectChatsCountQueryOptions = (
 	query: Partial<Query<CustomDirectusTypes, ProjectChat>> | undefined,
 	hasMessages: boolean,
 ) => ({
-	queryKey: [
-		"projects",
-		projectId,
-		"chats",
-		"count",
-		{ query, hasMessages },
-	] as const,
 	queryFn: async () => {
 		void query;
 		const { total } = await bff.get<{ chats: ProjectChat[]; total: number }>(
 			"/chats",
 			{
-				project_id: projectId,
 				limit: 1,
+				project_id: projectId,
 				...(hasMessages ? { has_messages: true } : {}),
 			},
 		);
 		return total;
 	},
+	queryKey: [
+		"projects",
+		projectId,
+		"chats",
+		"count",
+		{ hasMessages, query },
+	] as const,
 });
 
 export const useProjectChatsCount = (
@@ -293,6 +293,26 @@ export const useChatSuggestions = (
 		refetchOnWindowFocus: false,
 		retry: 1, // Retry once on failure, then give up gracefully
 		staleTime: 30_000, // 30 seconds - avoid rapid re-fetches
+	});
+};
+
+const CHAT_SEARCH_LIMIT = 50;
+
+/** Server-backed title search. Deliberately not the infinite/suspense hook:
+ * suspending on every keystroke would flash the list back to a skeleton. */
+export const useProjectChatSearch = (projectId: string, q: string) => {
+	const search = q.trim();
+	return useQuery({
+		enabled: search.length > 0,
+		placeholderData: keepPreviousData,
+		queryFn: () =>
+			bff.get<{ chats: ProjectChat[]; total: number }>("/chats", {
+				has_messages: true,
+				limit: CHAT_SEARCH_LIMIT,
+				project_id: projectId,
+				q: search,
+			}),
+		queryKey: ["projects", projectId, "chats", "search", search],
 	});
 };
 

--- a/echo/frontend/src/components/common/ScrollToBottom.tsx
+++ b/echo/frontend/src/components/common/ScrollToBottom.tsx
@@ -1,21 +1,19 @@
 import { t } from "@lingui/core/macro";
-import { ArrowDown } from "@phosphor-icons/react";
 import { ActionIcon, Tooltip } from "@mantine/core";
+import { ArrowDown } from "@phosphor-icons/react";
 
 interface ScrollToBottomButtonProps {
-	elementRef: React.RefObject<HTMLDivElement | null>;
-	isVisible: boolean;
+	onClick: () => void;
+	/** True means show the button. Note this is the opposite of the old
+	 * `isVisible` prop, which described the scroll sentinel. */
+	visible: boolean;
 }
 
 export const ScrollToBottomButton = ({
-	elementRef,
-	isVisible,
+	onClick,
+	visible,
 }: ScrollToBottomButtonProps) => {
-	const scrollToBottom = () => {
-		elementRef.current?.scrollIntoView({ behavior: "smooth" });
-	};
-
-	if (isVisible) return null; // Hide when visible
+	if (!visible) return null;
 
 	return (
 		<Tooltip label={t`Scroll to bottom`}>
@@ -26,7 +24,7 @@ export const ScrollToBottomButton = ({
 				aria-label={t`Scroll to bottom`}
 				className="rounded-full shadow-sm"
 				style={{ backgroundColor: "var(--app-background)" }}
-				onClick={scrollToBottom}
+				onClick={onClick}
 			>
 				<ArrowDown size="70%" weight="bold" />
 			</ActionIcon>

--- a/echo/frontend/src/components/common/scrollPosition.test.ts
+++ b/echo/frontend/src/components/common/scrollPosition.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { expect, it } from "vitest";
+import {
+	BOTTOM_THRESHOLD_PX,
+	evaluateScrollPosition,
+	resolveScrollContainer,
+} from "./scrollPosition";
+
+it("hides the button when there is nothing to scroll", () => {
+	const result = evaluateScrollPosition({
+		clientHeight: 800,
+		scrollHeight: 802,
+		scrollTop: 0,
+	});
+	expect(result.scrollable).toBe(false);
+	expect(result.showScrollButton).toBe(false);
+	expect(result.isAtBottom).toBe(true);
+});
+
+it("hides the button while parked at the bottom of a long thread", () => {
+	const result = evaluateScrollPosition({
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 3200,
+	});
+	expect(result.scrollable).toBe(true);
+	expect(result.isAtBottom).toBe(true);
+	expect(result.showScrollButton).toBe(false);
+});
+
+it("treats a small gap from the bottom as still at the bottom", () => {
+	const result = evaluateScrollPosition({
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 3200 - BOTTOM_THRESHOLD_PX,
+	});
+	expect(result.isAtBottom).toBe(true);
+	expect(result.showScrollButton).toBe(false);
+});
+
+it("shows the button once scrolled up past the threshold", () => {
+	const result = evaluateScrollPosition({
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+	expect(result.distanceFromBottom).toBe(2200);
+	expect(result.isAtBottom).toBe(false);
+	expect(result.showScrollButton).toBe(true);
+});
+
+it("resolves an overflow container even before it has anything to scroll", () => {
+	// Resolution happens at mount, when a chat thread is often still empty.
+	// The container must be found by its overflow style alone; requiring
+	// scrollHeight > clientHeight here would bind listeners to the wrong
+	// target forever.
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	document.body.append(container);
+	expect(resolveScrollContainer(container)).toBe(container);
+	container.remove();
+});
+
+it("walks up to the nearest overflow ancestor", () => {
+	const outer = document.createElement("div");
+	outer.style.overflowY = "scroll";
+	const inner = document.createElement("div");
+	outer.append(inner);
+	document.body.append(outer);
+	expect(resolveScrollContainer(inner)).toBe(outer);
+	outer.remove();
+});
+
+it("falls back to the scrolling element when no ancestor scrolls", () => {
+	const orphan = document.createElement("div");
+	document.body.append(orphan);
+	expect(resolveScrollContainer(orphan)).toBe(
+		document.scrollingElement ?? document.documentElement,
+	);
+	orphan.remove();
+});
+
+it("returns null for a null element", () => {
+	expect(resolveScrollContainer(null)).toBeNull();
+});

--- a/echo/frontend/src/components/common/scrollPosition.ts
+++ b/echo/frontend/src/components/common/scrollPosition.ts
@@ -1,0 +1,51 @@
+/** How far from the bottom still counts as "at the bottom". Wide enough to
+ * absorb sub-pixel rounding and a line of streaming text. */
+export const BOTTOM_THRESHOLD_PX = 64;
+/** Below this, the content does not meaningfully scroll and the button is noise. */
+export const SCROLLABLE_THRESHOLD_PX = 8;
+
+interface ScrollMetrics {
+	clientHeight: number;
+	scrollHeight: number;
+	scrollTop: number;
+}
+
+export const evaluateScrollPosition = ({
+	clientHeight,
+	scrollHeight,
+	scrollTop,
+}: ScrollMetrics) => {
+	const scrollable = scrollHeight - clientHeight > SCROLLABLE_THRESHOLD_PX;
+	const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+	const isAtBottom = !scrollable || distanceFromBottom <= BOTTOM_THRESHOLD_PX;
+	return {
+		distanceFromBottom,
+		isAtBottom,
+		scrollable,
+		showScrollButton: scrollable && !isAtBottom,
+	};
+};
+
+/** The scroll container is not the same element on every surface: the agentic
+ * thread scrolls itself, the classic chat page scrolls an ancestor. Resolve it
+ * from an anchor instead of asking each caller to know.
+ *
+ * Resolution is by overflow style alone, never by current scrollability:
+ * this runs at mount, when a thread is often still empty, and a container
+ * skipped for not overflowing YET would leave every listener bound to the
+ * wrong target after the messages load. */
+export const resolveScrollContainer = (
+	element: HTMLElement | null,
+): HTMLElement | null => {
+	if (!element) return null;
+	let current: HTMLElement | null = element;
+	while (current) {
+		const { overflowY } = window.getComputedStyle(current);
+		if (overflowY === "auto" || overflowY === "scroll") return current;
+		current = current.parentElement;
+	}
+	return (
+		(document.scrollingElement as HTMLElement | null) ??
+		document.documentElement
+	);
+};

--- a/echo/frontend/src/components/common/useStickToBottom.test.ts
+++ b/echo/frontend/src/components/common/useStickToBottom.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useStickToBottom } from "./useStickToBottom";
+
+/** jsdom has no ResizeObserver; grab an instance and call trigger() to simulate one firing. */
+class MockResizeObserver {
+	static instances: MockResizeObserver[] = [];
+	callback: ResizeObserverCallback;
+	observedTargets: Element[] = [];
+	constructor(callback: ResizeObserverCallback) {
+		this.callback = callback;
+		MockResizeObserver.instances.push(this);
+	}
+	observe(target: Element) {
+		this.observedTargets.push(target);
+	}
+	unobserve(target: Element) {
+		this.observedTargets = this.observedTargets.filter((t) => t !== target);
+	}
+	disconnect() {
+		this.observedTargets = [];
+	}
+	trigger() {
+		this.callback(
+			[] as unknown as ResizeObserverEntry[],
+			this as unknown as ResizeObserver,
+		);
+	}
+}
+
+/** jsdom reports 0 for these on every element; stub the ones a test needs. */
+const setMetrics = (
+	el: HTMLElement,
+	metrics: { clientHeight: number; scrollHeight: number; scrollTop: number },
+) => {
+	Object.defineProperty(el, "clientHeight", {
+		configurable: true,
+		value: metrics.clientHeight,
+	});
+	Object.defineProperty(el, "scrollHeight", {
+		configurable: true,
+		value: metrics.scrollHeight,
+	});
+	Object.defineProperty(el, "scrollTop", {
+		configurable: true,
+		value: metrics.scrollTop,
+		writable: true,
+	});
+};
+
+beforeEach(() => {
+	MockResizeObserver.instances = [];
+	window.ResizeObserver =
+		MockResizeObserver as unknown as typeof ResizeObserver;
+	// jsdom's Element has no scrollTo implementation at all.
+	Element.prototype.scrollTo =
+		Element.prototype.scrollTo ?? vi.fn<(...args: unknown[]) => void>();
+});
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+});
+
+it("measures the container on mount and reflects scroll position", () => {
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	document.body.append(container);
+	setMetrics(container, {
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+
+	expect(result.current.showScrollButton).toBe(true);
+	expect(result.current.isAtBottom).toBe(false);
+});
+
+it("updates on a scroll event fired on the resolved container", () => {
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	document.body.append(container);
+	setMetrics(container, {
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+	expect(result.current.showScrollButton).toBe(true);
+
+	act(() => {
+		setMetrics(container, {
+			clientHeight: 800,
+			scrollHeight: 4000,
+			scrollTop: 3200,
+		});
+		container.dispatchEvent(new Event("scroll"));
+	});
+
+	expect(result.current.showScrollButton).toBe(false);
+	expect(result.current.isAtBottom).toBe(true);
+});
+
+it("attaches the scroll listener to window, not the element, when the container is the scrolling element", () => {
+	const anchor = document.createElement("div");
+	document.body.append(anchor);
+	// No overflow ancestor, so this falls back to document.documentElement.
+	setMetrics(document.documentElement, {
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+
+	const windowAddSpy = vi.spyOn(window, "addEventListener");
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	renderHook(() => useStickToBottom(anchorRef));
+
+	const scrollListenerOnWindow = windowAddSpy.mock.calls.some(
+		([eventName]) => eventName === "scroll",
+	);
+	expect(scrollListenerOnWindow).toBe(true);
+});
+
+it("re-measures when the ResizeObserver fires (content growth)", () => {
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	document.body.append(container);
+	setMetrics(container, { clientHeight: 800, scrollHeight: 802, scrollTop: 0 });
+
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+	expect(result.current.showScrollButton).toBe(false);
+
+	act(() => {
+		// Content grows past scrollable while scrollTop stays put (streaming reply).
+		setMetrics(container, {
+			clientHeight: 800,
+			scrollHeight: 4000,
+			scrollTop: 0,
+		});
+		for (const observer of MockResizeObserver.instances) {
+			observer.trigger();
+		}
+	});
+
+	expect(result.current.showScrollButton).toBe(true);
+});
+
+it("caches the resolved container so a later anchor change doesn't re-resolve it", () => {
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	document.body.append(container);
+	setMetrics(container, { clientHeight: 800, scrollHeight: 802, scrollTop: 0 });
+
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+
+	// Detached, no overflow ancestor: re-resolving from this would fall back
+	// to document.documentElement instead of the original container.
+	const detached = document.createElement("div");
+	anchorRef.current = detached;
+
+	act(() => {
+		setMetrics(container, {
+			clientHeight: 800,
+			scrollHeight: 4000,
+			scrollTop: 0,
+		});
+		result.current.measure();
+	});
+
+	// Still reflects container's metrics: measure() used the cached one.
+	expect(result.current.showScrollButton).toBe(true);
+});
+
+it("scrolls the resolved container to its full height", async () => {
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	document.body.append(container);
+	setMetrics(container, {
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+	const scrollToSpy = vi
+		.spyOn(container, "scrollTo")
+		.mockImplementation(() => {});
+
+	const anchorRef = createRef<HTMLElement>();
+	anchorRef.current = anchor;
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+
+	act(() => {
+		result.current.scrollToBottom("smooth");
+	});
+	// scrollToBottom defers to the next animation frame.
+	await new Promise((resolve) => requestAnimationFrame(resolve));
+
+	expect(scrollToSpy).toHaveBeenCalledWith({ behavior: "smooth", top: 4000 });
+});
+
+it("attaches listeners once the anchor mounts later, via the wait-for-anchor observer", async () => {
+	document.body.setAttribute("data-app-scroll-root", "");
+
+	// Anchor starts unattached, mirroring a loading/picker screen.
+	const anchorRef = createRef<HTMLElement>();
+
+	const { result } = renderHook(() => useStickToBottom(anchorRef));
+	expect(result.current.showScrollButton).toBe(false);
+
+	const container = document.createElement("div");
+	container.style.overflowY = "auto";
+	const anchor = document.createElement("div");
+	container.append(anchor);
+	setMetrics(container, {
+		clientHeight: 800,
+		scrollHeight: 4000,
+		scrollTop: 1000,
+	});
+
+	await act(async () => {
+		anchorRef.current = anchor;
+		// Any mutation re-checks the ref; appending the container is enough.
+		document.body.append(container);
+		// MutationObserver callbacks are microtask-scheduled.
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+
+	expect(result.current.showScrollButton).toBe(true);
+
+	document.body.removeAttribute("data-app-scroll-root");
+});

--- a/echo/frontend/src/components/common/useStickToBottom.ts
+++ b/echo/frontend/src/components/common/useStickToBottom.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	evaluateScrollPosition,
+	resolveScrollContainer,
+} from "./scrollPosition";
+
+/** One measurement drives both the scroll-to-bottom button and autoscroll, so
+ * the two can never disagree about where the reader is. Measured once on mount
+ * (no flash) and then on scroll, resize, and content growth. */
+export const useStickToBottom = (
+	anchorRef: React.RefObject<HTMLElement | null>,
+) => {
+	const [state, setState] = useState({
+		isAtBottom: true,
+		showScrollButton: false,
+	});
+	const isAtBottomRef = useRef(true);
+	const containerRef = useRef<HTMLElement | null>(null);
+
+	const measure = useCallback(() => {
+		const container =
+			containerRef.current ?? resolveScrollContainer(anchorRef.current);
+		if (!container) return;
+		containerRef.current = container;
+		const next = evaluateScrollPosition({
+			clientHeight: container.clientHeight,
+			scrollHeight: container.scrollHeight,
+			scrollTop: container.scrollTop,
+		});
+		isAtBottomRef.current = next.isAtBottom;
+		setState((prev) =>
+			prev.isAtBottom === next.isAtBottom &&
+			prev.showScrollButton === next.showScrollButton
+				? prev
+				: {
+						isAtBottom: next.isAtBottom,
+						showScrollButton: next.showScrollButton,
+					},
+		);
+	}, [anchorRef]);
+
+	useEffect(() => {
+		let disposed = false;
+		let detachListeners: (() => void) | null = null;
+		let waitObserver: MutationObserver | null = null;
+
+		const setupListeners = (anchor: HTMLElement) => {
+			const container = resolveScrollContainer(anchor);
+			containerRef.current = container;
+			measure();
+			if (!container) return;
+			const scrollTarget: EventTarget =
+				container === document.documentElement ||
+				container === document.scrollingElement
+					? window
+					: container;
+			scrollTarget.addEventListener("scroll", measure, { passive: true });
+			window.addEventListener("resize", measure);
+			const observer = new ResizeObserver(measure);
+			observer.observe(container);
+			// The container's own box does not change when its content grows, so
+			// observing it alone would miss streaming messages entirely. The first
+			// child is the content wrapper that actually gets taller.
+			if (container.firstElementChild) {
+				observer.observe(container.firstElementChild);
+			}
+			if (anchor !== container) {
+				observer.observe(anchor);
+			}
+			detachListeners = () => {
+				scrollTarget.removeEventListener("scroll", measure);
+				window.removeEventListener("resize", measure);
+				observer.disconnect();
+			};
+		};
+
+		const attach = () => {
+			if (disposed) return;
+			const anchor = anchorRef.current;
+			if (anchor) {
+				setupListeners(anchor);
+				return;
+			}
+			// Anchor isn't mounted yet (e.g. still on a loading/picker screen).
+			// Watch for it instead of polling; disconnects once it appears.
+			waitObserver = new MutationObserver(() => {
+				if (!anchorRef.current) return;
+				waitObserver?.disconnect();
+				waitObserver = null;
+				attach();
+			});
+			const waitRoot =
+				document.querySelector<HTMLElement>("[data-app-scroll-root]") ??
+				document.body;
+			waitObserver.observe(waitRoot, { childList: true, subtree: true });
+		};
+
+		attach();
+
+		return () => {
+			disposed = true;
+			waitObserver?.disconnect();
+			detachListeners?.();
+		};
+	}, [anchorRef, measure]);
+
+	const scrollToBottom = useCallback(
+		(behavior: ScrollBehavior = "smooth") => {
+			window.requestAnimationFrame(() => {
+				const container =
+					containerRef.current ?? resolveScrollContainer(anchorRef.current);
+				if (!container) return;
+				container.scrollTo({ behavior, top: container.scrollHeight });
+			});
+		},
+		[anchorRef],
+	);
+
+	return {
+		isAtBottom: state.isAtBottom,
+		isAtBottomRef,
+		measure,
+		scrollToBottom,
+		showScrollButton: state.showScrollButton,
+	};
+};

--- a/echo/frontend/src/components/conversation/ConversationTranscriptSection.tsx
+++ b/echo/frontend/src/components/conversation/ConversationTranscriptSection.tsx
@@ -211,8 +211,12 @@ export const ConversationTranscriptSection = ({
 							{...testId("transcript-scroll-to-bottom")}
 						>
 							<ScrollToBottomButton
-								elementRef={bottomTargetRef}
-								isVisible={isBottomVisible}
+								visible={!isBottomVisible}
+								onClick={() =>
+									bottomTargetRef.current?.scrollIntoView({
+										behavior: "smooth",
+									})
+								}
 							/>
 						</Group>
 					) : null}

--- a/echo/frontend/src/components/layout/BaseLayout.tsx
+++ b/echo/frontend/src/components/layout/BaseLayout.tsx
@@ -1,12 +1,12 @@
+import { ActionIcon } from "@mantine/core";
+import { SidebarSimple } from "@phosphor-icons/react";
 import type { PropsWithChildren } from "react";
 import { Outlet } from "react-router";
 import { useAuthenticated } from "@/components/auth/hooks";
 import { AppSidebar, useSidebarView } from "@/features/sidebar";
 import { AppBreadcrumbs } from "@/features/sidebar/breadcrumbs/AppBreadcrumbs";
-import { InboxView } from "@/features/sidebar/views/InboxView";
 import { useSidebarState } from "@/features/sidebar/hooks/useSidebarState";
-import { ActionIcon } from "@mantine/core";
-import { SidebarSimple } from "@phosphor-icons/react";
+import { InboxView } from "@/features/sidebar/views/InboxView";
 import { Toaster } from "../common/Toaster";
 import { ErrorBoundary } from "../error/ErrorBoundary";
 import { TransitionCurtainProvider } from "./TransitionCurtainProvider";
@@ -60,7 +60,7 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 							</div>
 						)}
 						{isAuthenticated ? <AppBreadcrumbs /> : null}
-						<div className="flex-1 overflow-auto">
+						<div className="flex-1 overflow-auto" data-app-scroll-root>
 							<Outlet />
 							{children}
 						</div>

--- a/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
+++ b/echo/frontend/src/components/participant/ParticipantConversationAudio.tsx
@@ -938,8 +938,10 @@ export const ParticipantConversationAudio = () => {
 						}`}
 					>
 						<ScrollToBottomButton
-							elementRef={scrollTargetRef}
-							isVisible={isVisible}
+							visible={!isVisible}
+							onClick={() =>
+								scrollTargetRef.current?.scrollIntoView({ behavior: "smooth" })
+							}
 						/>
 					</Group>
 

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -3,7 +3,6 @@ import { Plural, Trans } from "@lingui/react/macro";
 import {
 	ActionIcon,
 	Alert,
-	Anchor,
 	Badge,
 	Box,
 	Button,
@@ -14,28 +13,44 @@ import {
 	Stack,
 	Text,
 	Textarea,
+	TextInput,
 	Title,
 } from "@mantine/core";
-import { useDisclosure, useDocumentTitle } from "@mantine/hooks";
-import { IconAlertCircle, IconArrowUp } from "@tabler/icons-react";
+import {
+	useDebouncedValue,
+	useDisclosure,
+	useDocumentTitle,
+} from "@mantine/hooks";
+import {
+	IconAlertCircle,
+	IconSearch,
+	IconSend,
+	IconX,
+} from "@tabler/icons-react";
 import { formatRelative } from "date-fns";
 import posthog from "posthog-js";
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useInView } from "react-intersection-observer";
-import { useLocation, useParams } from "react-router";
+import { useLocation, useParams, useSearchParams } from "react-router";
+import { AgenticIntroModal } from "@/components/chat/AgenticIntroModal";
 import {
 	ChatAccordionItemMenu,
 	ChatModeIndicator,
 } from "@/components/chat/ChatAccordion";
+import {
+	ChatComposerShell,
+	ConversationFocusChips,
+	ConversationPickerButton,
+} from "@/components/chat/ChatComposer";
 import { ChatModeSelector } from "@/components/chat/ChatModeSelector";
 import { ChatUpgradeModal } from "@/components/chat/FreeTierChatGate";
 import {
 	useInfiniteProjectChats,
 	useInitializeChatModeMutation,
 	usePrefetchSuggestions,
+	useProjectChatSearch,
 	useProjectChatsCount,
 } from "@/components/chat/hooks";
-import { InsertTemplateMenu } from "@/components/chat/InsertTemplateMenu";
 import { consumeChatPrefill } from "@/components/chat/prefill";
 import { BaseSkeleton } from "@/components/common/BaseSkeleton";
 import { NavigationButton } from "@/components/common/NavigationButton";
@@ -45,11 +60,7 @@ import {
 	useAttachChatConversationsMutation,
 	useCreateChatMutation,
 } from "@/components/project/hooks";
-import {
-	AGENTIC_CHAT_IS_DEFAULT,
-	ASK_DOCS_URL,
-	ENABLE_AGENTIC_CHAT,
-} from "@/config";
+import { AGENTIC_CHAT_IS_DEFAULT, ENABLE_AGENTIC_CHAT } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useWorkspace } from "@/hooks/useWorkspace";
@@ -57,6 +68,7 @@ import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
 import type { ChatMode } from "@/lib/api";
 import { isFreeTierLimitError } from "@/lib/freeTier";
 import { isReadOnlyRole } from "@/lib/roles";
+import { testId } from "@/lib/testUtils";
 
 const CHATS_PAGE_SIZE = 10;
 
@@ -70,11 +82,9 @@ const ChatsSectionSkeleton = () => (
 );
 
 const ProjectChatsSection = ({
-	filter,
 	projectId,
 	workspaceId,
 }: {
-	filter?: string;
 	projectId: string;
 	workspaceId: string;
 }) => {
@@ -86,6 +96,24 @@ const ProjectChatsSection = ({
 		hasMessages: true,
 		initialLimit: CHATS_PAGE_SIZE,
 	});
+
+	const [searchParams, setSearchParams] = useSearchParams();
+	const rawSearch = searchParams.get("chatq") ?? "";
+	const [debouncedSearch] = useDebouncedValue(rawSearch, 300);
+	const searchQuery = useProjectChatSearch(projectId, debouncedSearch);
+	const isSearching = debouncedSearch.trim().length > 0;
+
+	const setSearch = (next: string) => {
+		setSearchParams(
+			(current) => {
+				const params = new URLSearchParams(current);
+				if (next) params.set("chatq", next);
+				else params.delete("chatq");
+				return params;
+			},
+			{ replace: true },
+		);
+	};
 
 	useEffect(() => {
 		if (inView && chatsQuery.hasNextPage && !chatsQuery.isFetchingNextPage) {
@@ -106,37 +134,69 @@ const ProjectChatsSection = ({
 			}>
 		)?.flatMap((page) => page.chats) ?? [];
 
-	// The bar above doubles as a filter over your chats: typing narrows the
-	// list in place (gently, no layout jumps) while Enter still starts a new
-	// chat with the typed question.
-	const normalizedFilter = filter?.trim().toLowerCase() ?? "";
-	const visibleChats = useMemo(() => {
-		if (!normalizedFilter) return allChats;
-		return allChats.filter((chat) =>
-			(chat.name ?? "").toLowerCase().includes(normalizedFilter),
-		);
-	}, [allChats, normalizedFilter]);
+	const listedChats = isSearching ? (searchQuery.data?.chats ?? []) : allChats;
+	const shownCount = isSearching
+		? (searchQuery.data?.total ?? 0)
+		: (chatsCountQuery.data ?? 0);
 
-	const totalChats = chatsCountQuery.data ?? 0;
-	if (totalChats === 0) return null;
+	// Hide the whole section only when the project genuinely has no chats and
+	// the host is not searching; otherwise the empty states below do the talking.
+	if (!isSearching && (chatsCountQuery.data ?? 0) === 0) return null;
 
 	return (
 		<Stack gap="lg" className="pt-4 transition-opacity">
-			<Group gap="sm" align="center">
-				<Title order={2} fw={500} style={{ color: "var(--app-text)" }}>
-					<Trans>Chats</Trans>
-				</Title>
-				<Badge variant="light">{totalChats}</Badge>
+			<Group gap="sm" align="center" justify="space-between" wrap="wrap">
+				<Group gap="sm" align="center">
+					<Title order={2} fw={500} style={{ color: "var(--app-text)" }}>
+						<Trans>Chats</Trans>
+					</Title>
+					<Badge variant="light">{shownCount}</Badge>
+				</Group>
+				<TextInput
+					size="sm"
+					className="w-64"
+					value={rawSearch}
+					onChange={(event) => setSearch(event.currentTarget.value)}
+					placeholder={t`Search chats`}
+					aria-label={t`Search chats`}
+					leftSection={<IconSearch size={14} />}
+					rightSection={
+						rawSearch ? (
+							<ActionIcon
+								variant="subtle"
+								size="sm"
+								aria-label={t`Clear search`}
+								onClick={() => setSearch("")}
+							>
+								<IconX size={14} />
+							</ActionIcon>
+						) : null
+					}
+					{...testId("chats-search-input")}
+				/>
 			</Group>
 
-			{normalizedFilter && visibleChats.length === 0 && (
+			{isSearching && listedChats.length === 0 && !searchQuery.isFetching && (
 				<Text size="sm">
-					<Trans>No chats match. Press Enter to ask this as a new chat.</Trans>
+					<Trans>No chats match your search.</Trans>
+				</Text>
+			)}
+			{!isSearching && listedChats.length === 0 && (
+				<Text size="sm">
+					<Trans>No chats yet.</Trans>
+				</Text>
+			)}
+			{isSearching && shownCount > listedChats.length && (
+				<Text size="xs">
+					<Trans>
+						Showing the first {listedChats.length} of {shownCount} matches.
+						Narrow the search to see the rest.
+					</Trans>
 				</Text>
 			)}
 
 			<Stack gap="xs">
-				{visibleChats.map((item, index) => {
+				{listedChats.map((item, index) => {
 					const chatMode = (item as ProjectChat & { chat_mode?: string })
 						.chat_mode as
 						| "overview"
@@ -154,7 +214,11 @@ const ProjectChatsSection = ({
 									<ChatAccordionItemMenu chat={item as ProjectChat} />
 								</Group>
 							}
-							ref={index === visibleChats.length - 1 ? loadMoreRef : undefined}
+							ref={
+								!isSearching && index === listedChats.length - 1
+									? loadMoreRef
+									: undefined
+							}
 						>
 							<Stack gap={2}>
 								<Text size="sm" lineClamp={1}>
@@ -222,9 +286,9 @@ export const NewChatRoute = () => {
 	const [selectedConversationIds, setSelectedConversationIds] = useState<
 		string[]
 	>(() => {
-		const state = location.state as
-			| { selectedConversationIds?: unknown }
-			| null;
+		const state = location.state as {
+			selectedConversationIds?: unknown;
+		} | null;
 		return Array.isArray(state?.selectedConversationIds)
 			? state.selectedConversationIds.filter(
 					(id): id is string => typeof id === "string",
@@ -232,6 +296,7 @@ export const NewChatRoute = () => {
 			: [];
 	});
 	const [pickerOpened, pickerHandlers] = useDisclosure(false);
+	const [agenticIntroOpened, agenticIntroHandlers] = useDisclosure(false);
 
 	const handleModeSelected = async (
 		mode: ChatMode,
@@ -405,120 +470,96 @@ export const NewChatRoute = () => {
 						<Title order={2} fw={500}>
 							<Trans>Where would you like to start?</Trans>
 						</Title>
-						<Textarea
-							autosize
-							minRows={2}
-							maxRows={6}
-							radius="lg"
-							size="sm"
-							autoFocus
-							value={draft}
-							onChange={(event) => setDraft(event.currentTarget.value)}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" && !event.shiftKey) {
-									event.preventDefault();
-									startChat();
-								}
-							}}
-							placeholder={t`Ask about your conversations, or type to find an earlier chat`}
-							disabled={isPending}
-							styles={{
-								input: { backgroundColor: "transparent", resize: "none" },
-							}}
-							className="rounded-lg border shadow-sm"
-							style={{
-								backgroundColor: "var(--app-background)",
-								borderColor: "var(--mantine-color-primary-light)",
-							}}
-							rightSectionWidth={52}
-							rightSection={
-								isPending ? (
-									<Loader size="xs" />
-								) : (
-									<ActionIcon
-										size="lg"
-										radius="xl"
-										aria-label={t`Start a chat`}
-										onClick={startChat}
-										disabled={draft.trim().length === 0}
-									>
-										<IconArrowUp size={18} />
-									</ActionIcon>
-								)
-							}
-							{...{ "data-testid": "ask-home-input" }}
-						/>
 						{/* The picker has to be reachable from an empty selection: this
 						    screen is where a host narrows the chat before it exists. */}
-						<Group gap="sm" align="center">
-							{selectedConversationIds.length > 0 ? (
-								<>
-									<Text size="sm">
-										{modeToStart === "agentic" ? (
-											<Plural
-												value={selectedConversationIds.length}
-												one="Focusing on # conversation"
-												other="Focusing on # conversations"
-											/>
-										) : (
-											<Plural
-												value={selectedConversationIds.length}
-												one="Using # conversation"
-												other="Using # conversations"
-											/>
-										)}
-									</Text>
-									<Button
-										variant="subtle"
-										size="xs"
+						<ChatComposerShell
+							chips={
+								selectedConversationIds.length > 0 ? (
+									<ConversationFocusChips
+										count={selectedConversationIds.length}
 										disabled={isPending}
-										onClick={pickerHandlers.open}
-									>
-										<Trans>Change</Trans>
-									</Button>
-									<Button
-										variant="subtle"
-										size="xs"
-										disabled={isPending}
-										onClick={() => setSelectedConversationIds([])}
-									>
-										<Trans>Clear</Trans>
-									</Button>
-								</>
-							) : (
-								<Button
-									variant="subtle"
-									size="xs"
+										label={
+											modeToStart === "agentic" ? (
+												<Plural
+													value={selectedConversationIds.length}
+													one="Focusing on # conversation"
+													other="Focusing on # conversations"
+												/>
+											) : (
+												<Plural
+													value={selectedConversationIds.length}
+													one="Using # conversation"
+													other="Using # conversations"
+												/>
+											)
+										}
+										onClearAll={() => setSelectedConversationIds([])}
+									/>
+								) : undefined
+							}
+							footerLeft={
+								<ConversationPickerButton
+									ariaLabel={t`Choose conversations`}
 									disabled={isPending}
+									label={<Trans>Choose conversations</Trans>}
 									onClick={pickerHandlers.open}
-									{...{ "data-testid": "ask-home-choose-conversations" }}
+									testId="ask-home-choose-conversations"
+								/>
+							}
+							footerRight={
+								<Button
+									type="button"
+									size="sm"
+									radius="md"
+									leftSection={
+										isPending ? <Loader size={14} /> : <IconSend size={14} />
+									}
+									disabled={isPending || draft.trim().length === 0}
+									onClick={startChat}
+									{...testId("ask-home-send-button")}
 								>
-									<Trans>Choose conversations</Trans>
+									<Trans>Send</Trans>
 								</Button>
-							)}
-						</Group>
-						<Group gap="lg">
-							<InsertTemplateMenu
-								workspaceId={workspaceId}
-								onInsert={(content) => setDraft(content)}
+							}
+						>
+							<Textarea
+								variant="unstyled"
+								styles={{
+									input: { backgroundColor: "transparent", resize: "none" },
+								}}
+								autosize
+								minRows={2}
+								maxRows={10}
+								autoFocus
+								value={draft}
+								onChange={(event) => setDraft(event.currentTarget.value)}
+								onKeyDown={(event) => {
+									if (event.key === "Enter" && !event.shiftKey) {
+										event.preventDefault();
+										startChat();
+									}
+								}}
+								placeholder={t`Ask about your conversations...`}
+								disabled={isPending}
+								{...testId("ask-home-input")}
 							/>
-							{ASK_DOCS_URL && (
-								<Anchor
-									size="xs"
-									href={ASK_DOCS_URL}
-									target="_blank"
-									rel="noreferrer"
-								>
-									<Trans>What can Ask do?</Trans>
-								</Anchor>
-							)}
-						</Group>
+						</ChatComposerShell>
 						<Group gap="xs" align="center">
 							<Button
 								variant="subtle"
 								size="xs"
 								disabled={isPending}
-								onClick={startAgentic}
+								leftSection={<ChatModeIndicator mode="agentic" size="xs" />}
+								styles={{
+									section: { marginRight: "var(--mantine-spacing-sm)" },
+								}}
+								onClick={() => {
+									posthog.capture("agentic_chat_intro_opened", {
+										source: "ask_home",
+									});
+									agenticIntroHandlers.open();
+								}}
+								{...testId("ask-home-try-agentic")}
 							>
 								<Trans>Try Agentic instead</Trans>
 							</Button>
@@ -543,7 +584,6 @@ export const NewChatRoute = () => {
 
 				<Suspense fallback={<ChatsSectionSkeleton />}>
 					<ProjectChatsSection
-						filter={ENABLE_AGENTIC_CHAT ? draft : undefined}
 						projectId={projectId}
 						workspaceId={workspaceId}
 					/>
@@ -571,6 +611,17 @@ export const NewChatRoute = () => {
 					/>
 				)}
 			</Modal>
+			<AgenticIntroModal
+				opened={agenticIntroOpened}
+				onClose={agenticIntroHandlers.close}
+				onConfirm={() => {
+					posthog.capture("agentic_chat_intro_confirmed", {
+						source: "ask_home",
+					});
+					agenticIntroHandlers.close();
+					startAgentic();
+				}}
+			/>
 		</PageContainer>
 	);
 };

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -1,8 +1,9 @@
 import { useChat } from "@ai-sdk/react";
 import { t } from "@lingui/core/macro";
-import { Trans } from "@lingui/react/macro";
+import { Plural, Trans } from "@lingui/react/macro";
 import {
 	Alert,
+	Badge,
 	Box,
 	Button,
 	Divider,
@@ -15,7 +16,6 @@ import {
 	Title,
 } from "@mantine/core";
 import { useDisclosure, useDocumentTitle } from "@mantine/hooks";
-import { ChatCircleTextIcon } from "@phosphor-icons/react";
 import { usePostHog } from "@posthog/react";
 import {
 	IconAlertCircle,
@@ -23,20 +23,23 @@ import {
 	IconSend,
 	IconSquare,
 } from "@tabler/icons-react";
-import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router";
-import { useCurrentUser } from "@/components/auth/hooks";
 import { AgenticChatPanel } from "@/components/chat/AgenticChatPanel";
 import {
 	ChatAccordionItemMenu,
 	ChatModeIndicator,
 } from "@/components/chat/ChatAccordion";
+import {
+	ChatComposerShell,
+	ConversationFocusChips,
+	ConversationPickerButton,
+} from "@/components/chat/ChatComposer";
 import { ChatContextProgress } from "@/components/chat/ChatContextProgress";
 import { ChatHistoryMessage } from "@/components/chat/ChatHistoryMessage";
 import { ChatMessage } from "@/components/chat/ChatMessage";
 import { ChatModeSelector } from "@/components/chat/ChatModeSelector";
-import { ChatTemplatesMenu } from "@/components/chat/ChatTemplatesMenu";
+import { ChatTemplatesMenuConnected } from "@/components/chat/ChatTemplatesMenuConnected";
 import { formatMessage } from "@/components/chat/chatUtils";
 import {
 	ChatTurnLimitCard,
@@ -45,31 +48,23 @@ import {
 import {
 	useAddChatMessageMutation,
 	useChatHistory,
-	useChatSuggestions,
 	useInitializeChatModeMutation,
 	useLockConversationsMutation,
 	usePrefetchSuggestions,
 	useChat as useProjectChat,
 	useProjectChatContext,
 } from "@/components/chat/hooks";
-import {
-	useCreateUserTemplate,
-	useDeleteUserTemplate,
-	useQuickAccessPreferences,
-	useSaveQuickAccessPreferences,
-	useToggleAiSuggestions,
-	useUpdateUserTemplate,
-	useUserTemplates,
-} from "@/components/chat/hooks/useUserTemplates";
 import { consumeChatPrefill } from "@/components/chat/prefill";
-import type { QuickAccessItem } from "@/components/chat/templateKey";
-import { Templates } from "@/components/chat/templates";
 import { CopyRichTextIconButton } from "@/components/common/CopyRichTextIconButton";
 import { Logo } from "@/components/common/Logo";
 import { ScrollToBottomButton } from "@/components/common/ScrollToBottom";
 import { toast } from "@/components/common/Toaster";
+import { useStickToBottom } from "@/components/common/useStickToBottom";
 import { ConversationLinks } from "@/components/conversation/ConversationLinks";
-import { useConversationsCountByProjectId } from "@/components/conversation/hooks";
+import {
+	useClearChatContextMutation,
+	useConversationsCountByProjectId,
+} from "@/components/conversation/hooks";
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { useProjectById } from "@/components/project/hooks";
@@ -78,15 +73,14 @@ import {
 	API_BASE_URL,
 	ENABLE_AGENTIC_CHAT,
 } from "@/config";
-import { useElementOnScreen } from "@/hooks/useElementOnScreen";
 import { useLanguage } from "@/hooks/useLanguage";
 import { useLoadNotification } from "@/hooks/useLoadNotification";
 import { useWorkspace } from "@/hooks/useWorkspace";
 import { useWorkspaceUsage } from "@/hooks/useWorkspaceUsage";
 import { FREE_TIER_MAX_CHAT_USER_TURNS } from "@/lib/freeTier";
 import { isReadOnlyRole } from "@/lib/roles";
-import { resolveChatScreen } from "./chatModeRouting";
 import { testId } from "@/lib/testUtils";
+import { resolveChatScreen } from "./chatModeRouting";
 
 const useDembraneChat = ({ chatId }: { chatId: string }) => {
 	const chatHistoryQuery = useChatHistory(chatId);
@@ -95,18 +89,17 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 
 	const [templateKey, setTemplateKey] = useState<string | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	// Local stand-in for the server's "dembrane" context-added message, shown
+	// instantly instead of waiting on a history refetch (see customHandleSubmit).
+	const [pendingContextAnnouncement, setPendingContextAnnouncement] = useState<
+		TProjectChatContext["conversations"]
+	>([]);
 
 	const addChatMessageMutation = useAddChatMessageMutation();
 	const lockConversationsMutation = useLockConversationsMutation();
 
 	const lastInput = useRef("");
 	const lastMessageRef = useRef<HTMLDivElement>(null);
-
-	const [scrollTargetRef, isVisible] = useElementOnScreen({
-		root: null,
-		rootMargin: "-83px",
-		threshold: 0.1,
-	});
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: needs to be fixed
 	const contextToBeAdded = useMemo(() => {
@@ -216,11 +209,20 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 	const customHandleSubmit = async () => {
 		lastInput.current = input;
 		setIsSubmitting(true);
+		setPendingContextAnnouncement([]);
+
+		// Snapshot the not-yet-locked conversations before locking, so the
+		// announcement can render instantly instead of waiting on a refetch.
+		const conversationsBeingAdded = contextToBeAdded?.conversations ?? [];
 
 		try {
 			// Lock conversations first
 			await lockConversationsMutation.mutateAsync({ chatId });
 			await chatContextQuery.refetch();
+
+			if (conversationsBeingAdded.length > 0) {
+				setPendingContextAnnouncement(conversationsBeingAdded);
+			}
 
 			// Submit the chat
 			handleSubmit();
@@ -253,6 +255,8 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 		) {
 			// @ts-expect-error chatHistoryQuery.data is not typed
 			setMessages(chatHistoryQuery.data ?? messages);
+			// Real message has arrived; drop the stand-in so it doesn't double up.
+			setPendingContextAnnouncement([]);
 		}
 	}, [
 		chatHistoryQuery.data,
@@ -271,12 +275,11 @@ const useDembraneChat = ({ chatId }: { chatId: string }) => {
 		isInitializing: chatHistoryQuery.isLoading,
 		isLoading,
 		isSubmitting,
-		isVisible,
 		lastInputRef: lastInput,
 		lastMessageRef,
 		messages,
+		pendingContextAnnouncement,
 		reload,
-		scrollTargetRef,
 		setInput,
 		setTemplateKey,
 		status,
@@ -327,9 +330,9 @@ export const ProjectChatRoute = () => {
 	// Observers are free, read-only: chat is the upgrade wall. Server denies
 	// chat:use (403); the UI blocks here with a clear path to upgrade.
 	const isObserver = isReadOnlyRole(workspace?.role);
-	const queryClient = useQueryClient();
 	const chatQuery = useProjectChat(chatId ?? "");
 	const chatContextQuery = useProjectChatContext(chatId ?? "");
+	const clearChatContextMutation = useClearChatContextMutation();
 	const [referenceIds, setReferenceIds] = useState<string[]>([]);
 	const [templatesModalOpen, setTemplatesModalOpen] = useState(false);
 	const [saveAsTemplateContent, setSaveAsTemplateContent] = useState<
@@ -367,17 +370,18 @@ export const ProjectChatRoute = () => {
 	const isLegacyChat = rawChatMode == null && hasLockedConversations;
 	const chatMode = isLegacyChat ? "deep_dive" : rawChatMode;
 	const isModeSelected = chatMode !== null && chatMode !== undefined;
-	const isDeepDiveMode = chatMode === "deep_dive";
 	const isAgenticMode = chatMode === "agentic";
+
+	// Locked + not-yet-locked, so this stays visible after conversations lock.
+	const conversationCount = chatContextQuery.data?.conversations?.length ?? 0;
 
 	// Get total conversations count for overview mode
 	const _totalConversationsQuery = useConversationsCountByProjectId(
 		projectId ?? "",
 	);
 
-	// User templates & preferences. Fetch the project's workspace_id so
-	// the templates hook can return BOTH personal (scope='user') and
-	// workspace-shared (scope='workspace') templates for this workspace.
+	// Fetch the project's workspace_id: needed for the conversation picker
+	// modal below (workspace-scoped conversation list).
 	const projectForWorkspace = useProjectById({
 		projectId: projectId ?? "",
 		query: { fields: ["id", "workspace_id"] },
@@ -385,114 +389,10 @@ export const ProjectChatRoute = () => {
 	const projectWorkspaceId =
 		(projectForWorkspace.data as { workspace_id?: string | null } | undefined)
 			?.workspace_id ?? null;
-	const currentUserQuery = useCurrentUser();
-	const userTemplatesQuery = useUserTemplates(projectWorkspaceId);
-	const createUserTemplateMutation = useCreateUserTemplate(projectWorkspaceId);
-	const updateUserTemplateMutation = useUpdateUserTemplate(projectWorkspaceId);
-	const deleteUserTemplateMutation = useDeleteUserTemplate(projectWorkspaceId);
-	const quickAccessQuery = useQuickAccessPreferences();
-	const saveQuickAccessMutation = useSaveQuickAccessPreferences();
-	const toggleAiSuggestionsMutation = useToggleAiSuggestions();
-
-	const hideAiSuggestions = currentUserQuery.data?.hide_ai_suggestions ?? false;
-
-	// Resolve quick access items — default to first 3 built-in templates
-	const quickAccessItems: QuickAccessItem[] = useMemo(() => {
-		if (!quickAccessQuery.data || quickAccessQuery.data.length === 0)
-			return Templates.slice(0, 3).map((t) => ({
-				id: t.id,
-				title: t.title,
-				type: "static" as const,
-			}));
-		return quickAccessQuery.data
-			.map((pref) => {
-				if (pref.type === "static") {
-					const found = Templates.find((t) => t.id === pref.id);
-					if (found)
-						return {
-							id: found.id,
-							title: found.title,
-							type: "static" as const,
-						};
-				} else if (pref.type === "user") {
-					const found = userTemplatesQuery.data?.find((t) => t.id === pref.id);
-					if (found)
-						return {
-							id: found.id,
-							title: found.title,
-							type: "user" as const,
-						};
-				}
-				return null;
-			})
-			.filter(Boolean) as QuickAccessItem[];
-	}, [quickAccessQuery.data, userTemplatesQuery.data]);
-
-	const handleSaveQuickAccess = (items: QuickAccessItem[]) => {
-		saveQuickAccessMutation.mutate(
-			items.map((item) => ({
-				id: item.id,
-				type: item.type,
-			})),
-		);
-	};
 
 	// Language for suggestions
 	const { language } = useLanguage();
 	const prefetchSuggestions = usePrefetchSuggestions();
-
-	// Track conversation count for deep_dive mode to trigger suggestions refetch
-	const conversationCount = chatContextQuery.data?.conversations?.length ?? 0;
-	const prevConversationCountRef = useRef<number | null>(null);
-
-	// Fetch suggestions:
-	// - Overview mode: Fetch immediately when mode is selected
-	// - Deep dive mode: Only fetch after conversations are added (not on initial load)
-	const shouldFetchSuggestions =
-		isModeSelected &&
-		!isAgenticMode &&
-		!hideAiSuggestions &&
-		(!isDeepDiveMode || // overview mode: always fetch
-			conversationCount > 0); // deep_dive mode: only when conversations exist
-
-	const suggestionsQuery = useChatSuggestions(chatId ?? "", {
-		enabled: shouldFetchSuggestions,
-		language,
-	});
-
-	// Refetch suggestions when conversation context changes in deep_dive mode
-	// Cancel previous query and start a new one
-	useEffect(() => {
-		if (!isDeepDiveMode || !chatId) return;
-
-		// Skip on initial mount
-		if (prevConversationCountRef.current === null) {
-			prevConversationCountRef.current = conversationCount;
-			return;
-		}
-
-		// Only refetch if count actually changed
-		if (prevConversationCountRef.current !== conversationCount) {
-			prevConversationCountRef.current = conversationCount;
-
-			// Cancel any in-flight suggestions query
-			queryClient.cancelQueries({
-				queryKey: ["chats", chatId, "suggestions", language],
-			});
-
-			// Refetch suggestions if we have conversations
-			if (conversationCount > 0) {
-				suggestionsQuery.refetch();
-			}
-		}
-	}, [
-		conversationCount,
-		isDeepDiveMode,
-		chatId,
-		language,
-		queryClient,
-		suggestionsQuery,
-	]);
 
 	const {
 		isInitializing,
@@ -503,8 +403,7 @@ export const ProjectChatRoute = () => {
 		error,
 		contextToBeAdded,
 		lastMessageRef,
-		scrollTargetRef,
-		isVisible,
+		pendingContextAnnouncement,
 		setInput,
 		handleInputChange,
 		handleSubmit,
@@ -515,6 +414,10 @@ export const ProjectChatRoute = () => {
 		statusMessage,
 	} = useDembraneChat({ chatId: chatId ?? "" });
 	const normalizedInput = typeof input === "string" ? input : "";
+
+	const threadAnchorRef = useRef<HTMLDivElement>(null);
+	const { showScrollButton, scrollToBottom } =
+		useStickToBottom(threadAnchorRef);
 
 	// Which screen this chat opens on. Pure and unit-tested in
 	// ./chatModeRouting, because setting a mode is one-way: the server refuses
@@ -663,11 +566,12 @@ export const ProjectChatRoute = () => {
 		}
 	}, [normalizedInput, templateKey, setTemplateKey]);
 
-	// Track if we need to refetch suggestions after assistant response
+	// Bump this whenever the assistant finishes responding, so
+	// ChatTemplatesMenuConnected knows to refetch suggestions.
+	const [assistantResponseTick, setAssistantResponseTick] = useState(0);
 	const prevIsLoadingRef = useRef(isLoading);
 	const lastMessageRole = messages?.[messages.length - 1]?.role;
 
-	// Refetch suggestions when assistant finishes responding
 	useEffect(() => {
 		// Detect transition from loading to not loading with assistant message
 		if (
@@ -675,11 +579,10 @@ export const ProjectChatRoute = () => {
 			!isLoading &&
 			lastMessageRole === "assistant"
 		) {
-			// Refetch suggestions after assistant response completes
-			suggestionsQuery.refetch();
+			setAssistantResponseTick((n) => n + 1);
 		}
 		prevIsLoadingRef.current = isLoading;
-	}, [isLoading, lastMessageRole, suggestionsQuery]);
+	}, [isLoading, lastMessageRole]);
 
 	if (isInitializing || chatQuery.isLoading || chatContextQuery.isLoading) {
 		return (
@@ -785,7 +688,7 @@ export const ProjectChatRoute = () => {
 				<Divider />
 			</Stack>
 			{/* Body */}
-			<Box className="flex-grow">
+			<Box className="flex-grow" ref={threadAnchorRef}>
 				<Stack py="sm" pb="xl" className="relative h-full w-full">
 					<ChatHistoryMessage
 						// @ts-expect-error chatHistoryQuery.data is not typed
@@ -817,6 +720,27 @@ export const ProjectChatRoute = () => {
 								/>
 							</div>
 						))}
+
+					{pendingContextAnnouncement.length > 0 &&
+						messages.length > 0 &&
+						(messages[messages.length - 1].role === "user" || isLoading) && (
+							// biome-ignore lint/a11y/useValidAriaRole: role is a component prop for styling, not an ARIA attribute
+							<ChatMessage role="dembrane">
+								<Group gap="xs" align="baseline">
+									<Text size="xs" fw={500}>
+										<Trans>Context added:</Trans>
+									</Text>
+									<ConversationLinks
+										conversations={
+											pendingContextAnnouncement.map((c) => ({
+												id: c.conversation_id,
+												participant_name: c.conversation_participant_name,
+											})) as unknown as Conversation[]
+										}
+									/>
+								</Group>
+							</ChatMessage>
+						)}
 
 					{messages &&
 						messages.length > 0 &&
@@ -912,9 +836,6 @@ export const ProjectChatRoute = () => {
 				</Stack>
 			</Box>
 
-			{/* Scroll target for scroll to bottom button */}
-			<div ref={scrollTargetRef} aria-hidden="true" />
-
 			{/* Footer */}
 			<Box
 				className="bottom-0 w-full pb-2 pt-4 md:sticky"
@@ -927,94 +848,49 @@ export const ProjectChatRoute = () => {
 						className="absolute bottom-[105%] right-4 z-50 hidden md:flex"
 					>
 						<ScrollToBottomButton
-							elementRef={scrollTargetRef}
-							isVisible={isVisible}
+							visible={showScrollButton}
+							onClick={() => scrollToBottom("smooth")}
 						/>
 					</Group>
 
-					<ChatTemplatesMenu
+					<ChatTemplatesMenuConnected
+						chatId={chatId}
+						chatMode={chatMode}
+						projectId={projectId}
 						externalOpen={templatesModalOpen}
 						onExternalClose={() => setTemplatesModalOpen(false)}
 						onTemplateSelect={handleTemplateSelect}
 						selectedTemplateKey={templateKey}
-						suggestions={
-							hideAiSuggestions ? [] : suggestionsQuery.data?.suggestions
-						}
-						chatMode={chatMode}
-						userTemplates={userTemplatesQuery.data ?? []}
-						canCreateWorkspaceTemplate={Boolean(projectWorkspaceId)}
-						onCreateUserTemplate={(payload) =>
-							createUserTemplateMutation.mutateAsync(payload)
-						}
-						onUpdateUserTemplate={(payload) =>
-							updateUserTemplateMutation.mutateAsync(payload)
-						}
-						onDeleteUserTemplate={(id) =>
-							deleteUserTemplateMutation.mutateAsync(id)
-						}
-						isCreatingTemplate={createUserTemplateMutation.isPending}
-						isUpdatingTemplate={updateUserTemplateMutation.isPending}
-						isDeletingTemplate={deleteUserTemplateMutation.isPending}
-						quickAccessItems={quickAccessItems}
-						onSaveQuickAccess={handleSaveQuickAccess}
-						isSavingQuickAccess={saveQuickAccessMutation.isPending}
-						hideAiSuggestions={hideAiSuggestions}
-						onToggleAiSuggestions={(hide) =>
-							toggleAiSuggestionsMutation.mutate(hide)
-						}
 						saveAsTemplateContent={saveAsTemplateContent}
 						onClearSaveAsTemplate={() => setSaveAsTemplateContent(null)}
+						refetchSuggestionsKey={assistantResponseTick}
 					/>
 
 					<Divider />
-					{chatMode !== "overview" && (
-						<Group justify="space-between" gap="sm" wrap="wrap">
-							<Text size="xs" c="dimmed" fw={500}>
-								<Trans>
-									{conversationCount} conversations selected for this chat
-								</Trans>
-							</Text>
-							<Button
-								variant="light"
-								size="xs"
-								leftSection={<ChatCircleTextIcon size={16} />}
-								onClick={() => setConversationPickerOpen(true)}
-								{...testId("chat-select-conversations-button")}
-							>
-								<Trans>Select conversations</Trans>
-							</Button>
-						</Group>
-					)}
 					{needsConversations && (
 						<Alert
 							icon={<IconAlertCircle size="1rem" />}
-							title={t`Select conversations to continue`}
+							title={
+								<Group gap={6} wrap="nowrap">
+									<Text component="span" inherit>
+										<Trans>Select conversations to continue:</Trans>
+									</Text>
+									<Text
+										component="span"
+										size="sm"
+										fw={400}
+										style={{ color: "var(--app-text)" }}
+									>
+										<Trans>
+											Specific Details needs at least one conversation.
+										</Trans>
+									</Text>
+								</Group>
+							}
 							color="orange"
 							variant="light"
 							{...testId("chat-no-conversations-alert")}
-						>
-							<Text size="sm">
-								<Trans>Specific Details needs at least one conversation.</Trans>
-							</Text>
-						</Alert>
-					)}
-
-					{contextToBeAdded && contextToBeAdded.conversations.length > 0 && (
-						// biome-ignore lint/a11y/useValidAriaRole: this is not an ARIA attribute
-						<ChatMessage role="dembrane">
-							<Group gap="xs" align="baseline">
-								<Text size="xs" c="dimmed" fw={500} px="sm">
-									<Trans>Conversations:</Trans>
-								</Text>
-								<ConversationLinks
-									// @ts-expect-error conversation_id is not typed
-									conversations={contextToBeAdded.conversations.map((c) => ({
-										id: c.conversation_id,
-										participant_name: c.conversation_participant_name,
-									}))}
-								/>
-							</Group>
-						</ChatMessage>
+						/>
 					)}
 
 					{/* Only show context progress in deep dive mode - Big Picture uses dynamic summaries */}
@@ -1034,69 +910,108 @@ export const ProjectChatRoute = () => {
 							guardedSubmit();
 						}}
 					>
-						<Group className="flex-nowrap">
-							<Box className="grow">
-								<Textarea
-									placeholder={t`Type a message or press / for templates...`}
-									minRows={4}
-									maxRows={10}
-									autosize
-									value={normalizedInput}
-									onChange={handleInputChange}
-									disabled={isLoading || isSubmitting || atTurnLimit}
-									onKeyDown={(e) => {
-										if (e.key === "/" && normalizedInput.trim() === "") {
-											e.preventDefault();
-											setTemplatesModalOpen(true);
-											return;
+						<ChatComposerShell
+							chips={
+								chatMode !== "overview" &&
+								contextToBeAdded &&
+								contextToBeAdded.conversations.length > 0 ? (
+									<ConversationFocusChips
+										conversations={contextToBeAdded.conversations.map((c) => ({
+											id: c.conversation_id,
+											participant_name: c.conversation_participant_name,
+										}))}
+										isClearing={clearChatContextMutation.isPending}
+										label={
+											<Plural
+												value={contextToBeAdded.conversations.length}
+												one="Using # conversation:"
+												other="Using # conversations:"
+											/>
 										}
-										if (e.key === "Enter" && !e.shiftKey) {
-											e.preventDefault();
-											e.stopPropagation();
-											guardedSubmit();
+										onClearAll={() =>
+											clearChatContextMutation.mutate({
+												chatId: chatId ?? "",
+												conversationIds: contextToBeAdded.conversations.map(
+													(c) => c.conversation_id,
+												),
+											})
 										}
-									}}
-									color="gray"
-									{...testId("chat-input-textarea")}
-								/>
-								<Group
-									justify="space-between"
-									gap="sm"
-									className="mt-1 hidden lg:flex"
+									/>
+								) : undefined
+							}
+							footerLeft={
+								chatMode !== "overview" ? (
+									<Group gap={4} wrap="nowrap" align="center">
+										<ConversationPickerButton
+											ariaLabel={t`Select conversations`}
+											label={<Trans>Select conversations</Trans>}
+											onClick={() => setConversationPickerOpen(true)}
+											testId="chat-select-conversations-button"
+										/>
+										{conversationCount > 0 && (
+											<Badge variant="light">{conversationCount}</Badge>
+										)}
+									</Group>
+								) : undefined
+							}
+							footerRight={
+								<Button
+									type="submit"
+									size="sm"
+									radius="md"
+									rightSection={<IconSend size={14} />}
+									disabled={
+										normalizedInput.trim() === "" ||
+										isLoading ||
+										isSubmitting ||
+										atTurnLimit
+									}
+									{...testId("chat-send-button")}
 								>
-									<Text size="xs" className="italic" c="dimmed">
-										<Trans>Use Shift + Enter to add a new line</Trans>
-									</Text>
-									<Text size="xs" className="italic" c="dimmed">
-										<Trans>
-											dembrane can make mistakes. Please double-check responses.
-										</Trans>
-									</Text>
-								</Group>
-							</Box>
-							<Stack className="h-full self-start" gap="xs">
-								<Box>
-									<Button
-										size="lg"
-										type="submit"
-										onClick={(e) => {
-											e.preventDefault();
-											e.stopPropagation();
-											guardedSubmit();
-										}}
-										rightSection={<IconSend size={24} />}
-										disabled={
-											normalizedInput.trim() === "" ||
-											isLoading ||
-											isSubmitting ||
-											atTurnLimit
-										}
-										{...testId("chat-send-button")}
-									>
-										<Trans>Send</Trans>
-									</Button>
-								</Box>
-							</Stack>
+									<Trans>Send</Trans>
+								</Button>
+							}
+						>
+							<Textarea
+								variant="unstyled"
+								styles={{
+									input: { backgroundColor: "transparent", resize: "none" },
+								}}
+								placeholder={t`Type a message or press / for templates...`}
+								minRows={2}
+								maxRows={10}
+								autosize
+								value={normalizedInput}
+								onChange={handleInputChange}
+								disabled={isLoading || isSubmitting || atTurnLimit}
+								onKeyDown={(e) => {
+									if (e.key === "/" && normalizedInput.trim() === "") {
+										e.preventDefault();
+										setTemplatesModalOpen(true);
+										return;
+									}
+									if (e.key === "Enter" && !e.shiftKey) {
+										e.preventDefault();
+										e.stopPropagation();
+										guardedSubmit();
+									}
+								}}
+								{...testId("chat-input-textarea")}
+							/>
+						</ChatComposerShell>
+						<Group
+							justify="space-between"
+							gap="sm"
+							className="mt-1 hidden lg:flex"
+						>
+							<Text size="xs" className="italic" c="dimmed">
+								<Trans>Use Shift + Enter to add a new line</Trans>
+							</Text>
+							<Text size="xs" className="italic" c="dimmed">
+								<Trans>
+									dembrane can make mistakes. Please double-check responses.
+								</Trans>
+							</Text>
 						</Group>
 						<Stack gap="sm" className="mt-1 flex lg:hidden">
 							<Text size="xs" className="italic" c="dimmed">

--- a/echo/server/dembrane/api/v2/bff/chats.py
+++ b/echo/server/dembrane/api/v2/bff/chats.py
@@ -63,7 +63,6 @@ async def create_chat(
     ):
         raise free_tier_limit_error("chats")
 
-
     payload: dict = {
         "id": generate_uuid(),
         "project_id": body.project_id,
@@ -84,10 +83,12 @@ async def list_chats(
     limit: int = Query(15, ge=1, le=200),
     offset: int = Query(0, ge=0),
     has_messages: bool = Query(False),
+    q: Optional[str] = Query(None, max_length=200),
 ) -> dict:
     """List chats in a project. Returns {chats, total}.
 
     has_messages=true excludes chats with zero messages from page and total.
+    q filters by chat name, case-insensitive substring, applied to both.
     """
     access = await resolve_project_access(project_id, auth)
     access.require("chat:use")
@@ -95,6 +96,9 @@ async def list_chats(
     base_filter: dict = {"project_id": {"_eq": project_id}}
     if has_messages:
         base_filter["count(project_chat_messages)"] = {"_gt": 0}
+    search = (q or "").strip()
+    if search:
+        base_filter["name"] = {"_icontains": search}
     filt = filter_exclude_deleted(base_filter)
 
     chats = (

--- a/echo/server/tests/test_bff_chats_search.py
+++ b/echo/server/tests/test_bff_chats_search.py
@@ -1,0 +1,90 @@
+import pytest
+
+from dembrane.api.v2.bff.chats import list_chats
+
+
+class _RecordingDirectus:
+    """Captures the query each call receives so the test can assert on the
+    filter shape rather than on Directus behavior."""
+
+    def __init__(self) -> None:
+        self.queries: list[dict] = []
+
+    async def get_items(self, collection: str, payload: dict):
+        self.queries.append({"collection": collection, "payload": payload})
+        query = payload.get("query", {})
+        if "aggregate" in query:
+            return [{"count": {"id": 2}}]
+        return [{"id": "chat-1", "name": "Budget questions"}]
+
+
+class _Access:
+    workspace_id = "ws-1"
+    tier = "pro"
+
+    def require(self, _scope: str) -> None:
+        return None
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    directus = _RecordingDirectus()
+    monkeypatch.setattr("dembrane.api.v2.bff.chats.async_directus", directus)
+
+    async def _resolve(_project_id: str, _auth):
+        return _Access()
+
+    monkeypatch.setattr("dembrane.api.v2.bff.chats.resolve_project_access", _resolve)
+    return directus
+
+
+# Every parameter is passed explicitly on these direct calls. Bypassing the
+# router means FastAPI never resolves the `Query(...)` defaults, and a leftover
+# `Query(False)` sentinel is a truthy object: letting `has_messages` default
+# here would silently add the has-messages clause to every test.
+_DEFAULTS = {"limit": 15, "offset": 0, "has_messages": False}
+
+
+@pytest.mark.asyncio
+async def test_search_filters_page_and_total(patched) -> None:
+    result = await list_chats(auth=None, project_id="p-1", q="budget", **_DEFAULTS)
+
+    assert result["total"] == 2
+    page_filter = patched.queries[0]["payload"]["query"]["filter"]
+    count_filter = patched.queries[1]["payload"]["query"]["filter"]
+    assert page_filter["name"] == {"_icontains": "budget"}
+    # The count must use the same filter, or the header number disagrees with
+    # the list the host is looking at.
+    assert count_filter == page_filter
+
+
+@pytest.mark.asyncio
+async def test_blank_search_is_ignored(patched) -> None:
+    await list_chats(auth=None, project_id="p-1", q="   ", **_DEFAULTS)
+
+    page_filter = patched.queries[0]["payload"]["query"]["filter"]
+    assert "name" not in page_filter
+
+
+@pytest.mark.asyncio
+async def test_absent_search_is_ignored(patched) -> None:
+    await list_chats(auth=None, project_id="p-1", q=None, **_DEFAULTS)
+
+    page_filter = patched.queries[0]["payload"]["query"]["filter"]
+    assert "name" not in page_filter
+
+
+@pytest.mark.asyncio
+async def test_search_composes_with_has_messages(patched) -> None:
+    await list_chats(
+        auth=None,
+        project_id="p-1",
+        q="budget",
+        limit=15,
+        offset=0,
+        has_messages=True,
+    )
+
+    page_filter = patched.queries[0]["payload"]["query"]["filter"]
+    assert page_filter["name"] == {"_icontains": "budget"}
+    assert page_filter["count(project_chat_messages)"] == {"_gt": 0}


### PR DESCRIPTION
implementation instead of three drifting copies
  - Fix classic Specific Details to show "Context added" instantly on send, replacing a fragile history-refetch race with a local stand-in that's swapped for the real message once history reconciles
  - Fix scroll-to-bottom detection for chats that render their thread after an initial loading/mode-picker screen; the anchor-wait path now uses a scoped MutationObserver (via a new data-app-scroll-root marker) instead of a busy per-frame poll
  - Give agentic template pills their mode-accent border and fix long labels overflowing instead of truncating
  - Add a count-only mode to ConversationFocusChips and use it on the New Chat picker screen, removing a duplicated hand-rolled chips block
  - Add a disabled prop to ConversationFocusChips, separate from isClearing, so blocking the control for unrelated reasons doesn't misuse the clear-action's own loading state
  - Revert the agentic error-message masking added earlier in this branch (agentic_worker.py) to redo it together with a related prompt fix, rather than ship a half-finished whitelist
  - Add test coverage for the previously untested ConversationFocusChips precedence rules and the useStickToBottom hook's container resolution, scroll-target selection, and resize/mutation-driven remeasurement