### PR TITLE
agent: let the assistant read the host's reports

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -47,7 +47,7 @@ AgentInsightKind = Literal["capability_gap", "friction", "wish", "praise"]
 #   listProjectConversations, getProjectSettings, getProjectTags, getPortalLink,
 #   listDocs, readDoc, grepDocs, readSkill, listProjectChats, readChat,
 #   getLiveConversationStatus, readMemory, readGoal, listMethodologies,
-#   listCanvases, get_project_scope).
+#   listCanvases, listReports, readReport, get_project_scope).
 # - Write tools change durable state (editCanvas, addToCanvas,
 #   removeFromCanvas, pauseCanvasLoop, resumeCanvasLoop, stopCanvasLoop,
 #   remember, amendMemory, forgetMemory, reachOutToDembraneSupport, noteInsight,
@@ -201,7 +201,13 @@ When intent is unclear, ask one focused question instead of guessing.
 - Monitor: live participant recording and transcription health.
 - Library: conversations, canvases, reports, and analysis materials.
 - Host guide: guidance for sharing the portal and running collection.
-- Report: report creation, editing, and sharing.
+- Report: report creation, editing, and sharing. You can read what is there:
+  listReports for what exists and what the host asked each one to focus on, and
+  readReport for one in full. Do that before discussing reports, so you are
+  talking about their actual deliverable rather than reports in general, and so
+  you never redo analysis a published report already covers. You cannot create or
+  regenerate one; the host does that from the Report page, where "Guide the
+  report" is where they steer what it focuses on.
 - Conversations: the conversation list, transcripts, tags, and status.
 - Settings: project configuration and access controls.
 Never describe dashboard navigation beyond these surfaces. When sharing the
