### PR TITLE
feat(stateless): open transcribe to project hosts and meter it honestly

### DIFF
--- a/echo/directus/sync/snapshot/fields/conversation/source.json
+++ b/echo/directus/sync/snapshot/fields/conversation/source.json
@@ -23,6 +23,11 @@
           "icon": "content_copy",
           "text": "CLONE",
           "value": "CLONE"
+        },
+        {
+          "icon": "graphic_eq",
+          "text": "STATELESS_TRANSCRIPTION",
+          "value": "STATELESS_TRANSCRIPTION"
         }
       ]
     },

--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -3,7 +3,9 @@ import re
 import json
 from typing import Any, Annotated
 from logging import getLogger
+from datetime import datetime, timezone
 
+import sentry_sdk
 import nest_asyncio
 from fastapi import Form, APIRouter, UploadFile, HTTPException
 from pydantic import BaseModel
@@ -13,8 +15,10 @@ from dembrane.llms import MODELS, router_completion
 from dembrane.utils import generate_uuid
 from dembrane.prompts import render_prompt
 from dembrane.transcribe import TranscriptionError, transcribe_audio_dembrane_26_07
+from dembrane.audio_utils import get_duration_from_url
 from dembrane.async_helpers import run_in_thread_pool
-from dembrane.api.dependency_auth import DependencyDirectusSession
+from dembrane.directus_async import async_directus
+from dembrane.api.dependency_auth import DirectusSession, DependencyDirectusSession
 
 # Enable nested event loops for sync-to-async bridges
 nest_asyncio.apply()
@@ -270,10 +274,111 @@ STATELESS_SIGNED_URL_EXPIRY_SECONDS = 3600
 # clients that don't set one at all.
 ALLOWED_UPLOAD_CONTENT_TYPES = ("audio/", "video/", "application/octet-stream")
 
+# Marker on the metering row. conversation.source is a plain varchar whose choices
+# are a Directus UI hint, not a database constraint, so a new value needs no
+# migration; the snapshot's source.json carries the same value so the admin
+# dropdown stays truthful.
+STATELESS_CONVERSATION_SOURCE = "STATELESS_TRANSCRIPTION"
+# There is no participant on a stateless call. A fixed label keeps these rows
+# self-describing to anyone who finds one in the database.
+STATELESS_PARTICIPANT_NAME = "Stateless transcription"
+
 
 class StatelessTranscriptionResponse(BaseModel):
     transcript: str
     note: str
