### PR TITLE
fix(chat): composer polish, conversation picker placement, insight soft-delete

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -27,7 +27,7 @@ import {
 	IconSend,
 	IconSparkles,
 } from "@tabler/icons-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
 import {
 	type CSSProperties,
@@ -70,8 +70,10 @@ import type {
 import {
 	appendAgenticRunMessage,
 	createAgenticRun,
+	dismissAgentInsight,
 	getAgenticRun,
 	getAgenticRunEvents,
+	getDismissedAgentInsightIds,
 	getLatestAgenticRunForChat,
 	stopAgenticRun,
 	streamAgenticRun,
@@ -658,6 +660,23 @@ export const AgenticChatPanel = ({
 		[chatContextQuery.data?.conversations],
 	);
 	const clearChatContextMutation = useClearChatContextMutation();
+	// Insight cards replay from run events, which carry no current status, so
+	// the dismissed ids come from the project.
+	const dismissedInsightsQuery = useQuery({
+		queryKey: ["agentic", "dismissed-insights", projectId],
+		queryFn: () => getDismissedAgentInsightIds(projectId),
+	});
+	const dismissInsightMutation = useMutation({
+		mutationFn: (insightId: string) => dismissAgentInsight(insightId),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: ["agentic", "dismissed-insights", projectId],
+			}),
+	});
+	const dismissedInsightIds = useMemo(
+		() => new Set(dismissedInsightsQuery.data ?? []),
+		[dismissedInsightsQuery.data],
+	);
 	const [runId, setRunId] = useState<string | null>(null);
 	const [runStatus, setRunStatus] = useState<AgenticRunStatus | null>(null);
 	const [afterSeq, setAfterSeq] = useState(0);
@@ -1685,7 +1704,23 @@ export const AgenticChatPanel = ({
 							const note = parseInsightNote(node.item);
 							return note ? (
 								<div key={node.id}>
-									<InsightNoteCard note={note} />
+									<InsightNoteCard
+										note={note}
+										dismissed={
+											note.insightId
+												? dismissedInsightIds.has(note.insightId)
+												: false
+										}
+										isDismissing={
+											dismissInsightMutation.isPending &&
+											dismissInsightMutation.variables === note.insightId
+										}
+										onDismiss={
+											note.insightId
+												? () => dismissInsightMutation.mutate(note.insightId!)
+												: undefined
+										}
+									/>
 								</div>
 							) : null;
 						}
@@ -1858,10 +1893,10 @@ export const AgenticChatPanel = ({
 							footerRight={
 								<Button
 									type="submit"
-									size="sm"
+									size="md"
 									radius="md"
-									leftSection={
-										isSubmitting ? <Loader size={14} /> : <IconSend size={14} />
+									rightSection={
+										isSubmitting ? <Loader size={18} /> : <IconSend size={18} />
 									}
 									disabled={
 										isSubmitting || input.trim().length === 0 || atTurnLimit

--- a/echo/frontend/src/components/chat/AgenticIntroModal.tsx
+++ b/echo/frontend/src/components/chat/AgenticIntroModal.tsx
@@ -79,10 +79,10 @@ export const AgenticIntroModal = ({
 				</Button>
 				<Button
 					onClick={onConfirm}
-					aria-label={t`Switch to Agentic`}
+					aria-label={t`Start a new chat`}
 					{...testId("agentic-intro-modal-confirm")}
 				>
-					<Trans>Switch to Agentic</Trans>
+					<Trans>Start a new chat</Trans>
 				</Button>
 			</Group>
 		</Stack>

--- a/echo/frontend/src/components/chat/ChatAccordion.tsx
+++ b/echo/frontend/src/components/chat/ChatAccordion.tsx
@@ -44,8 +44,11 @@ export const ChatModeIndicator = ({
 	size = "sm",
 }: {
 	mode: "overview" | "deep_dive" | "agentic" | null | undefined;
-	size?: "xs" | "sm";
+	size?: "xs" | "compact-sm" | "sm";
 }) => {
+	// circle / glyph px per size token
+	const [circleSize, glyphSize] =
+		size === "xs" ? [20, 12] : size === "compact-sm" ? [26, 16] : [32, 20];
 	// Default to deep_dive if mode not set
 	const effectiveMode = mode ?? "deep_dive";
 	const isOverview = effectiveMode === "overview";
@@ -68,25 +71,17 @@ export const ChatModeIndicator = ({
 		>
 			<Box className="flex items-center justify-center">
 				{isOverview || isAgentic ? (
-					<ActionIcon
-						radius={100}
-						size={size === "xs" ? 20 : 32}
-						color={colors.primary}
-					>
+					<ActionIcon radius={100} size={circleSize} color={colors.primary}>
 						<IconSparkles
-							size={size === "xs" ? 12 : 20}
+							size={glyphSize}
 							color="var(--app-text)"
 							stroke={2}
 						/>
 					</ActionIcon>
 				) : (
-					<ActionIcon
-						radius={100}
-						size={size === "xs" ? 20 : 32}
-						color={colors.primary}
-					>
+					<ActionIcon radius={100} size={circleSize} color={colors.primary}>
 						<IconMessageCircle
-							size={size === "xs" ? 12 : 20}
+							size={glyphSize}
 							color="var(--app-text)"
 							stroke={2}
 						/>

--- a/echo/frontend/src/components/chat/ChatComposer.tsx
+++ b/echo/frontend/src/components/chat/ChatComposer.tsx
@@ -114,13 +114,13 @@ export const ConversationPickerButton = ({
 }) => (
 	<Button
 		variant="subtle"
-		size="compact-xs"
+		size="compact-sm"
 		disabled={disabled}
 		onClick={onClick}
 		aria-label={ariaLabel}
 		{...(id ? testId(id) : {})}
 	>
-		<ChatCircleTextIcon size={14} />
+		<ChatCircleTextIcon size={18} />
 		<span className="ms-1.5 hidden md:inline">{label}</span>
 	</Button>
 );

--- a/echo/frontend/src/components/chat/InsightNoteCard.tsx
+++ b/echo/frontend/src/components/chat/InsightNoteCard.tsx
@@ -1,7 +1,9 @@
 import { t } from "@lingui/core/macro";
-import { Badge, Group, Stack, Text } from "@mantine/core";
-import { LightbulbIcon } from "@phosphor-icons/react";
+import { Trans } from "@lingui/react/macro";
+import { Badge, Button, Group, Stack, Text } from "@mantine/core";
+import { LightbulbIcon, TrashIcon } from "@phosphor-icons/react";
 import { SuggestionCardFrame } from "@/components/common/SuggestionCardFrame";
+import { testId } from "@/lib/testUtils";
 import type { ParsedInsightNote } from "./agenticToolActivity";
 
 // Kept lowercase per brand: these read as quiet chips, not headings.
@@ -27,29 +29,37 @@ const shortInsightId = (insightId: string): string =>
 /** A calm, read-only card showing what the assistant noted for the dembrane
  * team: the kind chip, a short id suffix the host can reference, the restated
  * need, and any suggested capability. An amended note carries an "updated" chip;
- * a withdrawn one mutes and shows a "retracted" chip with the reason. There is
- * nothing to apply here, so no button. */
-export const InsightNoteCard = ({ note }: { note: ParsedInsightNote }) => {
+ * a withdrawn one mutes and shows a "retracted" chip with the reason. The host
+ * can remove the card, which archives the row rather than deleting it. */
+export const InsightNoteCard = ({
+	note,
+	dismissed = false,
+	onDismiss,
+	isDismissing = false,
+}: {
+	note: ParsedInsightNote;
+	dismissed?: boolean;
+	onDismiss?: () => void;
+	isDismissing?: boolean;
+}) => {
 	const retracted = note.mode === "retracted";
+	const muted = retracted || dismissed;
 	const edited = note.mode === "edited";
+	const canDismiss = Boolean(onDismiss) && !dismissed && note.insightId;
 	return (
 		<SuggestionCardFrame compact testId="agentic-insight-note">
 			<Stack gap="xs">
 				<Group gap="xs" wrap="nowrap">
-					<LightbulbIcon
-						size={16}
-						aria-hidden="true"
-						opacity={retracted ? 0.5 : 1}
-					/>
+					<LightbulbIcon size={16} aria-hidden="true" opacity={muted ? 0.5 : 1} />
 					<Badge
 						size="xs"
 						variant="outline"
 						radius="sm"
-						c={retracted ? "dimmed" : undefined}
+						c={muted ? "dimmed" : undefined}
 					>
 						{kindLabel(note.kind)}
 					</Badge>
-					{edited ? (
+					{edited && !dismissed ? (
 						<Badge size="xs" variant="light" radius="sm">
 							{t`updated`}
 						</Badge>
@@ -64,11 +74,29 @@ export const InsightNoteCard = ({ note }: { note: ParsedInsightNote }) => {
 							{t`insight ${shortInsightId(note.insightId)}`}
 						</Text>
 					) : null}
+					{canDismiss ? (
+						<Button
+							variant="outline"
+							color="red"
+							size="compact-xs"
+							ml="auto"
+							mt={10}
+							loading={isDismissing}
+							rightSection={<TrashIcon size={14} />}
+							aria-label={t`Remove`}
+							onClick={onDismiss}
+							{...testId("agentic-insight-note-remove")}
+						>
+							<Trans>Remove</Trans>
+						</Button>
+					) : null}
 				</Group>
-				<Text size="sm" c={retracted ? "dimmed" : undefined}>
-					{note.content}
-				</Text>
-				{note.suggestedCapability && !retracted ? (
+				{!dismissed ? (
+					<Text size="sm" c={muted ? "dimmed" : undefined}>
+						{note.content}
+					</Text>
+				) : null}
+				{note.suggestedCapability && !muted ? (
 					<Text size="xs" c="dimmed">
 						{note.suggestedCapability}
 					</Text>
@@ -78,10 +106,12 @@ export const InsightNoteCard = ({ note }: { note: ParsedInsightNote }) => {
 						{t`reason: ${note.reason}`}
 					</Text>
 				) : null}
-				<Text size="xs" c="dimmed">
-					{retracted
-						? t`retracted for the dembrane team`
-						: t`noted for the dembrane team`}
+				<Text size="xs" c={dismissed ? "red" : "dimmed"}>
+					{dismissed
+						? t`This insight has been deleted`
+						: retracted
+							? t`retracted for the dembrane team`
+							: t`noted for the dembrane team`}
 				</Text>
 			</Stack>
 		</SuggestionCardFrame>

--- a/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
+++ b/echo/frontend/src/components/conversation/ProjectConversationsPanel.tsx
@@ -91,8 +91,10 @@ type ProjectConversationsPanelProps = {
 	 * `selectionChatId` instead to write straight through to an existing chat. */
 	selection?: string[];
 	onSelectionChange?: (conversationIds: string[]) => void;
-	/** Renders the "Ask about these" action above the list. */
+	/** Renders the "Ask about these" action in the row above the list. */
 	onAskAboutSelection?: () => void;
+	/** Renders the selection on/off toggle in that same row. */
+	onToggleSelectionMode?: () => void;
 };
 
 const lineClampStyle = {
@@ -536,6 +538,7 @@ export const ProjectConversationsPanel = ({
 	selection,
 	onSelectionChange,
 	onAskAboutSelection,
+	onToggleSelectionMode,
 }: ProjectConversationsPanelProps) => {
 	const navigate = useI18nNavigate();
 	const { ref: loadMoreRef, inView } = useInView();
@@ -901,34 +904,55 @@ export const ProjectConversationsPanel = ({
 							)}
 						</Button>
 					)}
-
-				{isLocalSelectionMode && onAskAboutSelection && (
-					<Group gap="sm" align="center">
-						<Text size="sm" fw={500}>
-							<Trans>{conversationCount} selected</Trans>
-						</Text>
-						<Button
-							size="xs"
-							disabled={selectedConversationIds.size === 0}
-							onClick={onAskAboutSelection}
-							{...testId("conversations-ask-about-selection")}
-						>
-							<Trans>Ask about these</Trans>
-						</Button>
-						{selectedConversationIds.size > 0 && (
-							<Button
-								variant="subtle"
-								size="xs"
-								onClick={() => onSelectionChange?.([])}
-							>
-								<Trans>Clear</Trans>
-							</Button>
-						)}
-					</Group>
-				)}
 			</Stack>
 
 			<Divider />
+
+			{(onToggleSelectionMode ||
+				(isLocalSelectionMode && onAskAboutSelection)) && (
+				<Group gap="sm" align="center" justify="space-between">
+					{isLocalSelectionMode && onAskAboutSelection ? (
+						<Group gap="sm" align="center">
+							<Text size="sm" fw={500}>
+								<Trans>{conversationCount} selected</Trans>
+							</Text>
+							<Button
+								size="xs"
+								disabled={selectedConversationIds.size === 0}
+								onClick={onAskAboutSelection}
+								{...testId("conversations-ask-about-selection")}
+							>
+								<Trans>Ask about these</Trans>
+							</Button>
+							{selectedConversationIds.size > 0 && (
+								<Button
+									variant="subtle"
+									size="xs"
+									onClick={() => onSelectionChange?.([])}
+								>
+									<Trans>Clear</Trans>
+								</Button>
+							)}
+						</Group>
+					) : (
+						<Box />
+					)}
+					{onToggleSelectionMode && (
+						<Button
+							variant="outline"
+							size="xs"
+							onClick={onToggleSelectionMode}
+							{...testId("conversations-toggle-selection-mode")}
+						>
+							{selectionMode ? (
+								<Trans>Cancel selection</Trans>
+							) : (
+								<Trans>Select conversations</Trans>
+							)}
+						</Button>
+					)}
+				</Group>
+			)}
 
 			<Stack gap="sm">
 				{conversationsQuery.isLoading && (

--- a/echo/frontend/src/lib/api.ts
+++ b/echo/frontend/src/lib/api.ts
@@ -1357,6 +1357,20 @@ export const stopAgenticRun = async (runId: string) => {
 	);
 };
 
+export const dismissAgentInsight = async (insightId: string) => {
+	return api.post<unknown, { id: string; status: string }>(
+		`/agentic/insights/${insightId}/dismiss`,
+	);
+};
+
+export const getDismissedAgentInsightIds = async (projectId: string) => {
+	const response = await api.get<
+		unknown,
+		{ project_id: string; insight_ids: string[] }
+	>(`/agentic/projects/${projectId}/dismissed-insights`);
+	return response.insight_ids ?? [];
+};
+
 export const getChatSuggestions = async (
 	chatId: string,
 	language = "en",

--- a/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
+++ b/echo/frontend/src/routes/project/ProjectMonitorRoute.tsx
@@ -94,7 +94,7 @@ export const ProjectMonitorRoute = () => {
 					</Stack>
 					{sharingLink && (
 						<Tooltip label={t`Scan to join this project`} withArrow>
-							<Box className="w-[92px] shrink-0">
+							<Box className="w-[140px] shrink-0">
 								<QRCode value={sharingLink} />
 							</Box>
 						</Tooltip>

--- a/echo/frontend/src/routes/project/ProjectRoutes.tsx
+++ b/echo/frontend/src/routes/project/ProjectRoutes.tsx
@@ -1,12 +1,5 @@
 import { Trans } from "@lingui/react/macro";
-import {
-	Alert,
-	Button,
-	Divider,
-	Group,
-	LoadingOverlay,
-	Stack,
-} from "@mantine/core";
+import { Alert, Divider, LoadingOverlay, Stack } from "@mantine/core";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import { ProjectConversationsPanel } from "@/components/conversation/ProjectConversationsPanel";
@@ -54,22 +47,6 @@ export const ProjectConversationsRoute = () => {
 	return (
 		<PageContainer width="xl">
 			<Stack gap="md">
-				<Group justify="flex-end">
-					<Button
-						variant="outline"
-						size="xs"
-						onClick={() => {
-							if (pickerMode) setSelectedConversationIds([]);
-							setPickerMode((current) => !current);
-						}}
-					>
-						{pickerMode ? (
-							<Trans>Cancel selection</Trans>
-						) : (
-							<Trans>Select conversations</Trans>
-						)}
-					</Button>
-				</Group>
 				<ProjectConversationsPanel
 					projectId={projectId}
 					workspaceId={workspaceId}
@@ -77,6 +54,10 @@ export const ProjectConversationsRoute = () => {
 					selectionMode={pickerMode}
 					selection={selectedConversationIds}
 					onSelectionChange={setSelectedConversationIds}
+					onToggleSelectionMode={() => {
+						if (pickerMode) setSelectedConversationIds([]);
+						setPickerMode((current) => !current);
+					}}
 					onAskAboutSelection={() => {
 						navigate(`/w/${workspaceId}/projects/${projectId}/chats/new`, {
 							state: { selectedConversationIds },

--- a/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/NewChatRoute.tsx
@@ -499,9 +499,9 @@ export const NewChatRoute = () => {
 							}
 							footerLeft={
 								<ConversationPickerButton
-									ariaLabel={t`Choose conversations`}
+									ariaLabel={t`Select conversations`}
 									disabled={isPending}
-									label={<Trans>Choose conversations</Trans>}
+									label={<Trans>Select conversations</Trans>}
 									onClick={pickerHandlers.open}
 									testId="ask-home-choose-conversations"
 								/>
@@ -509,10 +509,10 @@ export const NewChatRoute = () => {
 							footerRight={
 								<Button
 									type="button"
-									size="sm"
+									size="md"
 									radius="md"
-									leftSection={
-										isPending ? <Loader size={14} /> : <IconSend size={14} />
+									rightSection={
+										isPending ? <Loader size={18} /> : <IconSend size={18} />
 									}
 									disabled={isPending || draft.trim().length === 0}
 									onClick={startChat}
@@ -547,9 +547,11 @@ export const NewChatRoute = () => {
 						<Group gap="xs" align="center">
 							<Button
 								variant="subtle"
-								size="xs"
+								size="sm"
 								disabled={isPending}
-								leftSection={<ChatModeIndicator mode="agentic" size="xs" />}
+								leftSection={
+									<ChatModeIndicator mode="agentic" size="compact-sm" />
+								}
 								styles={{
 									section: { marginRight: "var(--mantine-spacing-sm)" },
 								}}
@@ -563,7 +565,7 @@ export const NewChatRoute = () => {
 							>
 								<Trans>Try Agentic instead</Trans>
 							</Button>
-							<Badge size="sm" color="mauve" c="graphite">
+							<Badge size="md" color="mauve" c="graphite">
 								<Trans>Beta</Trans>
 							</Badge>
 						</Group>

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -1,6 +1,7 @@
 import { useChat } from "@ai-sdk/react";
 import { t } from "@lingui/core/macro";
 import { Plural, Trans } from "@lingui/react/macro";
+import { ChatCircleText as ChatCircleTextIcon } from "@phosphor-icons/react";
 import {
 	Alert,
 	Badge,
@@ -836,21 +837,25 @@ export const ProjectChatRoute = () => {
 					{needsConversations && (
 						<Alert
 							icon={<IconAlertCircle size="1rem" />}
+							p="xs"
+							styles={{
+								wrapper: { alignItems: "center" },
+								title: { marginBottom: 0 },
+							}}
 							title={
-								<Group gap={6} wrap="nowrap">
-									<Text component="span" inherit>
-										<Trans>Select conversations to continue:</Trans>
+								<Group gap="xl" wrap="nowrap" align="center">
+									<Text component="span" inherit c="graphite">
+										<Trans>Select a conversation to continue</Trans>
 									</Text>
-									<Text
-										component="span"
-										size="sm"
-										fw={400}
-										style={{ color: "var(--app-text)" }}
+									<Button
+										variant="subtle"
+										size="compact-sm"
+										leftSection={<ChatCircleTextIcon size={18} />}
+										onClick={() => setConversationPickerOpen(true)}
+										{...testId("chat-no-conversations-alert-select-button")}
 									>
-										<Trans>
-											Specific Details needs at least one conversation.
-										</Trans>
-									</Text>
+										<Trans>Select conversations</Trans>
+									</Button>
 								</Group>
 							}
 							color="orange"
@@ -923,9 +928,9 @@ export const ProjectChatRoute = () => {
 							footerRight={
 								<Button
 									type="submit"
-									size="sm"
+									size="md"
 									radius="md"
-									rightSection={<IconSend size={14} />}
+									rightSection={<IconSend size={18} />}
 									disabled={
 										normalizedInput.trim() === "" ||
 										isLoading ||

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -1696,6 +1696,57 @@ async def retract_agent_insight(
     return _agent_insight_payload(updated)
 
 
+@AgenticRouter.post("/insights/{insight_id}/dismiss")
+async def dismiss_agent_insight(
+    insight_id: str,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    """Hide a noted insight from the host's chat. Host-callable (no agent token):
+    this is the host clearing their own view, not the assistant withdrawing a
+    note. The row is never deleted, status moves to archived, because the
+    dembrane team may already have read it."""
+    insight = await _get_agent_insight_or_404(insight_id)
+    project_id = _to_related_id(insight.get("project_id"))
+    if not project_id:
+        raise HTTPException(status_code=404, detail="Insight not found")
+    await _assert_project_access(project_id, auth)
+
+    await async_directus.update_item("agent_insight", insight_id, {"status": "archived"})
+    updated = await _get_agent_insight_or_404(insight_id)
+    return _agent_insight_payload(updated)
+
+
+@AgenticRouter.get("/projects/{project_id}/dismissed-insights")
+async def list_dismissed_agent_insights(
+    project_id: str,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    """Ids of insights the host dismissed in this project, so a reloaded chat
+    keeps showing them as removed. Insight cards are rendered from replayed run
+    events, which never carry the row's current status."""
+    await _assert_project_access(project_id, auth)
+
+    rows = await async_directus.get_items(
+        "agent_insight",
+        {
+            "query": {
+                "filter": {
+                    "project_id": {"_eq": project_id},
+                    "status": {"_eq": "archived"},
+                },
+                "fields": ["id"],
+                "limit": -1,
+            }
+        },
+    )
+    ids = (
+        [row["id"] for row in rows if isinstance(row, dict) and row.get("id")]
+        if isinstance(rows, list)
+        else []
+    )
+    return {"project_id": project_id, "insight_ids": ids}
+
+
 async def _resolve_workspace_id_for_project(project_id: str) -> Optional[str]:
     """Resolve the workspace a project belongs to. Workspace is the data
     boundary, so it is never taken from the agent; the server derives it."""


### PR DESCRIPTION
Chat composer:
- Unify the picker label to "Select conversations" on the new-chat page and specific-mode chat; agentic keeps "Focus on conversations"
- Bump the picker button and send button (send icon now on the right in all three composers)
- Larger "Try Agentic instead" entry point; intro modal confirm now reads "Start a new chat"
- ChatModeIndicator gains a compact-sm step between xs and sm

Specific mode:
- The no-conversations alert is a single line of graphite copy plus a subtle "Select conversations" action that opens the picker

Conversations page:
- Move the selection toggle into the panel, in the row below the divider, with the "N selected / Ask about these" cluster on the same line

Agentic insights:
- Hosts can remove an insight card. POST /agentic/insights/{id}/dismiss archives the row (never deletes it) and GET /agentic/projects/{id}/dismissed-insights keeps the removed state after a reload, since insight cards replay from run events that carry no status

Monitor: QR code 92px -> 140px