### PR TITLE
fix(ui): drop env badge from spinning logo loaders

### DIFF
--- a/echo/frontend/src/components/common/Logo.tsx
+++ b/echo/frontend/src/components/common/Logo.tsx
@@ -11,18 +11,21 @@ type LogoProps = {
 	hideLogo?: boolean;
 	hideTitle?: boolean;
 	alwaysDembrane?: boolean;
+	hideEnvBadge?: boolean;
 } & GroupProps;
 
 export const LogoDembrane = ({
 	hideLogo,
 	hideTitle,
 	alwaysDembrane,
+	hideEnvBadge,
 	...props
 }: LogoProps) => {
 	const { logoUrl } = useWhitelabelLogo();
 	const effectiveLogoUrl = alwaysDembrane ? null : logoUrl;
 	// Show an env badge everywhere except production.
-	const hostEnv = APP_ENVIRONMENT === "production" ? null : APP_ENVIRONMENT;
+	const hostEnv =
+		hideEnvBadge || APP_ENVIRONMENT === "production" ? null : APP_ENVIRONMENT;
 
 	return (
 		<Group gap="sm" h="32px" align="center" {...props}>
@@ -52,7 +55,13 @@ export const LogoDembrane = ({
 	);
 };
 
-const LogoAiCoNL = ({ hideLogo, hideTitle, ...props }: LogoProps) => (
+const LogoAiCoNL = ({
+	hideLogo,
+	hideTitle,
+	alwaysDembrane: _alwaysDembrane,
+	hideEnvBadge: _hideEnvBadge,
+	...props
+}: LogoProps) => (
 	<Group gap="sm" h="30px" {...props}>
 		{!hideLogo && (
 			<img

--- a/echo/frontend/src/components/participant/SpikeMessage.tsx
+++ b/echo/frontend/src/components/participant/SpikeMessage.tsx
@@ -21,7 +21,14 @@ const SpikeMessage = ({
 				title={
 					<Group>
 						<div className={loading ? "animate-spin" : ""}>
-							<Logo className="min-w-[20px]" hideTitle alwaysDembrane h="20px" my={4} />
+							<Logo
+								className="min-w-[20px]"
+								hideTitle
+								hideEnvBadge
+								alwaysDembrane
+								h="20px"
+								my={4}
+							/>
 						</div>
 					</Group>
 				}

--- a/echo/frontend/src/components/participant/verify/VerifyArtefact.tsx
+++ b/echo/frontend/src/components/participant/verify/VerifyArtefact.tsx
@@ -312,7 +312,7 @@ export const VerifyArtefact = () => {
 							{...testId("portal-verify-artefact-revising")}
 						>
 							<div className="animate-spin">
-								<Logo hideTitle alwaysDembrane h="48px" />
+								<Logo hideTitle hideEnvBadge alwaysDembrane h="48px" />
 							</div>
 							<Stack gap="sm" align="center">
 								<Text size="xl" fw={600}>

--- a/echo/frontend/src/components/participant/verify/VerifyArtefactLoading.tsx
+++ b/echo/frontend/src/components/participant/verify/VerifyArtefactLoading.tsx
@@ -6,7 +6,7 @@ export const VerifyArtefactLoading = () => {
 	return (
 		<Stack align="center" justify="center" gap="xl" className="h-full">
 			<div className="animate-spin">
-				<Logo hideTitle alwaysDembrane h="48px" />
+				<Logo hideTitle hideEnvBadge alwaysDembrane h="48px" />
 			</div>
 			<Stack gap="sm" align="center">
 				<Text size="xl" fw={600}>

--- a/echo/frontend/src/components/participant/verify/VerifySelection.tsx
+++ b/echo/frontend/src/components/participant/verify/VerifySelection.tsx
@@ -209,7 +209,7 @@ export const VerifySelection = () => {
 		return (
 			<Stack align="center" justify="center" className="h-full">
 				<div className="animate-spin">
-					<Logo hideTitle alwaysDembrane h="48px" />
+					<Logo hideTitle hideEnvBadge alwaysDembrane h="48px" />
 				</div>
 			</Stack>
 		);

--- a/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
+++ b/echo/frontend/src/routes/project/chat/ProjectChatRoute.tsx
@@ -733,7 +733,7 @@ export const ProjectChatRoute = () => {
 						<Stack gap="xs">
 							<Group>
 								<Box className="animate-spin">
-									<Logo hideTitle alwaysDembrane h="20px" my={4} />
+									<Logo hideTitle hideEnvBadge alwaysDembrane h="20px" my={4} />
 								</Box>
 								<Text
 									size="sm"


### PR DESCRIPTION
The chat loader reuses <Logo> as its spinner, so the non-production environment badge ("next", "local") rendered as stray text next to the spinning logomark. Add a hideEnvBadge prop and set it on every loader-style usage (chat, participant spike message, verify screens). Header and auth-layout logos keep the badge.