+
+
+async def _assert_project_access(project_id: str, session: DirectusSession) -> None:
+    """Gate the endpoint on write access to the named project.
+
+    Mirrors agentic._assert_project_access: staff admins bypass the app-layer model
+    (they may have no app_user row) and non-members get 404 rather than 403, matching
+    the access ladder's don't-confirm-existence rule.
+
+    The policy is project:update, not conversation:read, because this call spends the
+    workspace's audio hours. Read-only observers can see a project's conversations and
+    must not be able to bill against it.
+    """
+    if session.is_admin:
+        return
+
+    from dembrane.api.v2.bff._access import resolve_project_access
+
+    access = await resolve_project_access(project_id, session)
+    access.require("project:update")
+
+
+def _probe_duration_seconds(audio_url: str) -> float | None:
+    """Audio duration in seconds, or None when it cannot be established.
+
+    The transcription pipeline returns only {"note", "raw", "error"} and no duration,
+    so this is the same ffprobe read the normal recording path uses when it stamps
+    conversation.duration after merging chunks.
+
+    None is deliberate rather than 0.0: a metering row carrying a made-up duration is
+    worse than one carrying a gap, because a written number gets believed.
+    """
+    try:
+        duration = get_duration_from_url(audio_url)
+    except Exception:
+        logger.exception("Failed to probe audio duration for stateless transcription")
+        return None
+
+    if duration <= 0:
+        logger.error(
+            "ffprobe returned a non-positive duration (%s) for a stateless transcription",
+            duration,
+        )
+        return None
+    return duration
+
+
+async def _record_stateless_usage(project_id: str, duration_seconds: float | None) -> str:
+    """Meter one stateless transcription as a conversation row that is born deleted.
+
+    Billing sums conversation.duration across a workspace *including* soft-deleted rows
+    (free_tier._workspace_lifetime_audio_hours: "delete preserves billable duration"),
+    so setting deleted_at at creation makes the row count for hours while staying out of
+    every listing, which all filter on deleted_at.
+
+    Deliberately not conversation_service.create. That helper raises
+    ConversationNotOpenForParticipationException when the project is closed to
+    participants, which is a portal toggle and has nothing to do with a host
+    transcribing their own audio, and it dispatches a conversation.started webhook,
+    which would be a lie for a conversation that never started.
+
+    Returns the new conversation id.
+    """
+    conversation_id = generate_uuid()
+
+    await async_directus.create_item(
+        "conversation",
+        {
+            "id": conversation_id,
+            "project_id": project_id,
+            "participant_name": STATELESS_PARTICIPANT_NAME,
+            "source": STATELESS_CONVERSATION_SOURCE,
+            "duration": duration_seconds,
+            "is_finished": True,
+            "deleted_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+    # New duration → bust usage cache, same as the participant upload path, so hours
+    # don't wait out the cache TTL before they surface.
+    try:
+        from dembrane.api.conversation import _invalidate_usage_cache_for_conversation
+
+        await _invalidate_usage_cache_for_conversation(conversation_id)
+    except Exception as exc:
+        logger.warning(
+            "usage cache invalidation failed for stateless conversation %s: %s",
+            conversation_id,
+            exc,
+        )
+
+    return conversation_id
 
 
 def _parse_hotwords(hotwords: str | None) -> list[str] | None:
@@ -298,11 +403,15 @@ def _run_stateless_transcription(
     anonymize_transcripts: bool,
     custom_guidance_prompt: str | None,
     prompt_override: str | None,
-) -> tuple[str, dict[str, Any]]:
+) -> tuple[str, dict[str, Any], float | None]:
     """Blocking pipeline: (optionally) park the upload in S3, transcribe, clean up.
 
     Runs in the thread pool; exactly one of file / audio_file_uri is set (the
     endpoint validates that).
+
+    Returns (transcript, metadata, duration_seconds). The duration is probed here
+    rather than by the caller because a parked upload only exists inside this
+    function: the finally below deletes it.
     """
     s3_key: str | None = None
 
@@ -322,7 +431,7 @@ def _run_stateless_transcription(
         raise ValueError("No audio input provided")
 
     try:
-        return transcribe_audio_dembrane_26_07(
+        transcript, meta = transcribe_audio_dembrane_26_07(
             audio_url,
             language=language,
             hotwords=hotwords,
@@ -331,6 +440,9 @@ def _run_stateless_transcription(
             custom_guidance_prompt=custom_guidance_prompt,
             prompt_override=prompt_override,
         )
+        # After transcription so a probe failure can never cost the caller a
+        # transcript, and before the finally so the parked upload is still there.
+        return transcript, meta, _probe_duration_seconds(audio_url)
     finally:
         # Stateless means no residue: drop the parked upload even when the
         # transcription failed. Caller-provided URIs are never deleted.
@@ -349,6 +461,7 @@ def _run_stateless_transcription(
 async def transcribe_stateless(
     session: DependencyDirectusSession,
     file: UploadFile | None = None,
+    project_id: Annotated[str | None, Form()] = None,
     audio_file_uri: Annotated[str | None, Form()] = None,
     language: Annotated[str | None, Form()] = "en",
     hotwords: Annotated[str | None, Form()] = None,
@@ -358,19 +471,27 @@ async def transcribe_stateless(
     prompt_override: Annotated[str | None, Form()] = None,
 ) -> StatelessTranscriptionResponse:
     """Run the Dembrane-26-07 transcription pipeline on one audio input and return the
-    transcript in the response. Nothing is written to the database.
+    transcript in the response. No transcript, audio or conversation content is stored.
 
     Provide exactly one of:
     - file: multipart audio upload. It is parked in S3 for the duration of the request
       and deleted afterwards, whether transcription worked or not.
     - audio_file_uri: an S3 key (signed automatically) or a full URL. Never deleted.
 
+    project_id names the project to bill. Any caller with write access to it may use
+    this endpoint; the audio duration is metered against that project's workspace as a
+    soft-deleted conversation row, which counts for hours and shows up nowhere. Staff
+    admins may omit project_id, which is how the endpoint originally worked, and such
+    calls are not metered because there is no project to bill.
+
     hotwords is a comma-separated list. custom_guidance_prompt is appended to the
     default transcription prompt; prompt_override replaces that prompt entirely (the
     PII redaction pass keeps its own dedicated prompt either way).
     """
-    if not session.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    if project_id:
+        await _assert_project_access(project_id, session)
+    elif not session.is_admin:
+        raise HTTPException(status_code=403, detail="project_id is required")
 
     if (file is None) == (audio_file_uri is None):
         raise HTTPException(status_code=400, detail="Provide exactly one of file or audio_file_uri")
@@ -392,7 +513,7 @@ async def transcribe_stateless(
             )
 
     try:
-        transcript, meta = await run_in_thread_pool(
+        transcript, meta, duration_seconds = await run_in_thread_pool(
             _run_stateless_transcription,
             file,
             audio_file_uri,
@@ -408,5 +529,33 @@ async def transcribe_stateless(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except TranscriptionError as e:
         raise HTTPException(status_code=502, detail=str(e)) from e
+
+    if project_id:
+        if duration_seconds is None:
+            # The row is still written: it records that the workspace spent a
+            # transcription, and a null duration is queryable as "unknown" in a way
+            # that a zero never would be. Loud, because this under-bills.
+            logger.error(
+                "Metering a stateless transcription for project %s with no duration: "
+                "ffprobe could not read the audio",
+                project_id,
+            )
+            sentry_sdk.capture_message(
+                "stateless transcription metered without a duration",
+                level="error",
+            )
+        try:
+            conversation_id = await _record_stateless_usage(project_id, duration_seconds)
+            logger.info(
+                "Metered stateless transcription for project %s as conversation %s (%s s)",
+                project_id,
+                conversation_id,
+                duration_seconds,
+            )
+        except Exception as exc:
+            # The caller did the work and gets the transcript. Losing the metering row
+            # is our problem to fix, not theirs to retry.
+            logger.exception("Failed to meter stateless transcription for project %s", project_id)
+            sentry_sdk.capture_exception(exc)
 
     return StatelessTranscriptionResponse(transcript=transcript, note=meta.get("note") or "")

--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -281,7 +281,7 @@ ALLOWED_UPLOAD_CONTENT_TYPES = ("audio/", "video/", "application/octet-stream")
 STATELESS_CONVERSATION_SOURCE = "STATELESS_TRANSCRIPTION"
 # There is no participant on a stateless call. A fixed label keeps these rows
 # self-describing to anyone who finds one in the database.
-STATELESS_PARTICIPANT_NAME = "Stateless transcription"
+STATELESS_PARTICIPANT_NAME = "Voice note"
 
 
 class StatelessTranscriptionResponse(BaseModel):

--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -1,12 +1,20 @@
+import os
+import re
 import json
-from typing import Any
+from typing import Any, Annotated
 from logging import getLogger
 
 import nest_asyncio
-from fastapi import APIRouter
+from fastapi import Form, APIRouter, UploadFile, HTTPException
+from pydantic import BaseModel
 
+from dembrane.s3 import delete_from_s3, get_signed_url, save_to_s3_from_file_like
 from dembrane.llms import MODELS, router_completion
+from dembrane.utils import generate_uuid
 from dembrane.prompts import render_prompt
+from dembrane.transcribe import TranscriptionError, transcribe_audio_dembrane_26_07
+from dembrane.async_helpers import run_in_thread_pool
+from dembrane.api.dependency_auth import DependencyDirectusSession
 
 # Enable nested event loops for sync-to-async bridges
 nest_asyncio.apply()
@@ -252,3 +260,153 @@ async def transcribe_webhook(payload: dict) -> None:
     logger = getLogger("stateless.webhook.transcribe")
     logger.debug(f"Transcribe webhook received: {payload}")
     logger.info("Transcription webhook received but integration is disabled; ignoring payload.")
+
+
+# Uploaded audio is parked under this prefix only for the duration of the request.
+STATELESS_UPLOAD_S3_PREFIX = "stateless-transcription"
+STATELESS_UPLOAD_MAX_MB = 100
+STATELESS_SIGNED_URL_EXPIRY_SECONDS = 3600
+# webm/mp4 recordings often carry a video/* content type; octet-stream covers
+# clients that don't set one at all.
+ALLOWED_UPLOAD_CONTENT_TYPES = ("audio/", "video/", "application/octet-stream")
+
+
+class StatelessTranscriptionResponse(BaseModel):
+    transcript: str
+    note: str
+
+
+def _parse_hotwords(hotwords: str | None) -> list[str] | None:
+    if not hotwords:
+        return None
+    parsed = [word.strip() for word in hotwords.split(",") if word.strip()]
+    return parsed or None
+
+
+def _stateless_upload_key(filename: str | None) -> str:
+    raw_extension = os.path.splitext(filename or "")[1].lower()
+    extension = raw_extension if re.fullmatch(r"\.[a-z0-9]{1,9}", raw_extension) else ""
+    return f"{STATELESS_UPLOAD_S3_PREFIX}/{generate_uuid()}{extension}"
+
+
+def _run_stateless_transcription(
+    file: UploadFile | None,
+    audio_file_uri: str | None,
+    language: str | None,
+    hotwords: list[str] | None,
+    use_pii_redaction: bool,
+    anonymize_transcripts: bool,
+    custom_guidance_prompt: str | None,
+    prompt_override: str | None,
+) -> tuple[str, dict[str, Any]]:
+    """Blocking pipeline: (optionally) park the upload in S3, transcribe, clean up.
+
+    Runs in the thread pool; exactly one of file / audio_file_uri is set (the
+    endpoint validates that).
+    """
+    s3_key: str | None = None
+
+    if file is not None:
+        s3_key = _stateless_upload_key(file.filename)
+        save_to_s3_from_file_like(file, s3_key, public=False, size_limit_mb=STATELESS_UPLOAD_MAX_MB)
+        audio_url = get_signed_url(s3_key, expires_in_seconds=STATELESS_SIGNED_URL_EXPIRY_SECONDS)
+    elif audio_file_uri and audio_file_uri.startswith(("http://", "https://")):
+        # Full URLs (external or already signed) pass through untouched.
+        audio_url = audio_file_uri
+    elif audio_file_uri:
+        # Bare bucket keys get signed, mirroring transcribe_conversation_chunk.
+        audio_url = get_signed_url(
+            audio_file_uri, expires_in_seconds=STATELESS_SIGNED_URL_EXPIRY_SECONDS
+        )
+    else:
+        raise ValueError("No audio input provided")
+
+    try:
+        return transcribe_audio_dembrane_26_07(
+            audio_url,
+            language=language,
+            hotwords=hotwords,
+            use_pii_redaction=use_pii_redaction,
+            anonymize_transcripts=anonymize_transcripts,
+            custom_guidance_prompt=custom_guidance_prompt,
+            prompt_override=prompt_override,
+        )
+    finally:
+        # Stateless means no residue: drop the parked upload even when the
+        # transcription failed. Caller-provided URIs are never deleted.
+        if s3_key is not None:
+            try:
+                delete_from_s3(s3_key)
+            except Exception:
+                logger.exception(f"Failed to delete stateless upload from S3: {s3_key}")
+
+
+@StatelessRouter.post(
+    "/transcribe",
+    response_model=StatelessTranscriptionResponse,
+    summary="Transcribe one audio file synchronously, storing nothing",
+)
+async def transcribe_stateless(
+    session: DependencyDirectusSession,
+    file: UploadFile | None = None,
+    audio_file_uri: Annotated[str | None, Form()] = None,
+    language: Annotated[str | None, Form()] = "en",
+    hotwords: Annotated[str | None, Form()] = None,
+    use_pii_redaction: Annotated[bool, Form()] = False,
+    anonymize_transcripts: Annotated[bool, Form()] = False,
+    custom_guidance_prompt: Annotated[str | None, Form()] = None,
+    prompt_override: Annotated[str | None, Form()] = None,
+) -> StatelessTranscriptionResponse:
+    """Run the Dembrane-26-07 transcription pipeline on one audio input and return the
+    transcript in the response. Nothing is written to the database.
+
+    Provide exactly one of:
+    - file: multipart audio upload. It is parked in S3 for the duration of the request
+      and deleted afterwards, whether transcription worked or not.
+    - audio_file_uri: an S3 key (signed automatically) or a full URL. Never deleted.
+
+    hotwords is a comma-separated list. custom_guidance_prompt is appended to the
+    default transcription prompt; prompt_override replaces that prompt entirely (the
+    PII redaction pass keeps its own dedicated prompt either way).
+    """
+    if not session.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    if (file is None) == (audio_file_uri is None):
+        raise HTTPException(status_code=400, detail="Provide exactly one of file or audio_file_uri")
+
+    if file is not None:
+        if file.content_type and not file.content_type.startswith(ALLOWED_UPLOAD_CONTENT_TYPES):
+            raise HTTPException(
+                status_code=400, detail=f"Unsupported content type: {file.content_type}"
+            )
+        file.file.seek(0, 2)
+        file_size = file.file.tell()
+        file.file.seek(0)
+        if file_size == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+        if file_size > STATELESS_UPLOAD_MAX_MB * 1024 * 1024:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File size exceeds {STATELESS_UPLOAD_MAX_MB}MB limit",
+            )
+
+    try:
+        transcript, meta = await run_in_thread_pool(
+            _run_stateless_transcription,
+            file,
+            audio_file_uri,
+            language,
+            _parse_hotwords(hotwords),
+            use_pii_redaction,
+            anonymize_transcripts,
+            custom_guidance_prompt,
+            prompt_override,
+        )
+    except ValueError as e:
+        # Invalid S3 key (path traversal) or an input that failed sanitization.
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except TranscriptionError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return StatelessTranscriptionResponse(transcript=transcript, note=meta.get("note") or "")

--- a/echo/server/dembrane/audio_utils.py
+++ b/echo/server/dembrane/audio_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import math
 import time
@@ -627,6 +628,71 @@ def probe_from_s3(file_name: str, input_format: str) -> dict:
 
 def get_duration_from_s3(file_name: str) -> float:
     probe_data = probe_from_s3(file_name, get_file_format_from_file_path(file_name))
+    if "format" in probe_data and "duration" in probe_data["format"]:
+        return float(probe_data["format"]["duration"])
+    else:
+        raise ValueError("Duration not found in ffprobe output")
+
+
+# ffprobe's own error text echoes the URL it was given, and the URLs we probe are
+# presigned: the query string is the credential. Strip it before anything is logged.
+def _redact_query(text: str) -> str:
+    return re.sub(r"\?\S*", "?<redacted>", text)
+
+
+# ffprobe reads a remote file over range requests, so a probe is cheap on a large
+# object. It is not free on an unreachable host, hence the wall-clock ceiling.
+PROBE_URL_TIMEOUT_SECONDS = 120
+
+
+def probe_from_url(url: str, timeout_seconds: int = PROBE_URL_TIMEOUT_SECONDS) -> dict:
+    """Run ffprobe against an http(s) URL without downloading the file into memory.
+
+    Unlike probe_from_bytes this needs no format hint, because ffprobe detects the
+    container from the stream. That matters for callers holding a presigned URL or an
+    upload whose filename carries no usable extension.
+
+    The protocol whitelist is load-bearing: without it a redirect or a playlist could
+    point ffprobe at file:// and turn a URL probe into a local file read.
+    """
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("probe_from_url only accepts http(s) URLs")
+
+    cmd = [
+        "ffprobe",
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-protocol_whitelist",
+        "http,https,tcp,tls,crypto",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        url,
+    ]
+
+    process = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout_seconds
+    )
+
+    stderr_output = _redact_query(process.stderr.decode().strip())
+    if stderr_output:
+        logger.debug(f"ffprobe stderr: {stderr_output}")
+
+    if process.returncode != 0:
+        raise ValueError(f"ffprobe failed on url: {stderr_output or 'Unknown error'}")
+
+    output = process.stdout.decode()
+    if not output:
+        raise ValueError("ffprobe returned empty output")
+
+    return json.loads(output)
+
+
+def get_duration_from_url(url: str, timeout_seconds: int = PROBE_URL_TIMEOUT_SECONDS) -> float:
+    """Audio duration in seconds for an http(s) URL, via ffprobe."""
+    probe_data = probe_from_url(url, timeout_seconds=timeout_seconds)
     if "format" in probe_data and "duration" in probe_data["format"]:
         return float(probe_data["format"]["duration"])
     else:

--- a/echo/server/dembrane/transcribe.py
+++ b/echo/server/dembrane/transcribe.py
@@ -109,11 +109,16 @@ def _transcribe_audio_gemini(
     hotwords: Optional[List[str]],
     use_pii_redaction: bool,
     custom_guidance_prompt: Optional[str] = None,
+    prompt_override: Optional[str] = None,
 ) -> tuple[str, str]:
-    """Single Gemini pass: transcribe audio directly, normalize hotwords, optional PII redaction."""
+    """Single Gemini pass: transcribe audio directly, normalize hotwords, optional PII redaction.
+
+    prompt_override replaces the entire rendered transcription prompt. The JSON output
+    contract still holds because response_format enforces the schema independently.
+    """
     logger = logging.getLogger("transcribe.transcribe_audio_gemini")
 
-    prompt = render_prompt(
+    prompt = prompt_override or render_prompt(
         "transcript_from_audio_workflow",
         "en",
         {
@@ -218,6 +223,7 @@ def transcribe_audio_dembrane_26_07(
     use_pii_redaction: bool = False,
     anonymize_transcripts: bool = False,
     custom_guidance_prompt: Optional[str] = None,
+    prompt_override: Optional[str] = None,
 ) -> tuple[str, dict[str, Any]]:
     """Transcribe audio through the Dembrane-26-07 workflow: one Gemini EU pass.
 
@@ -230,6 +236,9 @@ def transcribe_audio_dembrane_26_07(
        original correction-and-redaction pass runs on the audio plus that transcript.
     No raw response is stored.
 
+    prompt_override replaces the rendered transcription prompt for pass 1 only. The
+    redaction pass keeps its own dedicated prompt so redaction stays reliable.
+
     Returns:
         0: The transcript
         1: {"note": str, "raw": dict, "error": None}
@@ -238,7 +247,7 @@ def transcribe_audio_dembrane_26_07(
 
     # Pass 1: transcription only, no redaction.
     transcript, note = _transcribe_audio_gemini(
-        audio_file_uri, language, hotwords, False, custom_guidance_prompt
+        audio_file_uri, language, hotwords, False, custom_guidance_prompt, prompt_override
     )
 
     # Regex runs before correction, matching the old pipeline order.

--- a/echo/server/tests/api/test_stateless_transcribe.py
+++ b/echo/server/tests/api/test_stateless_transcribe.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+from datetime import datetime
 
 import pytest
 from httpx import AsyncClient, ASGITransport
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 import dembrane.api.stateless as stateless_api
+import dembrane.api.conversation as conversation_api
+from dembrane.api.v2.bff import _access as bff_access
 from dembrane.transcribe import TranscriptionError
 from dembrane.api.stateless import StatelessRouter
 from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+
+PROBED_DURATION_SECONDS = 137.25
 
 
 class _FakeS3:
@@ -65,6 +71,75 @@ def captured_transcribe(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
     monkeypatch.setattr(stateless_api, "transcribe_audio_dembrane_26_07", _fake)
     return captured
+
+
+@pytest.fixture(autouse=True)
+def probed_duration(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stand in for ffprobe. Autouse so no test ever shells out or hits the network."""
+    probed: list[str] = []
+
+    def _fake(url: str, **_kwargs: Any) -> float:
+        probed.append(url)
+        return PROBED_DURATION_SECONDS
+
+    monkeypatch.setattr(stateless_api, "get_duration_from_url", _fake)
+    return probed
+
+
+class _FakeDirectus:
+    """Captures conversation rows the endpoint writes."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.created: list[tuple[str, dict[str, Any]]] = []
+        self.fail = fail
+
+    async def create_item(self, collection: str, data: dict[str, Any]) -> dict[str, Any]:
+        if self.fail:
+            raise RuntimeError("directus is down")
+        self.created.append((collection, data))
+        return {"data": data}
+
+
+@pytest.fixture
+def fake_directus(monkeypatch: pytest.MonkeyPatch) -> _FakeDirectus:
+    directus = _FakeDirectus()
+    monkeypatch.setattr(stateless_api, "async_directus", directus)
+
+    async def _no_cache_bust(conversation_id: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(
+        conversation_api, "_invalidate_usage_cache_for_conversation", _no_cache_bust
+    )
+    return directus
+
+
+def _grant_project_access(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    allowed_project_ids: set[str],
+    denied_policy: str | None = None,
+) -> list[str]:
+    """Fake the v2 access ladder. Returns the list of policies that were required.
+
+    Ladder semantics, same as agentic: a project the caller isn't on is a 404 (don't
+    confirm existence), a policy the caller's role lacks is a 403.
+    """
+    required: list[str] = []
+
+    async def _resolve(project_id: str, auth: Any) -> Any:  # noqa: ARG001
+        if project_id not in allowed_project_ids:
+            raise HTTPException(status_code=404, detail="Project not found")
+
+        def _require(policy: str) -> None:
+            required.append(policy)
+            if denied_policy is not None and policy == denied_policy:
+                raise HTTPException(status_code=403, detail="Forbidden")
+
+        return SimpleNamespace(require=_require, role="member", project={})
+
+    monkeypatch.setattr(bff_access, "resolve_project_access", _resolve)
+    return required
 
 
 @pytest.mark.asyncio
@@ -207,3 +282,233 @@ async def test_rejects_empty_and_non_audio_uploads(fake_s3: _FakeS3) -> None:
     assert empty.status_code == 400
     assert wrong_type.status_code == 400
     assert fake_s3.saved == []
+
+
+# ── project access + metering ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_host_with_project_access_is_metered(
+    fake_s3: _FakeS3,
+    fake_directus: _FakeDirectus,
+    captured_transcribe: dict[str, Any],
+    probed_duration: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    required = _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["transcript"] == "hello world"
+    # A host, not an admin, and the gate is write access rather than read.
+    assert required == ["project:update"]
+
+    # Duration came from the same audio that was transcribed.
+    assert probed_duration == [captured_transcribe["audio_file_uri"]]
+
+    assert len(fake_directus.created) == 1
+    collection, row = fake_directus.created[0]
+    assert collection == "conversation"
+    assert row["project_id"] == "proj-1"
+    assert row["source"] == stateless_api.STATELESS_CONVERSATION_SOURCE
+    assert row["duration"] == PROBED_DURATION_SECONDS
+    # Born deleted: counted for billable hours, invisible in every listing.
+    assert row["deleted_at"]
+    assert datetime.fromisoformat(row["deleted_at"]).tzinfo is not None
+    assert row["participant_name"] == stateless_api.STATELESS_PARTICIPANT_NAME
+    assert row["is_finished"] is True
+
+    # Still stateless about the audio itself.
+    assert fake_s3.deleted == fake_s3.saved
+
+
+@pytest.mark.asyncio
+async def test_host_without_project_access_is_refused(
+    fake_s3: _FakeS3, fake_directus: _FakeDirectus, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "someone-elses-project"},
+        )
+
+    # 404 rather than 403: the ladder does not confirm a project's existence to
+    # someone who isn't on it (same as agentic._assert_project_access).
+    assert response.status_code == 404
+    assert fake_s3.saved == []
+    assert fake_directus.created == []
+
+
+@pytest.mark.asyncio
+async def test_host_lacking_write_policy_is_forbidden(
+    fake_s3: _FakeS3, fake_directus: _FakeDirectus, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _grant_project_access(
+        monkeypatch, allowed_project_ids={"proj-1"}, denied_policy="project:update"
+    )
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 403
+    assert fake_s3.saved == []
+    assert fake_directus.created == []
+
+
+@pytest.mark.asyncio
+async def test_non_admin_without_project_id_is_forbidden(
+    fake_s3: _FakeS3, fake_directus: _FakeDirectus
+) -> None:
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+        )
+
+    assert response.status_code == 403
+    assert fake_s3.saved == []
+    assert fake_directus.created == []
+
+
+@pytest.mark.asyncio
+async def test_admin_without_project_id_still_works_and_is_not_metered(
+    fake_s3: _FakeS3, fake_directus: _FakeDirectus, captured_transcribe: dict[str, Any]
+) -> None:
+    async with _client(_build_app(is_admin=True)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"transcript": "hello world", "note": "speak closer"}
+    # No project means nothing to bill, which is how the endpoint shipped.
+    assert fake_directus.created == []
+
+
+@pytest.mark.asyncio
+async def test_admin_with_project_id_is_metered_without_consulting_the_ladder(
+    fake_s3: _FakeS3,
+    fake_directus: _FakeDirectus,
+    captured_transcribe: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _explode(project_id: str, auth: Any) -> Any:  # noqa: ARG001
+        raise AssertionError("staff admins must not need an app_user row")
+
+    monkeypatch.setattr(bff_access, "resolve_project_access", _explode)
+
+    async with _client(_build_app(is_admin=True)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 200
+    assert len(fake_directus.created) == 1
+    assert fake_directus.created[0][1]["project_id"] == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_metering_failure_does_not_cost_the_caller_their_transcript(
+    fake_s3: _FakeS3, captured_transcribe: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+    monkeypatch.setattr(stateless_api, "async_directus", _FakeDirectus(fail=True))
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"transcript": "hello world", "note": "speak closer"}
+    assert fake_s3.deleted == fake_s3.saved
+
+
+@pytest.mark.asyncio
+async def test_unreadable_duration_is_recorded_as_null_never_as_zero(
+    fake_s3: _FakeS3,
+    fake_directus: _FakeDirectus,
+    captured_transcribe: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+
+    def _boom(url: str, **_kwargs: Any) -> float:  # noqa: ARG001
+        raise ValueError("ffprobe failed on url")
+
+    monkeypatch.setattr(stateless_api, "get_duration_from_url", _boom)
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 200
+    assert len(fake_directus.created) == 1
+    assert fake_directus.created[0][1]["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_non_positive_duration_is_treated_as_unknown(
+    fake_s3: _FakeS3,
+    fake_directus: _FakeDirectus,
+    captured_transcribe: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """merge_multiple_audio_files_and_save_to_s3 uses -1.0 as its probe-failed
+    sentinel; a negative or zero duration is a failure here too, not a free minute."""
+    _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+    monkeypatch.setattr(stateless_api, "get_duration_from_url", lambda _url, **_k: -1.0)
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("memo.mp3", b"fake-audio", "audio/mpeg")},
+            data={"project_id": "proj-1"},
+        )
+
+    assert response.status_code == 200
+    assert fake_directus.created[0][1]["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_uri_input_is_metered_too(
+    fake_s3: _FakeS3,
+    fake_directus: _FakeDirectus,
+    captured_transcribe: dict[str, Any],
+    probed_duration: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _grant_project_access(monkeypatch, allowed_project_ids={"proj-1"})
+
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            data={"project_id": "proj-1", "audio_file_uri": "https://example.com/a.mp3?sig=1"},
+        )
+
+    assert response.status_code == 200
+    assert probed_duration == ["https://example.com/a.mp3?sig=1"]
+    assert fake_directus.created[0][1]["duration"] == PROBED_DURATION_SECONDS
+    # A caller-provided URI is still never deleted.
+    assert fake_s3.deleted == []

--- a/echo/server/tests/api/test_stateless_transcribe.py
+++ b/echo/server/tests/api/test_stateless_transcribe.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+
+import dembrane.api.stateless as stateless_api
+from dembrane.transcribe import TranscriptionError
+from dembrane.api.stateless import StatelessRouter
+from dembrane.api.dependency_auth import DirectusSession, require_directus_session
+
+
+class _FakeS3:
+    """Records the S3 traffic the endpoint generates so tests can assert on order."""
+
+    def __init__(self) -> None:
+        self.saved: list[str] = []
+        self.deleted: list[str] = []
+        self.signed: list[str] = []
+
+    def save(self, file_obj: Any, key: str, public: bool, size_limit_mb: int = 100) -> str:
+        assert public is False
+        self.saved.append(key)
+        return f"http://s3.local/bucket/{key}"
+
+    def sign(self, key: str, expires_in_seconds: int = 3600) -> str:
+        self.signed.append(key)
+        return f"https://signed.example/{key}"
+
+    def delete(self, key: str) -> None:
+        self.deleted.append(key)
+
+
+def _build_app(is_admin: bool = True) -> FastAPI:
+    app = FastAPI()
+    app.include_router(StatelessRouter, prefix="/stateless")
+    session = DirectusSession(user_id="user-1", is_admin=is_admin)
+    app.dependency_overrides[require_directus_session] = lambda: session
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.fixture
+def fake_s3(monkeypatch: pytest.MonkeyPatch) -> _FakeS3:
+    s3 = _FakeS3()
+    monkeypatch.setattr(stateless_api, "save_to_s3_from_file_like", s3.save)
+    monkeypatch.setattr(stateless_api, "get_signed_url", s3.sign)
+    monkeypatch.setattr(stateless_api, "delete_from_s3", s3.delete)
+    return s3
+
+
+@pytest.fixture
+def captured_transcribe(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def _fake(audio_file_uri: str, **kwargs: Any) -> tuple[str, dict[str, Any]]:
+        captured["audio_file_uri"] = audio_file_uri
+        captured.update(kwargs)
+        return "hello world", {"note": "speak closer", "raw": {}, "error": None}
+
+    monkeypatch.setattr(stateless_api, "transcribe_audio_dembrane_26_07", _fake)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_upload_is_transcribed_then_deleted(
+    fake_s3: _FakeS3, captured_transcribe: dict[str, Any]
+) -> None:
+    async with _client(_build_app()) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("meeting.MP3", b"fake-audio", "audio/mpeg")},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"transcript": "hello world", "note": "speak closer"}
+
+    assert len(fake_s3.saved) == 1
+    key = fake_s3.saved[0]
+    assert key.startswith("stateless-transcription/")
+    assert key.endswith(".mp3")
+    # transcription consumed the signed URL of the parked upload, then the upload was dropped
+    assert captured_transcribe["audio_file_uri"] == f"https://signed.example/{key}"
+    assert fake_s3.deleted == [key]
+
+
+@pytest.mark.asyncio
+async def test_upload_is_deleted_even_when_transcription_fails(
+    fake_s3: _FakeS3, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(audio_file_uri: str, **kwargs: Any) -> tuple[str, dict[str, Any]]:
+        raise TranscriptionError("model unavailable")
+
+    monkeypatch.setattr(stateless_api, "transcribe_audio_dembrane_26_07", _boom)
+
+    async with _client(_build_app()) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.wav", b"fake-audio", "audio/wav")},
+        )
+
+    assert response.status_code == 502
+    assert fake_s3.deleted == fake_s3.saved
+
+
+@pytest.mark.asyncio
+async def test_all_params_forwarded(fake_s3: _FakeS3, captured_transcribe: dict[str, Any]) -> None:
+    async with _client(_build_app()) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.mp3", b"fake-audio", "audio/mpeg")},
+            data={
+                "language": "nl",
+                "hotwords": "Dembrane, Sameer , ",
+                "use_pii_redaction": "true",
+                "anonymize_transcripts": "true",
+                "custom_guidance_prompt": "prefer formal spelling",
+                "prompt_override": "Transcribe in ALL CAPS.",
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured_transcribe["language"] == "nl"
+    assert captured_transcribe["hotwords"] == ["Dembrane", "Sameer"]
+    assert captured_transcribe["use_pii_redaction"] is True
+    assert captured_transcribe["anonymize_transcripts"] is True
+    assert captured_transcribe["custom_guidance_prompt"] == "prefer formal spelling"
+    assert captured_transcribe["prompt_override"] == "Transcribe in ALL CAPS."
+
+
+@pytest.mark.asyncio
+async def test_bare_s3_key_is_signed_and_never_deleted(
+    fake_s3: _FakeS3, captured_transcribe: dict[str, Any]
+) -> None:
+    async with _client(_build_app()) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            data={"audio_file_uri": "chunks/abc/audio.mp3"},
+        )
+
+    assert response.status_code == 200
+    assert fake_s3.signed == ["chunks/abc/audio.mp3"]
+    assert captured_transcribe["audio_file_uri"] == "https://signed.example/chunks/abc/audio.mp3"
+    assert fake_s3.saved == []
+    assert fake_s3.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_full_url_passes_through_untouched(
+    fake_s3: _FakeS3, captured_transcribe: dict[str, Any]
+) -> None:
+    async with _client(_build_app()) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            data={"audio_file_uri": "https://example.com/a.mp3?sig=1"},
+        )
+
+    assert response.status_code == 200
+    assert captured_transcribe["audio_file_uri"] == "https://example.com/a.mp3?sig=1"
+    assert fake_s3.signed == []
+    assert fake_s3.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_requires_exactly_one_audio_input(fake_s3: _FakeS3) -> None:
+    async with _client(_build_app()) as client:
+        neither = await client.post("/stateless/transcribe", data={"language": "en"})
+        both = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.mp3", b"fake-audio", "audio/mpeg")},
+            data={"audio_file_uri": "chunks/abc/audio.mp3"},
+        )
+
+    assert neither.status_code == 400
+    assert both.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_admin_is_forbidden(fake_s3: _FakeS3) -> None:
+    async with _client(_build_app(is_admin=False)) as client:
+        response = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.mp3", b"fake-audio", "audio/mpeg")},
+        )
+
+    assert response.status_code == 403
+    assert fake_s3.saved == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_and_non_audio_uploads(fake_s3: _FakeS3) -> None:
+    async with _client(_build_app()) as client:
+        empty = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.mp3", b"", "audio/mpeg")},
+        )
+        wrong_type = await client.post(
+            "/stateless/transcribe",
+            files={"file": ("a.txt", b"not audio", "text/plain")},
+        )
+
+    assert empty.status_code == 400
+    assert wrong_type.status_code == 400
+    assert fake_s3.saved == []

--- a/echo/server/tests/test_transcribe_dembrane_26_07.py
+++ b/echo/server/tests/test_transcribe_dembrane_26_07.py
@@ -26,7 +26,9 @@ class _FakeCompletion:
 def _stub_common(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(transcribe, "GCP_SA_JSON", {"type": "service_account"})
     monkeypatch.setattr(
-        transcribe, "_get_audio_file_object", lambda _uri: {"type": "file", "file": {"file_data": "x"}}
+        transcribe,
+        "_get_audio_file_object",
+        lambda _uri: {"type": "file", "file": {"file_data": "x"}},
     )
 
 
@@ -52,7 +54,9 @@ def test_transcribe_26_07_audio_only_no_candidate(monkeypatch: pytest.MonkeyPatc
     def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
         captured["model"] = model
         captured["messages"] = messages
-        return _FakeCompletion(json.dumps({"corrected_transcript": "hello world", "note": "speak closer"}))
+        return _FakeCompletion(
+            json.dumps({"corrected_transcript": "hello world", "note": "speak closer"})
+        )
 
     monkeypatch.setattr(transcribe, "router_completion", _fake_router)
 
@@ -97,6 +101,53 @@ def test_transcribe_26_07_empty_maps_to_placeholder(monkeypatch: pytest.MonkeyPa
 
     transcript, _meta = transcribe.transcribe_audio_dembrane_26_07("https://example.com/a.mp3")
     assert transcript == "[Nothing to transcribe]"
+
+
+def test_transcribe_26_07_prompt_override_replaces_transcription_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_common(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+        captured["messages"] = messages
+        return _FakeCompletion(json.dumps({"corrected_transcript": "HELLO", "note": ""}))
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    transcript, _meta = transcribe.transcribe_audio_dembrane_26_07(
+        "https://example.com/a.mp3", prompt_override="Transcribe in ALL CAPS."
+    )
+
+    assert transcript == "HELLO"
+    system_msg = next(m for m in captured["messages"] if m["role"] == "system")
+    assert system_msg["content"][0]["text"] == "Transcribe in ALL CAPS."
+
+
+def test_transcribe_26_07_prompt_override_leaves_redaction_prompt_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The override only swaps the pass-1 transcription prompt. The dedicated
+    redaction pass keeps its own prompt so redaction stays reliable."""
+    _stub_common(monkeypatch)
+    system_prompts: list[str] = []
+
+    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+        system_msg = next(m for m in messages if m["role"] == "system")
+        system_prompts.append(system_msg["content"][0]["text"])
+        return _FakeCompletion(json.dumps({"corrected_transcript": "x", "note": ""}))
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    transcribe.transcribe_audio_dembrane_26_07(
+        "https://example.com/a.mp3",
+        use_pii_redaction=True,
+        prompt_override="Transcribe in ALL CAPS.",
+    )
+
+    assert len(system_prompts) == 2
+    assert system_prompts[0] == "Transcribe in ALL CAPS."
+    assert system_prompts[1] != "Transcribe in ALL CAPS."
 
 
 def test_transcribe_26_07_pii_runs_correction_pass_over_audio_and_transcript(
@@ -150,7 +201,10 @@ def test_transcribe_26_07_anonymize_regex_before_correction_and_hides_raw(
         "router_completion",
         _router_dispatch(
             {"corrected_transcript": "my name is Usama, call me at 0612345678", "note": ""},
-            {"corrected_transcript": "my name is <redacted_name>, call me at <redacted_phone>", "note": ""},
+            {
+                "corrected_transcript": "my name is <redacted_name>, call me at <redacted_phone>",
+                "note": "",
+            },
         ),
     )
     seen: dict[str, str] = {}


### PR DESCRIPTION
Two changes on top of the stateless transcription endpoint. **This PR includes
@spashii's `feat(stateless): add synchronous stateless transcription endpoint`
commit (46e51b7)**, because it is based on that branch rather than on `main`.

## 1. Any host with project access may call it

`POST /stateless/transcribe` was admin-only. It now takes an optional
`project_id` form field and asserts access to it through the v2 access ladder,
reusing the shape of `agentic._assert_project_access`:

- staff admins bypass the app-layer model (they may have no `app_user` row);
- a caller who is not on the project gets **404**, not 403, matching the ladder's
  don't-confirm-existence rule;
- a member whose role lacks the policy gets **403**.

The policy required is `project:update`, not `conversation:read`. A call spends
the workspace's audio hours, and the `observer` role is deliberately read-only:
observers can see a project's conversations and should not be able to bill
against one. `project:update` is held by member, external, admin and owner, and
carries no tier gate.

An **admin with no `project_id` keeps working exactly as before**, which is what
the endpoint was built for. Those calls are not metered, because there is no
project to bill.

## 2. The call is metered as a soft-deleted conversation row

After a successful transcription with a `project_id`, we create a `conversation`
row with `source = "STATELESS_TRANSCRIPTION"` and `deleted_at` already
populated.

The billing reasoning: `_workspace_lifetime_audio_hours` (`free_tier.py`) sums
`conversation.duration` across a workspace's projects with **no `deleted_at`
filter at all**, and says so in its own docstring ("Includes soft-deleted rows
(PRD §270: delete preserves billable duration)"). Every place that lists
conversations does filter on `deleted_at`. So a row that is born deleted meters
honestly and shows up nowhere: the hours are billed, the product never displays a
conversation the host did not create.

The usage cache is busted afterwards via
`_invalidate_usage_cache_for_conversation`, best effort, exactly as the
participant upload path does, so hours do not wait out the cache TTL.

**A metering failure never fails the transcription.** The caller did the work and
gets their transcript; the failure is `logger.exception`'d and sent to Sentry.
Losing the row is ours to fix, not theirs to retry.

`conversation.source` is a plain `varchar(255)` whose `select-dropdown` choices
are a Directus UI hint rather than a database constraint, so **no migration**.
`echo/directus/sync/snapshot/fields/conversation/source.json` gains the choice so
the admin dropdown stays truthful.

## Duration

`transcribe_audio_dembrane_26_07` returns `{"note", "raw", "error"}` and
**carries no duration**, so it had to come from somewhere else. On the normal
recording path, `conversation.duration` is written by `get_conversation_content`
from the value `merge_multiple_audio_files_and_save_to_s3` gets out of **ffprobe**
on the merged file. So this uses ffprobe too.

`audio_utils` gains `probe_from_url` / `get_duration_from_url`, which probe an
http(s) URL directly. `get_duration_from_s3` was not reusable here: it routes
through `get_file_format_from_file_path`, which needs a recognised extension, and
a stateless upload can arrive as `application/octet-stream` with no usable
filename. ffprobe detects the container from the stream, so a URL probe needs no
hint and covers all three input shapes (parked upload, bare S3 key, caller URL)
with one code path. It reads over range requests rather than downloading into
memory, runs under a wall-clock timeout, and sets `-protocol_whitelist` so a
redirect cannot turn a URL probe into a `file://` read. ffprobe's stderr echoes
the URL it was given, and the URLs here are presigned, so the query string is
stripped before anything is logged.

The probe runs after transcription succeeds and before the `finally` deletes the
parked upload.

**When the probe fails, the row is still written with a null duration, plus a
loud error log and a Sentry message. Never a zero.** A null is queryable as
"unknown" and can be backfilled; a zero would be silently believed. A negative or
zero reading is treated as failure too, matching the `-1.0` sentinel the merge
path uses.

## Two judgement calls worth your eye

**1. `conversation_service.create` is not used, so `is_conversation_allowed` does
not gate this.** That helper raises `ConversationNotOpenForParticipationException`
when the project's `is_conversation_allowed` is false. That flag is a
participant-facing portal toggle: it controls whether strangers with the link can
record. A host transcribing their own voice note into their own project is not
participation, and having the portal closed should not block them. The helper
also dispatches a `conversation.started` webhook, which would be untrue for a row
that is born deleted, and would fire integrations for a conversation that never
started. So the row is created directly. **Say if you disagree**: the alternative
is honouring the toggle and 403'ing when the portal is closed.

**2. `participant_name` on a row with no participant** is the fixed string
`"Stateless transcription"`. The field is nullable, so null was an option, and so
was the caller's user id or the uploaded filename. A constant was chosen because
it makes the row self-describing to anyone who finds one in the database, and
because the caller's identity is already in the API logs while a filename would
be user content stored on a row whose whole point is storing no user content.
Easy to change if you would rather see who made the call.

A third, smaller one: these rows do not get an `is_over_cap` stamp, since that is
computed by the finish-time task path. Their duration still counts toward the
workspace total that the next conversation's stamp reads.

## Verified, not assumed

Read and confirmed in the tree:

- `_workspace_lifetime_audio_hours` filters only on `project_id`, never
  `deleted_at`; its docstring says soft-deleted rows are included.
- `conversation.source` is `character varying(255)`, nullable, no constraint; the
  choices live only in Directus field meta.
- `conversation.duration` is a nullable `real`; `deleted_at` is a nullable
  `timestamptz`.
- `conversation_service.create` does raise on `is_conversation_allowed` and does
  dispatch `conversation.started`.
- `transcribe_audio_dembrane_26_07` returns `{"note": note, "raw": {}, "error":
  None}`, no duration anywhere.
- `_invalidate_usage_cache_for_conversation` is best effort and no-ops on any
  missing link.
- `project:update` is in the member, external, admin and owner presets, absent
  from observer, and not in `TIER_REQUIRED_FOR_POLICY`.
- ffprobe ships in the server image (`Dockerfile` copies it from
  `mwader/static-ffmpeg`).

Assumed, and worth a second opinion: that `project:update` is the right policy
name for "may spend this workspace's hours" (there is no `conversation:create` in
the matrix), and that metering only when `project_id` is present is right, rather
than requiring `project_id` from everyone including admins.

## Tests

`echo/server/tests/api/test_stateless_transcribe.py` grows from 8 to 18 tests,
all existing ones kept. New coverage: a host with access succeeds and produces a
row with the right `project_id`, `source`, populated `deleted_at` and real
duration; a non-member gets 404 and a policy-denied member gets 403, neither
touching S3 or Directus; a non-admin with no `project_id` gets 403; the admin
path still works and is not metered; an admin with a `project_id` is metered
without consulting the ladder; a Directus failure still returns the transcript; a
failed probe and a negative probe both write null rather than zero; and a URI
input is metered too. An autouse fixture stands in for ffprobe so no test shells
out or touches the network.

Run locally with the `pr-testing.yml` env block:

- `uv run pytest -q tests/api/test_stateless_transcribe.py`: **18 passed**
- `uv run ruff check .` (what CI runs): **clean**, and `ruff format --check` on
  the three changed files is clean
- `uv run mypy dembrane/ --ignore-missing-imports`: 73 pre-existing errors, none
  in `stateless.py` or `audio_utils.py`

The wider unit suite (`-m "not integration and not slow and not smoke"`,
excluding `test_audio_utils.py`) gives **1264 passed, 45 failed**. All 45 were
checked by re-running the same files with `dembrane/`, `tests/` and `directus/`
reverted to 46e51b7: **identical failures, same count, same names**. They are
billing, tier, seat, invite and token-count tests that want services this laptop
does not have. `tests/test_audio_utils.py` is excluded because it talks to a real
S3 endpoint and fails here regardless of this branch; nothing in it exercises the
new prober.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
