### PR TITLE
fix(chat): give the project update card one voice per line

### DIFF
--- a/echo/frontend/src/components/chat/ProjectUpdateSuggestionCard.test.tsx
+++ b/echo/frontend/src/components/chat/ProjectUpdateSuggestionCard.test.tsx
@@ -99,6 +99,9 @@ describe("ProjectUpdateSuggestionCard", () => {
 		renderCard(contextSuggestion);
 		expect(screen.getByText(/Waiting on you/)).toBeTruthy();
 		expect(screen.getByText(/Project context/)).toBeTruthy();
+		// The headline and the button say this already; the card does not
+		// narrate itself a third time.
+		expect(screen.queryByText(/Nothing changes until you accept/)).toBeNull();
 		// The diff itself is not built until the host asks for it.
 		expect(screen.queryByText("Current")).toBeNull();
 		expect(screen.queryByText("Proposed")).toBeNull();
@@ -164,17 +167,59 @@ describe("ProjectUpdateSuggestionCard", () => {
 			summary: "",
 		});
 		fireEvent.click(screen.getByTestId("suggestion-expand-button"));
-		expect(screen.getByText("Old title").className).toContain("line-through");
-		expect(screen.getByText("New title").className).toContain("text-green-900");
+		const removed = screen.getByText("Old title");
+		const added = screen.getByText("New title");
+		expect(removed.className).toContain("line-through");
+		expect(added.className).toContain("text-green-900");
+		// Both sides are marked before colour is decoded: the removal is struck
+		// through, the addition sits on a background, same as the word diff.
+		expect(removed.className).toContain("bg-red-100");
+		expect(added.className).toContain("bg-green-100");
 	});
 