@@ -1347,6 +1353,40 @@ def create_agent_graph(
         return knowledge.read_skill(path)
 
     @tool
+    async def listReports() -> dict[str, Any]:
+        """List the reports in this project, newest first, without their text.
+
+        Use this before saying anything about reports: whether one exists, what
+        the host already asked for, whether one is still generating. Each entry
+        carries its id, status, when it was made, its language, and the
+        instructions that shaped it. Read one by id when the host is discussing
+        it. You cannot create or regenerate a report; the host does that from the
+        Report page."""
+        client = _create_echo_client()
+        try:
+            reports = await client.list_project_reports(project_id)
+        finally:
+            await client.close()
+        return {"reports": reports, "count": len(reports)}
+
+    @tool
+    async def readReport(report_id: str) -> dict[str, Any]:
+        """Read one report in full: its content, and the instructions behind it.
+
+        Use this when the host asks what a report says, wants it summarized, or
+        wants to build on it. Quote it as their report, not as your own finding.
+        If the host is asking for something the report already covers, say so
+        instead of redoing the work."""
+        normalized_id = str(report_id).strip()
+        if not normalized_id:
+            raise ValueError("report_id is required")
+        client = _create_echo_client()
+        try:
+            return await client.get_project_report(project_id, normalized_id)
+        finally:
+            await client.close()
+
+    @tool
     async def getProjectSettings() -> dict[str, Any]:
         """Read the project's current editable settings (portal, language, context).
 
@@ -2259,6 +2299,8 @@ def create_agent_graph(
         readDoc,
         grepDocs,
         readSkill,
+        listReports,
+        readReport,
         getProjectSettings,
         getProjectTags,
         getPortalLink,

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -146,6 +146,17 @@ class EchoClient:
         payload = await self.get(f"/agentic/projects/{project_id}/settings")
         return payload if isinstance(payload, dict) else {}
 
+    async def list_project_reports(self, project_id: str) -> list[dict[str, Any]]:
+        payload = await self.get(f"/agentic/projects/{project_id}/reports")
+        if isinstance(payload, dict):
+            reports = payload.get("reports")
+            return reports if isinstance(reports, list) else []
+        return []
+
+    async def get_project_report(self, project_id: str, report_id: str) -> dict[str, Any]:
+        payload = await self.get(f"/agentic/projects/{project_id}/reports/{report_id}")
+        return payload if isinstance(payload, dict) else {}
+
     async def list_project_tags(self, project_id: str) -> list[dict[str, Any]]:
         payload = await self.get(f"/v2/bff/tags?project_id={project_id}")
         return payload if isinstance(payload, list) else []

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -579,6 +579,34 @@ def test_project_setup_tools_include_project_tags_reader():
     assert "navigateTo" in tools
 
 
+def test_report_read_tools_are_registered():
+    # Registering is the whole feature: a tool defined but left out of the list
+    # fails silently, and the assistant simply keeps being blind to reports.
+    tools = _make_doc_tools()
+
+    assert "listReports" in tools
+    assert "readReport" in tools
+
+
+def test_report_tools_are_reads_not_writes():
+    # The host creates and regenerates reports; report generation is the most
+    # expensive operation in the product and it stays behind their own click.
+    tools = _make_doc_tools()
+
+    assert "createReport" not in tools
+    assert "generateReport" not in tools
+    assert "proposeReport" not in tools
+
+
+def test_prompt_tells_the_agent_it_can_read_reports():
+    prompt = " ".join(SYSTEM_PROMPT.lower().split())
+
+    assert "listreports" in prompt
+    assert "readreport" in prompt
+    # It must not imply it can make one.
+    assert "you cannot create or regenerate one" in prompt
+
+
 @pytest.mark.asyncio
 async def test_get_portal_link_returns_project_link_from_settings_language():
     llm = _CaptureLLM()

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -1791,6 +1791,102 @@ async def list_agent_insights(
     return {"project_id": project_id, "insights": insights}
 
 
+# Reports are a host's deliverable, and until now the assistant could not see one.
+# It would describe the Report page while being unable to say what was on it, and
+# would happily propose work the host had already published. These two reads close
+# that gap. Both are read-only; nothing here creates or regenerates a report.
+#
+# `kind` is filtered explicitly because a canvas is also a project_report row
+# (kind='canvas'), and the host-facing list endpoints omit that filter, so canvases
+# surface there as untitled reports. Do not copy that omission.
+REPORT_LIST_FIELDS = [
+    "id",
+    "status",
+    "date_created",
+    "language",
+    "user_instructions",
+]
+
+REPORT_VISIBLE_STATUSES = ["published", "scheduled", "draft", "archived"]
+
+
+def _report_title(content: Optional[str]) -> Optional[str]:
+    """First markdown H1, which is how the dashboard titles a report."""
+    for line in (content or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip() or None
+    return None
+
+
+@AgenticRouter.get("/projects/{project_id}/reports")
+async def list_project_reports_for_agent(
+    project_id: str,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    """Reports in this project, newest first, without their content.
+
+    Content is deliberately omitted: a report is long, and listing five of them
+    would crowd out everything else in the turn. Read one by id when the host is
+    actually talking about it."""
+    await _assert_project_access(project_id, auth)
+
+    rows = await async_directus.get_items(
+        "project_report",
+        {
+            "query": {
+                "filter": {
+                    "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
+                    "status": {"_in": REPORT_VISIBLE_STATUSES},
+                    "deleted_at": {"_null": True},
+                },
+                "fields": REPORT_LIST_FIELDS,
+                "sort": "-date_created",
+                "limit": 20,
+            }
+        },
+    )
+    reports = (
+        [row for row in rows if isinstance(row, dict) and row.get("id") is not None]
+        if isinstance(rows, list)
+        else []
+    )
+    return {"project_id": project_id, "reports": reports}
+
+
+@AgenticRouter.get("/projects/{project_id}/reports/{report_id}")
+async def get_project_report_for_agent(
+    project_id: str,
+    report_id: str,
+    auth: DependencyDirectusSession,
+) -> dict[str, Any]:
+    """One report, with its content and the instructions that shaped it."""
+    await _assert_project_access(project_id, auth)
+
+    rows = await async_directus.get_items(
+        "project_report",
+        {
+            "query": {
+                "filter": {
+                    "id": {"_eq": report_id},
+                    "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
+                    "deleted_at": {"_null": True},
+                },
+                "fields": [*REPORT_LIST_FIELDS, "content"],
+                "limit": 1,
+            }
+        },
+    )
+    report = rows[0] if isinstance(rows, list) and rows else None
+    if not isinstance(report, dict):
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    report["title"] = _report_title(report.get("content"))
+    return report
+
+
 async def _resolve_workspace_id_for_project(project_id: str) -> Optional[str]:
     """Resolve the workspace a project belongs to. Workspace is the data
     boundary, so it is never taken from the agent; the server derives it."""


### PR DESCRIPTION
## The problem

The assistant's system prompt tells hosts the Report page exists. It then cannot say a single thing about what is on it.

There are no report tools in the agent's 42-tool registry, no report methods on `echo_client`, and no report endpoints in `api/agentic.py`. So today it will discuss reports in the abstract while the host is looking at theirs, and it will cheerfully redo analysis that a published report already covers.

## What this adds

Two read tools. Nothing else.

- **`listReports`** returns what exists, newest first, with each report's status, date, language and the `user_instructions` that shaped it. **No content**, deliberately: five reports of markdown would crowd out everything else in the turn.
- **`readReport(report_id)`** returns one in full, with its content and a title derived from the first markdown H1, which is how the dashboard titles them.

Backed by two `GET`s on `AgenticRouter`, both gated with `_assert_project_access`, matching the existing host-callable handlers in that file.

## Reads only, and the prompt says so

The host creates and regenerates reports from the Report page, where **"Guide the report"** is where they steer the focus. Report generation is the most expensive operation in the product, and it stays behind the host's own click. The prompt now points at that surface by name instead of being vague about it.

Tests assert that no `createReport`, `generateReport` or `proposeReport` crept in, and that the prompt does not claim otherwise.

## One thing worth a reviewer's eye

Both queries filter `kind: {"_eq": "report"}` explicitly.

**A canvas is also a `project_report` row** (`kind='canvas'`), and the host-facing list endpoints (`api/project.py:658`, `api/v2/bff/reports.py:67`) omit that filter. So canvases already surface in the host's report list as untitled entries, because `_extract_report_title` reads the first H1 of `content` and a canvas has none.

That leak is **not fixed here** since it is out of scope, but it is not copied either. Worth its own small PR, along with `free_tier.count_workspace_reports`, which has the same omission and therefore lets a canvas consume the free tier's single lifetime report allowance.

## Testing

`65 agent tests pass` (three new). `ruff check` clean on `agentic.py`. Both files parse.

The registration test is the load-bearing one: a tool defined but left out of the `tools` list fails silently, and the assistant simply stays blind. That is exactly the failure this PR exists to fix, so it gets a test rather than a careful reading.

## Not in this PR

- `proposeReport` and its card. Scoped separately, and it depends on this landing first so the assistant can propose a revision rather than a blind duplicate.
- Format control. `user_instructions` steers focus inside a hardcoded Q&A article template; changing the format is seven Jinja locale files and a different conversation.
- `docs/users/host/reports.md`, which describes a sections model that does not exist and never mentions custom instructions. The assistant reads it as ground truth via the knowledge VFS, so it will confidently walk a host through UI that is not there. Its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)