-	it("says what a change to the project context reaches", () => {
+	it("says what a change to the project context reaches, exactly once", () => {
 		renderCard(contextSuggestion);
-		expect(
-			screen.getByText(
-				/read by transcription, chat answers and canvas generation/,
-			),
-		).toBeTruthy();
+		const impact = /read by transcription, chat answers and canvas generation/;
+		// Collapsed, the resting block is the only place it can be said.
+		expect(screen.getAllByText(impact).length).toBe(1);
+
+		// Expanded, the copy beside the field carries it and the resting one
+		// stands down. Both used to render, the same sentence twice on one card.
+		fireEvent.click(screen.getByTestId("suggestion-expand-button"));
+		expect(screen.getAllByText(impact).length).toBe(1);
+
+		fireEvent.click(screen.getByTestId("suggestion-expand-button"));
+		expect(screen.getAllByText(impact).length).toBe(1);
+	});
+
+	it("does not offer to untick the only field there is", () => {
+		renderCard(contextSuggestion);
+		fireEvent.click(screen.getByTestId("suggestion-expand-button"));
+		// Unticking the single field only disables Accept, which reads as a
+		// broken card rather than a choice.
+		expect(screen.queryByText(/Untick a field/)).toBeNull();
+	});
+
+	it("offers to untick a field once there is more than one", () => {
+		renderCard(twoFieldSuggestion);
+		fireEvent.click(screen.getByTestId("suggestion-expand-button"));
+		expect(screen.getByText(/Untick a field/)).toBeTruthy();
+	});
+
+	it("gives the note the action row rather than stacking a second one", () => {
+		renderCard(contextSuggestion, vi.fn());
+		fireEvent.click(screen.getByTestId("suggestion-note-button"));
+
+		expect(screen.getByTestId("suggestion-note-input")).toBeTruthy();
+		// One submit on screen at a time: accept, dismiss and the expand toggle
+		// stand down while the note is being written.
+		expect(screen.queryByTestId("suggestion-apply-button")).toBeNull();
+		expect(screen.queryByTestId("suggestion-dismiss-button")).toBeNull();
+		expect(screen.queryByTestId("suggestion-expand-button")).toBeNull();
+
+		fireEvent.click(screen.getByTestId("suggestion-note-cancel-button"));
+		expect(screen.getByTestId("suggestion-apply-button")).toBeTruthy();
+		expect(screen.queryByTestId("suggestion-note-input")).toBeNull();
 	});
 
 	it("lets a field be left out and blocks accept when nothing is ticked", () => {

--- a/echo/frontend/src/components/chat/ProjectUpdateSuggestionCard.tsx
+++ b/echo/frontend/src/components/chat/ProjectUpdateSuggestionCard.tsx
@@ -148,10 +148,14 @@ const ValueText = ({
 		<Text
 			size="sm"
 			component="span"
+			// Same marking as the word diff path. The removal carries a shape
+			// signal in the strikethrough; without a background the addition
+			// carried none, so it vanished in greyscale and for a colour-blind
+			// reader. Both sides now read as marked before colour is decoded.
 			className={
 				kind === "old"
-					? "break-words text-red-900 line-through decoration-red-400"
-					: "break-words text-green-900"
+					? "break-words bg-red-100 text-red-900 line-through decoration-red-400"
+					: "break-words bg-green-100 text-green-900"
 			}
 		>
 			{display}
@@ -259,13 +263,13 @@ const ChangeDetail = ({
 	return (
 		<Stack gap={6}>
 			{unchanged ? (
-				<Text size="sm" fs="italic">
+				<Text size="sm" fs="italic" c="dimmed">
 					<Trans>This field already holds the proposed value.</Trans>
 				</Text>
 			) : null}
 
 			{chunks ? (
-				<Text size="xs">
+				<Text size="xs" c="dimmed">
 					<Plural
 						value={diff?.addedWords ?? 0}
 						one="# word added"
@@ -281,7 +285,7 @@ const ChangeDetail = ({
 			) : null}
 
 			<Stack gap={2}>
-				<Text size="xs">
+				<Text size="xs" c="dimmed">
 					<Trans>Current</Trans>
 				</Text>
 				<Box className={VALUE_BOX}>
@@ -294,7 +298,7 @@ const ChangeDetail = ({
 			</Stack>
 
 			<Stack gap={2}>
-				<Text size="xs">
+				<Text size="xs" c="dimmed">
 					<Trans>Proposed</Trans>
 				</Text>
 				{editing ? (
@@ -553,24 +557,26 @@ export const ProjectUpdateSuggestionCard = ({
 				{suggestion.summary ? (
 					<Text size="sm">{suggestion.summary}</Text>
 				) : null}
-				{restingImpact ? (
+				{/* The impact sentence is said once. Collapsed, this is the only
+				    place it can be said at all; expanded, the per-field copy sits
+				    beside the field it describes, and keeping this one would print
+				    the same sentence twice on one card. */}
+				{restingImpact && !expanded ? (
 					<Text size="sm" fs="italic">
 						{restingImpact}
 					</Text>
 				) : null}
-				<Text size="xs">
-					<Trans>
-						Nothing changes until you accept. Open the changes to see the
-						current value next to the proposed one.
-					</Trans>
-				</Text>
 
 				<div id={panelId} hidden={!expanded}>
 					{expanded ? (
 						<Stack gap="lg" className="pt-1">
-							<Text size="xs">
-								<Trans>Untick a field to leave it exactly as it is.</Trans>
-							</Text>
+							{/* With one field there is nothing to leave out: unticking
+							    only disables Accept, which reads as a broken card. */}
+							{suggestion.changes.length > 1 ? (
+								<Text size="xs" c="dimmed">
+									<Trans>Untick a field to leave it exactly as it is.</Trans>
+								</Text>
+							) : null}
 							{suggestion.changes.map((change) => {
 								const value = effectiveValue(change);
 								const impact = fieldImpact(change.field);
@@ -654,6 +660,20 @@ export const ProjectUpdateSuggestionCard = ({
 					) : null}
 				</div>
 
+				{selectedCount !== totalCount ? (
+					<Text size="xs" c="dimmed">
+						<Trans>
+							{selectedCount} of {totalCount} fields selected. Accept applies
+							only the ticked ones.
+						</Trans>
+					</Text>
+				) : null}
+
+				{/* Writing a note is its own step, so it takes the action row over
+				    rather than stacking a second one on top of it. Stacked, the
+				    card offered four verbs and two submit buttons at once and it
+				    was not obvious which one sent the note. Cancel puts the
+				    original row back untouched. */}
 				{noteOpen ? (
 					<Stack gap="xs">
 						<Textarea
@@ -676,6 +696,7 @@ export const ProjectUpdateSuggestionCard = ({
 									setNoteOpen(false);
 									setNote("");
 								}}
+								{...testId("suggestion-note-cancel-button")}
 							>
 								<Trans>Cancel</Trans>
 							</Button>
@@ -690,77 +711,68 @@ export const ProjectUpdateSuggestionCard = ({
 							</Button>
 						</Group>
 					</Stack>
-				) : null}
-
-				{selectedCount !== totalCount ? (
-					<Text size="xs">
-						<Trans>
-							{selectedCount} of {totalCount} fields selected. Accept applies
-							only the ticked ones.
-						</Trans>
-					</Text>
-				) : null}
-
-				<Group justify="space-between" gap="xs" wrap="wrap">
-					<Button
-						variant="subtle"
-						size="xs"
-						className={COARSE_TAP_TARGET}
-						aria-expanded={expanded}
-						aria-controls={panelId}
-						leftSection={
-							expanded ? (
-								<IconChevronUp size={14} aria-hidden />
-							) : (
-								<IconChevronDown size={14} aria-hidden />
-							)
-						}
-						onClick={() => setExpanded((prev) => !prev)}
-						{...testId("suggestion-expand-button")}
-					>
-						{expanded ? (
-							<Trans>Hide the changes</Trans>
-						) : (
-							<Plural
-								value={suggestion.changes.length}
-								one="Show what changes (# field)"
-								other="Show what changes (# fields)"
-							/>
-						)}
-					</Button>
-					<Group gap="xs" wrap="wrap">
-						{onSendNote && !noteOpen ? (
-							<Button
-								variant="subtle"
-								size="xs"
-								className={COARSE_TAP_TARGET}
-								onClick={() => setNoteOpen(true)}
-								{...testId("suggestion-note-button")}
-							>
-								<Trans>Add a note</Trans>
-							</Button>
-						) : null}
+				) : (
+					<Group justify="space-between" gap="xs" wrap="wrap">
 						<Button
 							variant="subtle"
 							size="xs"
 							className={COARSE_TAP_TARGET}
-							onClick={() => setDismissed(true)}
-							{...testId("suggestion-dismiss-button")}
+							aria-expanded={expanded}
+							aria-controls={panelId}
+							leftSection={
+								expanded ? (
+									<IconChevronUp size={14} aria-hidden />
+								) : (
+									<IconChevronDown size={14} aria-hidden />
+								)
+							}
+							onClick={() => setExpanded((prev) => !prev)}
+							{...testId("suggestion-expand-button")}
 						>
-							<Trans>Dismiss</Trans>
+							{expanded ? (
+								<Trans>Hide the changes</Trans>
+							) : (
+								<Plural
+									value={suggestion.changes.length}
+									one="Show what changes (# field)"
+									other="Show what changes (# fields)"
+								/>
+							)}
 						</Button>
-						<Button
-							size="xs"
-							className={COARSE_TAP_TARGET}
-							loading={updateProjectMutation.isPending}
-							disabled={selectedChanges.length === 0}
-							onClick={() => void handleApply()}
-							{...testId("suggestion-apply-button")}
-						>
-							<Trans>Accept</Trans>
-						</Button>
+						<Group gap="xs" wrap="wrap">
+							{onSendNote ? (
+								<Button
+									variant="subtle"
+									size="xs"
+									className={COARSE_TAP_TARGET}
+									onClick={() => setNoteOpen(true)}
+									{...testId("suggestion-note-button")}
+								>
+									<Trans>Add a note</Trans>
+								</Button>
+							) : null}
+							<Button
+								variant="subtle"
+								size="xs"
+								className={COARSE_TAP_TARGET}
+								onClick={() => setDismissed(true)}
+								{...testId("suggestion-dismiss-button")}
+							>
+								<Trans>Dismiss</Trans>
+							</Button>
+							<Button
+								size="xs"
+								className={COARSE_TAP_TARGET}
+								loading={updateProjectMutation.isPending}
+								disabled={selectedChanges.length === 0}
+								onClick={() => void handleApply()}
+								{...testId("suggestion-apply-button")}
+							>
+								<Trans>Accept</Trans>
+							</Button>
+						</Group>
 					</Group>
-				</Group>
+				)}
 			</Stack>
 		</SuggestionCardFrame>
 	);

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -573,12 +573,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1381,7 +1381,7 @@ msgstr "A short note on what this project is about. You can edit it later."
 msgid "a workspace"
 msgstr "a workspace"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr "Absolute https URL. Workspace-level logo overrides when set."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1592,8 +1592,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -3058,7 +3058,7 @@ msgstr "can read"
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Cancel"
@@ -3276,7 +3276,7 @@ msgstr "Change workspace role?"
 msgid "Change your own role?"
 msgstr "Change your own role?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr "Clear search"
 #~ msgstr "Clear the {liveProjectCount} project(s) first. You can delete all projects across your team from the team page."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3937,7 +3937,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4300,7 +4300,7 @@ msgstr "Crop logo"
 msgid "Crop Logo"
 msgstr "Crop Logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4811,7 +4811,7 @@ msgstr "Discoverable in this organisation"
 #~ msgstr "Discoverable in this team"
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4882,7 +4882,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr "Done"
@@ -5077,7 +5077,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Edit"
 
@@ -6622,7 +6622,7 @@ msgstr "Hide revision data"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -9078,8 +9078,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -9141,8 +9141,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -9164,8 +9164,8 @@ msgid "Oldest First"
 msgstr "Oldest First"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10790,7 +10790,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr "Proposed"
 
@@ -11736,7 +11736,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12406,7 +12406,7 @@ msgstr "Send invite"
 msgid "Send invites"
 msgstr "Send invites"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12727,7 +12727,7 @@ msgstr "Show more"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12753,7 +12753,7 @@ msgstr "Show revision data"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13559,7 +13559,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13766,7 +13766,7 @@ msgstr "There was an error creating your report. Please try again or contact sup
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "These are your default view templates. Once you create your library these will be your first two views."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13875,7 +13875,7 @@ msgstr "This email is already in the list."
 msgid "participant.modal.refine.info.available.in"
 msgstr "This feature will be available in {remainingTime} seconds."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14765,7 +14765,7 @@ msgstr "Unsubscribe"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15740,7 +15740,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "What patterns emerge from the data?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -397,12 +397,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "a workspace"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1403,8 +1403,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -3059,7 +3059,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3237,7 +3237,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3714,7 +3714,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4075,7 +4075,7 @@ msgstr ""
 msgid "Crop Logo"
 msgstr "Logo zuschneiden"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4594,7 +4594,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4607,7 +4607,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4665,7 +4665,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr ""
@@ -4852,7 +4852,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -6360,7 +6360,7 @@ msgstr "Revisionsdaten verbergen"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -8792,8 +8792,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -8854,8 +8854,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -8877,8 +8877,8 @@ msgid "Oldest First"
 msgstr "Älteste zuerst"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10576,7 +10576,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11501,7 +11501,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Überprüfen Sie die Aktivität für Ihren Arbeitsbereich. Filtern Sie nach Sammlung oder Aktion und exportieren Sie die aktuelle Ansicht für weitere Untersuchungen."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12168,7 +12168,7 @@ msgstr ""
 msgid "Send invites"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12485,7 +12485,7 @@ msgstr "Mehr anzeigen"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12511,7 +12511,7 @@ msgstr "Revisionsdaten anzeigen"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13301,7 +13301,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13499,7 +13499,7 @@ msgstr "Beim Erstellen Ihres Berichts ist ein Fehler aufgetreten. Bitte versuche
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "Diese sind Ihre Standard-Ansichtsvorlagen. Sobald Sie Ihre Bibliothek erstellen, werden dies Ihre ersten beiden Ansichten sein."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13605,7 +13605,7 @@ msgstr "Diese E-Mail ist bereits in der Liste."
 msgid "participant.modal.refine.info.available.in"
 msgstr "Diese Funktion wird in {remainingTime} Sekunden verfügbar sein."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14471,7 +14471,7 @@ msgstr "Abmelden"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15424,7 +15424,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "Welche Muster ergeben sich aus den Daten?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -573,12 +573,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr "{0, plural, one {# with errors} other {# with errors}}"
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr "{0, plural, one {# word added} other {# words added}}"
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr "{0, plural, one {# word removed} other {# words removed}}"
 
@@ -615,7 +615,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr "{0, plural, one {Move # project to another workspace.} other {Move # projects to another workspace.}}"
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 
@@ -1026,7 +1026,7 @@ msgstr "{seats} seats"
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr "{selectedCount, plural, one {# selected} other {# selected}}"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 
@@ -1381,7 +1381,7 @@ msgstr "A short note on what this project is about. You can edit it later."
 msgid "a workspace"
 msgstr "a workspace"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr "About the suggested project update: {hostNote}"
 
@@ -1402,7 +1402,7 @@ msgstr "About you"
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr "Absolute https URL. Workspace-level logo overrides when set."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr "Accept"
 
@@ -1592,8 +1592,8 @@ msgstr "Add a name and a prompt before applying."
 msgid "Add a name, description, and framing."
 msgstr "Add a name, description, and framing."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr "Add a note"
 
@@ -3058,7 +3058,7 @@ msgstr "can read"
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Cancel"
@@ -3276,7 +3276,7 @@ msgstr "Change workspace role?"
 msgid "Change your own role?"
 msgstr "Change your own role?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr "Changes applied. You can fine-tune them anytime in project settings."
 
@@ -3457,7 +3457,7 @@ msgstr "Clear search"
 #~ msgstr "Clear the {liveProjectCount} project(s) first. You can delete all projects across your team from the team page."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr "cleared"
 
@@ -3937,7 +3937,7 @@ msgstr "Could not add your conversations to this chat"
 msgid "Could not apply all the tag changes."
 msgstr "Could not apply all the tag changes."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr "Could not apply the changes. Nothing was saved."
 
@@ -4300,7 +4300,7 @@ msgstr "Crop logo"
 msgid "Crop Logo"
 msgstr "Crop Logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr "Current"
 
@@ -4811,7 +4811,7 @@ msgstr "Discoverable in this organisation"
 #~ msgstr "Discoverable in this team"
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4824,7 +4824,7 @@ msgstr "Dismiss"
 msgid "Dismissed"
 msgstr "Dismissed"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr "Dismissed. Nothing was changed."
 
@@ -4882,7 +4882,7 @@ msgstr "Does not update on its own. Updated {updatedAgo}."
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr "Done"
@@ -5077,7 +5077,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Edit"
 
@@ -6622,7 +6622,7 @@ msgstr "Hide revision data"
 msgid "Hide steps"
 msgstr "Hide steps"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr "Hide the changes"
 
@@ -9078,8 +9078,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr "Notes the assistant saved about this workspace from chats. Everyone in the workspace shares them."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -9141,8 +9141,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr "Observers are only available in workspaces for an external client. Pick only external-client workspaces, or choose a different role."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr "off"
 
@@ -9164,8 +9164,8 @@ msgid "Oldest First"
 msgstr "Oldest First"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr "on"
 
@@ -10790,7 +10790,7 @@ msgstr "Projects will show up here once someone on the organisation shares one w
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr "Proposed"
 
@@ -11736,7 +11736,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12406,7 +12406,7 @@ msgstr "Send invite"
 msgid "Send invites"
 msgstr "Send invites"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr "Send note"
 
@@ -12727,7 +12727,7 @@ msgstr "Show more"
 msgid "Show more versions"
 msgstr "Show more versions"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr "Show only what changed"
 
@@ -12753,7 +12753,7 @@ msgstr "Show revision data"
 msgid "Show steps"
 msgstr "Show steps"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr "Show the full text"
 
@@ -13559,7 +13559,7 @@ msgstr "The assistant forgets it in every future chat."
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr "The assistant is preparing this canvas."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr "The assistant suggests updating {headlineFields}. Waiting on you."
 
@@ -13766,7 +13766,7 @@ msgstr "There was an error creating your report. Please try again or contact sup
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "These are your default view templates. Once you create your library these will be your first two views."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr "These changes are applied to your project."
 
@@ -13875,7 +13875,7 @@ msgstr "This email is already in the list."
 msgid "participant.modal.refine.info.available.in"
 msgstr "This feature will be available in {remainingTime} seconds."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr "This field already holds the proposed value."
 
@@ -14765,7 +14765,7 @@ msgstr "Unsubscribe"
 msgid "Untagged"
 msgstr "Untagged"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr "Untick a field to leave it exactly as it is."
 
@@ -15740,7 +15740,7 @@ msgstr "What gets sent"
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "What patterns emerge from the data?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr "What should be different about this?"
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -397,12 +397,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "a workspace"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1403,8 +1403,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -2844,7 +2844,7 @@ msgstr ""
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Cancelar"
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3240,7 +3240,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4078,7 +4078,7 @@ msgstr ""
 msgid "Crop Logo"
 msgstr "Recortar logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4597,7 +4597,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4610,7 +4610,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4668,7 +4668,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr ""
@@ -4855,7 +4855,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Editar"
 
@@ -6363,7 +6363,7 @@ msgstr "Ocultar datos de revisión"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -8795,8 +8795,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -8857,8 +8857,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -8880,8 +8880,8 @@ msgid "Oldest First"
 msgstr "Más antiguos primero"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10582,7 +10582,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11507,7 +11507,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Revisa la actividad de tu espacio de trabajo. Filtra por colección o acción, y exporta la vista actual para una investigación más detallada."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12174,7 +12174,7 @@ msgstr ""
 msgid "Send invites"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12491,7 +12491,7 @@ msgstr "Mostrar más"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12517,7 +12517,7 @@ msgstr "Mostrar datos de revisión"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13307,7 +13307,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13505,7 +13505,7 @@ msgstr "Hubo un error al crear tu informe. Por favor, inténtalo de nuevo o cont
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "Estas son tus plantillas de vista predeterminadas. Una vez que crees tu biblioteca, estas serán tus primeras dos vistas."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13611,7 +13611,7 @@ msgstr "Este correo electrónico ya está en la lista."
 msgid "participant.modal.refine.info.available.in"
 msgstr "Esta función estará disponible en {remainingTime} segundos."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14475,7 +14475,7 @@ msgstr "Desuscribirse"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15428,7 +15428,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "¿Qué patrones salen de los datos?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -412,12 +412,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -454,7 +454,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "a workspace"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1228,7 +1228,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1418,8 +1418,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -2859,7 +2859,7 @@ msgstr ""
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Annuler"
@@ -3077,7 +3077,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3732,7 +3732,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4093,7 +4093,7 @@ msgstr ""
 msgid "Crop Logo"
 msgstr "Recadrer le logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4625,7 +4625,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4683,7 +4683,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr ""
@@ -4870,7 +4870,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Modifier"
 
@@ -6378,7 +6378,7 @@ msgstr "Masquer les données de révision"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -8810,8 +8810,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -8872,8 +8872,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -8895,8 +8895,8 @@ msgid "Oldest First"
 msgstr "Plus ancien en premier"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10597,7 +10597,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11522,7 +11522,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Examinez l'activité de votre espace de travail. Filtrez par collection ou action, et exportez la vue actuelle pour une investigation plus approfondie."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12189,7 +12189,7 @@ msgstr ""
 msgid "Send invites"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12506,7 +12506,7 @@ msgstr "Afficher plus"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12532,7 +12532,7 @@ msgstr "Afficher les données de révision"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13322,7 +13322,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13520,7 +13520,7 @@ msgstr "Il y avait une erreur lors de la création de votre rapport. Veuillez r�
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "Voici vos modèles de vue par défaut. Une fois que vous avez créé votre bibliothèque, ces deux vues seront vos premières."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13626,7 +13626,7 @@ msgstr "Cette e-mail est déjà dans la liste."
 msgid "participant.modal.refine.info.available.in"
 msgstr "Cette fonctionnalité sera disponible dans {remainingTime} secondes."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14490,7 +14490,7 @@ msgstr "Se désabonner"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15447,7 +15447,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "Quelles tendances se dégagent des données ?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -573,12 +573,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1381,7 +1381,7 @@ msgstr ""
 msgid "a workspace"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1592,8 +1592,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -3058,7 +3058,7 @@ msgstr ""
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Cancel"
@@ -3276,7 +3276,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3937,7 +3937,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "Crop Logo"
 msgstr "Crop Logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4811,7 +4811,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4882,7 +4882,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr ""
@@ -5077,7 +5077,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Edit"
 
@@ -6622,7 +6622,7 @@ msgstr "Hide revision data"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -9078,8 +9078,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -9141,8 +9141,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -9164,8 +9164,8 @@ msgid "Oldest First"
 msgstr "Oldest First"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10790,7 +10790,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11736,7 +11736,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12406,7 +12406,7 @@ msgstr ""
 msgid "Send invites"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12727,7 +12727,7 @@ msgstr "Show more"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12753,7 +12753,7 @@ msgstr "Show revision data"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13559,7 +13559,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13766,7 +13766,7 @@ msgstr "There was an error creating your report. Please try again or contact sup
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "These are your default view templates. Once you create your library these will be your first two views."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13875,7 +13875,7 @@ msgstr "This email is already in the list."
 msgid "participant.modal.refine.info.available.in"
 msgstr "This feature will be available in {remainingTime} seconds."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14765,7 +14765,7 @@ msgstr "Unsubscribe"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15740,7 +15740,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "What patterns emerge from the data?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -231,12 +231,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr "{0, plural, one {# met fouten} other {# met fouten}}"
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr "{0, plural, one {Verplaats # project naar een andere werkruimte.} other {Verplaats # projecten naar een andere werkruimte.}}"
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -654,7 +654,7 @@ msgstr "{seats} plekken"
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr "Een korte notitie over waar dit project over gaat. Je kunt dit later aan
 msgid "a workspace"
 msgstr "een werkruimte"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr "Over jou"
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1185,8 +1185,8 @@ msgstr "Voeg een naam en een prompt toe voordat je dit toepast."
 msgid "Add a name, description, and framing."
 msgstr "Voeg een naam, beschrijving en framing toe."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -2603,7 +2603,7 @@ msgstr "kan lezen"
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Annuleren"
@@ -2813,7 +2813,7 @@ msgstr "Werkruimterol wijzigen?"
 msgid "Change your own role?"
 msgstr "Je eigen rol wijzigen?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr "Wijzigingen toegepast. Je kunt ze altijd bijstellen in de projectinstellingen."
 
@@ -2989,7 +2989,7 @@ msgstr "Zoekopdracht wissen"
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr "gewist"
 
@@ -3453,7 +3453,7 @@ msgstr "Kon je gesprekken niet aan deze chat toevoegen"
 msgid "Could not apply all the tag changes."
 msgstr "Kon niet alle tagwijzigingen toepassen."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr "Kon de wijzigingen niet toepassen. Er is niets opgeslagen."
 
@@ -3810,7 +3810,7 @@ msgstr "Logo bijsnijden"
 msgid "Crop Logo"
 msgstr "Logo bijsnijden"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4315,7 +4315,7 @@ msgstr "Vindbaar in deze organisatie"
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4328,7 +4328,7 @@ msgstr "Negeren"
 msgid "Dismissed"
 msgstr "Genegeerd"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4394,7 +4394,7 @@ msgstr "Wordt niet vanzelf bijgewerkt. Bijgewerkt {updatedAgo}."
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr "Klaar"
@@ -4575,7 +4575,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Bewerken"
 
@@ -6035,7 +6035,7 @@ msgstr "Revisiegegevens verbergen"
 msgid "Hide steps"
 msgstr "Stappen verbergen"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -8368,8 +8368,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr "Notities die de assistent vanuit chats over deze werkruimte heeft opgeslagen. Iedereen in de werkruimte deelt ze."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -8430,8 +8430,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr "Waarnemers zijn alleen beschikbaar in werkruimtes voor een externe klant. Kies alleen werkruimtes van externe klanten, of kies een andere rol."
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr "uit"
 
@@ -8453,8 +8453,8 @@ msgid "Oldest First"
 msgstr "Oudste eerst"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr "aan"
 
@@ -10144,7 +10144,7 @@ msgstr "Projecten verschijnen hier zodra iemand in de organisatie er een met je 
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11026,7 +11026,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Bekijk de activiteiten van je werkruimte. Filter op collectie of actie en exporteer de huidige weergave voor verder onderzoek."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -11687,7 +11687,7 @@ msgstr "Uitnodiging versturen"
 msgid "Send invites"
 msgstr "Uitnodigingen versturen"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -11984,7 +11984,7 @@ msgstr "Meer tonen"
 msgid "Show more versions"
 msgstr "Meer versies tonen"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12010,7 +12010,7 @@ msgstr "Revisiegegevens tonen"
 msgid "Show steps"
 msgstr "Stappen tonen"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -12758,7 +12758,7 @@ msgstr "De assistent vergeet dit in elke toekomstige chat."
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -12950,7 +12950,7 @@ msgstr "Er is een fout opgetreden bij het maken van uw rapport. Probeer het alst
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "Dit zijn uw standaard weergave sjablonen. Zodra u uw bibliotheek hebt gemaakt, zullen deze uw eerste twee weergaven zijn."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr "Deze wijzigingen zijn toegepast op je project."
 
@@ -13055,7 +13055,7 @@ msgstr "Deze e-mail is al in de lijst."
 msgid "participant.modal.refine.info.available.in"
 msgstr "Deze functie is beschikbaar over {remainingTime} seconden."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -13917,7 +13917,7 @@ msgstr "Afmelden"
 msgid "Untagged"
 msgstr "Zonder tag"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -14829,7 +14829,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "Welke patronen zie je in de data?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -573,12 +573,12 @@ msgid "{0, plural, one {# with errors} other {# with errors}}"
 msgstr ""
 
 #. placeholder {0}: diff?.addedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:269
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:273
 msgid "{0, plural, one {# word added} other {# words added}}"
 msgstr ""
 
 #. placeholder {0}: diff?.removedWords ?? 0
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:275
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:279
 msgid "{0, plural, one {# word removed} other {# words removed}}"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "{0, plural, one {Move # project to another workspace.} other {Move # proj
 msgstr ""
 
 #. placeholder {0}: suggestion.changes.length
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:724
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:735
 msgid "{0, plural, one {Show what changes (# field)} other {Show what changes (# fields)}}"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 #~ msgid "{selectedCount, plural, one {# selected} other {# selected}}"
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:697
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
 msgid "{selectedCount} of {totalCount} fields selected. Accept applies only the ticked ones."
 msgstr ""
 
@@ -1381,7 +1381,7 @@ msgstr ""
 msgid "a workspace"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:468
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:472
 msgid "About the suggested project update: {hostNote}"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 #~ msgid "Absolute https URL. Workspace-level logo overrides when set."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:760
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:771
 msgid "Accept"
 msgstr ""
 
@@ -1592,8 +1592,8 @@ msgstr ""
 msgid "Add a name, description, and framing."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:664
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:740
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:684
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:751
 msgid "Add a note"
 msgstr ""
 
@@ -3058,7 +3058,7 @@ msgstr ""
 #: src/components/common/ImageCropModal.tsx:145
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:680
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:701
 #: src/components/chat/AgenticChatPanel.tsx:1882
 msgid "Cancel"
 msgstr "Cancel"
@@ -3276,7 +3276,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:454
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:458
 msgid "Changes applied. You can fine-tune them anytime in project settings."
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:133
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:514
 msgid "cleared"
 msgstr ""
 
@@ -3937,7 +3937,7 @@ msgstr ""
 msgid "Could not apply all the tag changes."
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:457
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:461
 msgid "Could not apply the changes. Nothing was saved."
 msgstr ""
 
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "Crop Logo"
 msgstr "Crop Logo"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:285
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:289
 msgid "Current"
 msgstr ""
 
@@ -4811,7 +4811,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/goal/GoalSuggestionCard.tsx:104
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:750
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:761
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:530
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:534
 msgid "Dismissed. Nothing was changed."
 msgstr ""
 
@@ -4882,7 +4882,7 @@ msgstr ""
 #: src/routes/onboarding/OnboardingRoute.tsx:530
 #: src/components/project/ProjectSharingModal.tsx:268
 #: src/components/invite/InviteModal.tsx:811
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 #: src/components/chat/AgenticChatPanel.tsx:381
 msgid "Done"
 msgstr ""
@@ -5077,7 +5077,7 @@ msgstr "ECHO"
 #: src/components/project/webhooks/WebhookSettingsCard.tsx:647
 #: src/components/methodology/WorkspaceMethodologiesSection.tsx:234
 #: src/components/chat/TemplatesModal.tsx:608
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:618
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:624
 msgid "Edit"
 msgstr "Edit"
 
@@ -6622,7 +6622,7 @@ msgstr "Hide revision data"
 msgid "Hide steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:733
 msgid "Hide the changes"
 msgstr ""
 
@@ -9078,8 +9078,8 @@ msgid "Notes the assistant saved about this workspace from chats. Everyone in th
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:562
-msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
-msgstr ""
+#~ msgid "Nothing changes until you accept. Open the changes to see the current value next to the proposed one."
+#~ msgstr ""
 
 #: src/features/sidebar/views/InboxView.tsx:325
 #: src/components/inbox/Inbox.tsx:268
@@ -9141,8 +9141,8 @@ msgid "Observers are only available in workspaces for an external client. Pick o
 msgstr ""
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:142
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:506
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:510
 msgid "off"
 msgstr ""
 
@@ -9164,8 +9164,8 @@ msgid "Oldest First"
 msgstr "Oldest First"
 
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:140
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:319
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:504
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:323
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:508
 msgid "on"
 msgstr ""
 
@@ -10790,7 +10790,7 @@ msgstr ""
 msgid "Prompt"
 msgstr "Prompt"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:298
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:302
 msgid "Proposed"
 msgstr ""
 
@@ -11736,7 +11736,7 @@ msgid "Review activity for your workspace. Filter by collection or action, and e
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
 #: src/components/goal/GoalSuggestionCard.tsx:112
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:538
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:542
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
 msgid "Review again"
@@ -12406,7 +12406,7 @@ msgstr ""
 msgid "Send invites"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:689
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:710
 msgid "Send note"
 msgstr ""
 
@@ -12727,7 +12727,7 @@ msgstr "Show more"
 msgid "Show more versions"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:341
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:345
 msgid "Show only what changed"
 msgstr ""
 
@@ -12753,7 +12753,7 @@ msgstr "Show revision data"
 msgid "Show steps"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:343
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:347
 msgid "Show the full text"
 msgstr ""
 
@@ -13559,7 +13559,7 @@ msgstr ""
 #~ msgid "The assistant is preparing this canvas."
 #~ msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:549
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:553
 msgid "The assistant suggests updating {headlineFields}. Waiting on you."
 msgstr ""
 
@@ -13766,7 +13766,7 @@ msgstr "There was an error creating your report. Please try again or contact sup
 #~ msgid "These are your default view templates. Once you create your library these will be your first two views."
 #~ msgstr "These are your default view templates. Once you create your library these will be your first two views."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:482
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:486
 msgid "These changes are applied to your project."
 msgstr ""
 
@@ -13875,7 +13875,7 @@ msgstr "This email is already in the list."
 msgid "participant.modal.refine.info.available.in"
 msgstr "This feature will be available in {remainingTime} seconds."
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:263
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:267
 msgid "This field already holds the proposed value."
 msgstr ""
 
@@ -14765,7 +14765,7 @@ msgstr "Unsubscribe"
 msgid "Untagged"
 msgstr ""
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:577
 msgid "Untick a field to leave it exactly as it is."
 msgstr ""
 
@@ -15740,7 +15740,7 @@ msgstr ""
 #~ msgid "What patterns emerge from the data?"
 #~ msgstr "What patterns emerge from the data?"
 
-#: src/components/chat/ProjectUpdateSuggestionCard.tsx:665
+#: src/components/chat/ProjectUpdateSuggestionCard.tsx:685
 msgid "What should be different about this?"
 msgstr ""
 


### PR DESCRIPTION
Follows #939, which made the project update proposal legible. This is polish on top of that, not a redesign: the layout, the collapse, the word diff and the per-field impact copy all stay exactly as they are. Six defects and hierarchy problems found by looking at the card live and measuring it.

## What a host sees change

**The impact sentence stops printing twice.** "The project context is read by transcription, chat answers and canvas generation, so a change here reaches more than one screen." was rendering in the resting block and again inside the Project context field row, about 200px apart, both italic. The resting copy now stands down once the card is expanded, so the sentence lands beside the field it describes when that is where it matters, and carries the resting block when the card is closed. It can no longer render twice in any state.

**The card gets a tonal hierarchy.** Every text run was `rgb(45,45,44)`: headline, summary, impact line, helper line, the Current and Proposed labels, the word counts, separated only by 15px against 12px and italic. Four equally black paragraphs stacked is what made a 192px card read as a wall. The genuinely secondary text now uses Mantine `c="dimmed"`, the convention the sibling cards already use: the helper lines, the Current and Proposed labels, the word counts. The headline, the summary, the assistant's reason and the impact line keep full contrast.

**The resting block stops repeating itself.** The headline already ends "Waiting on you", then "Nothing changes until you accept." said it again, then "Open the changes to see the current value next to the proposed one." narrated the button sitting directly beneath it. Both sentences are deleted. The headline and the button carry it, and the resting card is now three lines instead of five.

**"Untick a field to leave it exactly as it is." only shows when there is a field to leave out.** On a single-field proposal, unticking the one field just disables Accept, which reads as a broken card rather than a choice. The hint appears from two fields up.

**Short-value additions carry a non-colour signal.** In the word diff path an addition gets a green background and reads fine. `ValueText`, the plain before and after used for short values, the project name, key terms and booleans, gave the addition dark green text with no background while the removed counterpart was loudly struck through. The diff was asymmetric and died in greyscale or for a colour-blind reader. Both sides now use the same marking as the word diff path, so the removal is struck through and the addition sits on a background.

**Opening the note replaces the action row instead of stacking on it.** Cancel and Send note sat directly above Dismiss and Accept: four verbs, two competing submits, three rows at 390px. Writing a note is its own step, so it now takes the row over. Cancel puts the original row back untouched.

## What I chose not to do

- **No Directus change, no change to apply semantics, no change to `echo/agent/agent.py`.** The prompt is Sameer's, separately.
- **The per-field impact line and the assistant's reason stay full contrast.** They are the two body paragraphs inside an expanded field, and dimming either would have been a judgement beyond what was asked. If the expanded state still reads heavy, that is the next thing to look at.
- **No focus management on the note.** Opening the note unmounts the "Add a note" button and focus falls to the body, which is the behaviour on `main` today too, since that button already unmounted on open. `autoFocus` on the textarea would fix it, but it can fight the chat list's stick-to-bottom scrolling, so it is worth doing deliberately rather than as a side effect of this pass.
- **The expand toggle is hidden while the note is open.** That is the cost of the note replacing the whole row rather than half of it. An expanded panel stays visible; Cancel brings the toggle back.
- **Still not seen in a browser.** Everything here is reasoned from the reported measurements and asserted in jsdom.

## Verification

- `./node_modules/.bin/tsc --noEmit` clean
- `./node_modules/.bin/biome lint src/components/chat/ProjectUpdateSuggestionCard.tsx src/components/chat/ProjectUpdateSuggestionCard.test.tsx --diagnostic-level=error` clean, and `biome format` reports no fixes
- `./node_modules/.bin/lingui extract` then `lingui compile --typescript`, all eight catalogs committed, and `git diff --exit-code -- src/locales` clean when run again afterwards, which is what `ci-check-i18n-catalogs` checks
- `./node_modules/.bin/vitest run src/components/chat/ProjectUpdateSuggestionCard.test.tsx src/components/common/wordDiff.test.ts` passes 24 tests, up from 21. The three new ones cover the dedupe (the impact sentence appears exactly once collapsed, expanded and collapsed again), the single-field hint, and the note taking the action row over
- Full suite: 124 passed, 2 failed across 7 failing files. These are the pre-existing failures #939 documented, the six Playwright specs vitest picks up and `useChunkAnchorScroll.test.tsx` missing its jsdom pragma. Unchanged from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
