### PR TITLE
fix(chat): keep the step chip live until the run is, not until a message lands

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -934,6 +934,22 @@ export const AgenticChatPanel = ({
 		return nodes;
 	}, [timeline]);
 
+	// Which tool group is allowed to keep showing itself as live.
+	//
+	// A run can post an assistant message and then carry on working, so "the last
+	// node in the timeline" stops being the tool group the moment any message
+	// renders beneath it. Keying on that made the chip settle to a green
+	// past-tense summary mid-run while the composer still read "Working on your
+	// answer...", which is the same contradiction the live chip was added to fix,
+	// arriving a few seconds later. Key on the newest TOOL GROUP instead: it is
+	// the one doing the work, wherever it sits in the list.
+	const newestToolGroupIndex = useMemo(() => {
+		for (let index = timelineNodes.length - 1; index >= 0; index -= 1) {
+			if (timelineNodes[index].kind === "tool_group") return index;
+		}
+		return -1;
+	}, [timelineNodes]);
+
 	// Drop the optimistic echo once the persisted user message arrives.
 	useEffect(() => {
 		if (!pendingUserMessage) return;
@@ -1632,7 +1648,6 @@ export const AgenticChatPanel = ({
 						)}
 
 					{timelineNodes.map((node, nodeIndex) => {
-						const isNewestNode = nodeIndex === timelineNodes.length - 1;
 						if (node.kind === "message") {
 							const focusedConversations = (
 								node.item.role === "user"
@@ -1782,7 +1797,7 @@ export const AgenticChatPanel = ({
 								items={node.items}
 								expanded={Boolean(expandedGroupIds[node.id])}
 								onToggle={() => toggleGroupDetails(node.id)}
-								stillWorking={isNewestNode && isRunInFlight}
+								stillWorking={nodeIndex === newestToolGroupIndex && isRunInFlight}
 							/>
 						);
 					})}

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr "can read"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4606,7 +4606,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5411,7 +5411,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Error"
 
@@ -5874,11 +5874,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6070,9 +6070,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6716,11 +6716,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6808,7 +6808,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7753,7 +7753,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11342,7 +11342,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11771,7 +11771,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12393,7 +12393,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Send"
 
@@ -14306,7 +14306,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15164,7 +15164,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15762,11 +15762,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15852,7 +15852,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15927,7 +15927,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2245,7 +2245,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -2875,7 +2875,7 @@ msgstr "Abbrechen"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3080,7 +3080,7 @@ msgstr "Das Ändern der Sprache während eines aktiven Chats kann unerwartete Er
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4392,7 +4392,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5177,7 +5177,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Fehler"
 
@@ -5625,11 +5625,11 @@ msgstr "Ergebnis konnte nicht überarbeitet werden. Bitte versuchen Sie es erneu
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fehler beim Beenden der Aufnahme bei Änderung des Mikrofons. Bitte versuchen Sie es erneut."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5816,9 +5816,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Fokus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6454,11 +6454,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6536,7 +6536,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7323,7 +7323,7 @@ msgstr "Link zur Datenschutzerklärung Ihrer Organisation, die angezeigt wird"
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn-Beitrag (Experimentell)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7331,7 +7331,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7397,7 +7397,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7480,7 +7480,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11114,7 +11114,7 @@ msgstr "Umbenennen"
 #~ msgstr "Umbenennen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Chat umbenennen"
 
@@ -11536,7 +11536,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Dateien vor dem Hochladen überprüfen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12155,7 +12155,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Senden"
 
@@ -14021,7 +14021,7 @@ msgstr "Zu groß"
 msgid "Too long"
 msgstr "Zu lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14865,7 +14865,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Verwenden Sie Shift + Enter, um eine neue Zeile hinzuzufügen"
 
@@ -15446,11 +15446,11 @@ msgstr "Was soll ECHO aus den Gesprächen analysieren oder generieren?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Worauf soll sich dieser Bericht konzentrieren?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15536,7 +15536,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15611,7 +15611,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 
@@ -2453,7 +2453,7 @@ msgstr "Ask about these"
 #~ msgstr "Ask about your conversations, or type to find an earlier chat"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr "Ask about your conversations..."
 
@@ -3059,7 +3059,7 @@ msgstr "can read"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr "Cancel anytime. You keep access until the period ends."
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr "Cancel current run"
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4606,7 +4606,7 @@ msgstr "dembrane B.V. {0}, all rights reserved."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5411,7 +5411,7 @@ msgstr "Entered details"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Error"
 
@@ -5874,11 +5874,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr "Failed to stop run"
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr "Failed to submit agentic message"
 
@@ -6070,9 +6070,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr "Focus on conversations"
 
@@ -6716,11 +6716,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr "I accept the <0>terms</0>"
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr "I applied the canvas."
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr "I applied the goal."
 
@@ -6808,7 +6808,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr "Image style"
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr "Improve my setup"
 
@@ -7595,7 +7595,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr "List my conversations"
 
@@ -7603,7 +7603,7 @@ msgstr "List my conversations"
 #~ msgid "List project conversations"
 #~ msgstr "List project conversations"
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr "List the conversations in this project."
 
@@ -7670,7 +7670,7 @@ msgstr "Live recordings, transcription progress, and errors show up here as part
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live stream disconnected. Updating on a slower poll until it reconnects."
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live stream interrupted. Falling back to polling."
 
@@ -7753,7 +7753,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr "Loading this chat..."
 
@@ -11342,7 +11342,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11771,7 +11771,7 @@ msgstr "Review before creating."
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr "Review my project settings and suggest improvements."
 
@@ -12393,7 +12393,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Send"
 
@@ -14306,7 +14306,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Too many to list here. The assistant reads through them in batches."
 
@@ -15164,7 +15164,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15762,11 +15762,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr "What themes came up across the conversations in this project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr "What themes came up?"
 
@@ -15852,7 +15852,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr "Where would you like to start?"
 
@@ -15927,7 +15927,7 @@ msgstr "Within my organisation"
 msgid "Worked through {0} steps"
 msgstr "Worked through {0} steps"
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr "Working on your answer..."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2845,7 +2845,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -2878,7 +2878,7 @@ msgstr "Cancelar"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3083,7 +3083,7 @@ msgstr "Cambiar el idioma durante una conversación activa puede provocar result
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4395,7 +4395,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5180,7 +5180,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Error"
 
@@ -5628,11 +5628,11 @@ msgstr "Error al revisar el resultado. Por favor, inténtalo de nuevo."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Error al detener la grabación al cambiar el dispositivo. Por favor, inténtalo de nuevo."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5819,9 +5819,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Enfoque"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6457,11 +6457,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6539,7 +6539,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7326,7 +7326,7 @@ msgstr "Enlace a la política de privacidad de tu organización que se mostrará
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publicación LinkedIn (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7334,7 +7334,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7400,7 +7400,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7483,7 +7483,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11120,7 +11120,7 @@ msgstr "Renombrar"
 #~ msgstr "Renombrar"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Renombrar chat"
 
@@ -11542,7 +11542,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Revisar archivos antes de subir"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12161,7 +12161,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Enviar"
 
@@ -14024,7 +14024,7 @@ msgstr "Demasiado grande"
 msgid "Too long"
 msgstr "Demasiado largo"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14869,7 +14869,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Usa Shift + Enter para agregar una nueva línea"
 
@@ -15450,11 +15450,11 @@ msgstr "¿Qué debe ECHO analizar o generar a partir de las conversaciones?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "¿En qué debe centrarse este informe?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15540,7 +15540,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15615,7 +15615,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -435,7 +435,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2263,7 +2263,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -2893,7 +2893,7 @@ msgstr "Annuler"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr "Changer de langue pendant une conversation active peut provoquer des ré
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Discussion"
 
@@ -4410,7 +4410,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5195,7 +5195,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Erreur"
 
@@ -5643,11 +5643,11 @@ msgstr "Échec de la révision du résultat. Veuillez réessayer."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Échec de l'arrêt de l'enregistrement lors du changement de périphérique. Veuillez réessayer."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5834,9 +5834,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6472,11 +6472,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6554,7 +6554,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7341,7 +7341,7 @@ msgstr "Lien vers la politique de confidentialité de votre organisation qui ser
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publication LinkedIn (Expérimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7349,7 +7349,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7415,7 +7415,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7498,7 +7498,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11135,7 +11135,7 @@ msgstr "Renommer"
 #~ msgstr "Renommer"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Renommer le chat"
 
@@ -11557,7 +11557,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Examiner les fichiers avant le téléchargement"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12176,7 +12176,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Envoyer"
 
@@ -14039,7 +14039,7 @@ msgstr "Trop grande"
 msgid "Too long"
 msgstr "Trop long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14884,7 +14884,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Utilisez Shift + Entrée pour ajouter une nouvelle ligne"
 
@@ -15469,11 +15469,11 @@ msgstr "Que doit ECHO analyser ou générer à partir des conversations ?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Sur quoi ce rapport doit-il se concentrer ?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15559,7 +15559,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15634,7 +15634,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4606,7 +4606,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5411,7 +5411,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Error"
 
@@ -5874,11 +5874,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6070,9 +6070,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6716,11 +6716,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6808,7 +6808,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7753,7 +7753,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11342,7 +11342,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11771,7 +11771,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12393,7 +12393,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Send"
 
@@ -14306,7 +14306,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15164,7 +15164,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15762,11 +15762,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15852,7 +15852,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15927,7 +15927,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -252,7 +252,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# werkruimte} other {# werkruimtes}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focus op # gesprek:} other {Focus op # gesprekken:}}"
 
@@ -1988,7 +1988,7 @@ msgstr "Vragen | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Vraag een organisatie-admin om deze upgrade aan te vragen."
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Stel een vraag over de gesprekken in dit project, of vraag hulp bij het opzetten ervan. Elke wijziging wordt eerst ter beoordeling voorgesteld en er wordt niets opgeslagen totdat je het goedkeurt."
 
@@ -2019,7 +2019,7 @@ msgstr "Hierover vragen"
 #~ msgstr "Vraag iets over je gesprekken, of typ om een eerdere chat te vinden"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr "Vraag iets over je gesprekken..."
 
@@ -2604,7 +2604,7 @@ msgstr "kan lezen"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -2637,7 +2637,7 @@ msgstr "Annuleren"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr "Annuleer wanneer je wilt. Je houdt toegang tot het einde van de periode."
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr "Huidige run stoppen"
 
@@ -2834,7 +2834,7 @@ msgstr "Wijziging van de taal tijdens een actief gesprek kan onverwachte resulta
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4128,7 +4128,7 @@ msgstr "dembrane B.V. {0}, alle rechten voorbehouden."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane kan fouten maken. Controleer antwoorden altijd even."
 
@@ -4887,7 +4887,7 @@ msgstr "Gegevens ingevuld"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Fout"
 
@@ -5322,11 +5322,11 @@ msgstr "Fout bij het herzien van het resultaat. Probeer het opnieuw."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fout bij het stoppen van de opname bij wijziging van het apparaat. Probeer het opnieuw."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr "De run stoppen is mislukt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr "Bericht versturen is mislukt"
 
@@ -5513,9 +5513,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr "Focus op gesprekken"
 
@@ -6121,11 +6121,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr "Ik heb het canvas toegepast."
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr "Ik heb het doel toegepast."
 
@@ -6201,7 +6201,7 @@ msgstr "Als je je bij een bestaande organisatie wilt aansluiten, maak dan geen n
 msgid "Image style"
 msgstr "Beeldstijl"
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr "Verbeter mijn instellingen"
 
@@ -6955,7 +6955,7 @@ msgstr "Link naar de privacyverklaring van uw organisatie die aan deelnemers wor
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimenteel)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr "Toon mijn gesprekken"
 
@@ -6963,7 +6963,7 @@ msgstr "Toon mijn gesprekken"
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr "Toon de gesprekken in dit project."
 
@@ -7029,7 +7029,7 @@ msgstr "Live opnames, voortgang van transcriptie en fouten verschijnen hier zodr
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live verbinding verbroken. We werken minder vaak bij tot de verbinding terug is."
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live verbinding onderbroken. We halen updates nu periodiek op."
 
@@ -7110,7 +7110,7 @@ msgstr "Projecten laden..."
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr "Deze chat laden..."
 
@@ -10659,7 +10659,7 @@ msgstr "Naam wijzigen"
 #~ msgstr "Naam wijzigen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Chat hernoemen"
 
@@ -11060,7 +11060,7 @@ msgstr "Controleer voordat je aanmaakt."
 msgid "Review files before uploading"
 msgstr "Bestanden bekijken voordat u uploadt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr "Bekijk mijn projectinstellingen en stel verbeteringen voor."
 
@@ -11674,7 +11674,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Verzenden"
 
@@ -13469,7 +13469,7 @@ msgstr "Te groot"
 msgid "Too long"
 msgstr "Te lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Te veel om hier te tonen. De assistent leest ze in delen door."
 
@@ -14293,7 +14293,7 @@ msgstr "Gebruik deze cyclus"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Gebruik Shift + Enter om een nieuwe regel toe te voegen"
 
@@ -14849,11 +14849,11 @@ msgstr "Wat moet ECHO analyseren of genereren uit de gesprekken?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Waar moet dit rapport zich op richten?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr "Welke thema's kwamen naar voren in de gesprekken in dit project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr "Welke thema's kwamen naar voren?"
 
@@ -14935,7 +14935,7 @@ msgid "Where would you like to go?"
 msgstr "Waar wil je naartoe?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr "Waar wil je beginnen?"
 
@@ -15004,7 +15004,7 @@ msgstr "Binnen mijn organisatie"
 msgid "Worked through {0} steps"
 msgstr "{0} stappen doorlopen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr "Bezig met je antwoord..."
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1912
+#: src/components/chat/AgenticChatPanel.tsx:1927
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1592
+#: src/components/chat/AgenticChatPanel.tsx:1608
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1972
+#: src/components/chat/AgenticChatPanel.tsx:1987
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1882
+#: src/components/chat/AgenticChatPanel.tsx:1897
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1870
+#: src/components/chat/AgenticChatPanel.tsx:1885
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1436
+#: src/components/chat/AgenticChatPanel.tsx:1452
 msgid "Chat"
 msgstr "Chat"
 
@@ -4606,7 +4606,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:1993
+#: src/components/chat/AgenticChatPanel.tsx:2008
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5411,7 +5411,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1538
+#: src/components/chat/AgenticChatPanel.tsx:1554
 msgid "Error"
 msgstr "Error"
 
@@ -5874,11 +5874,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1428
+#: src/components/chat/AgenticChatPanel.tsx:1444
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1387
+#: src/components/chat/AgenticChatPanel.tsx:1403
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6070,9 +6070,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1939
-#: src/components/chat/AgenticChatPanel.tsx:1940
-#: src/components/chat/AgenticChatPanel.tsx:2003
+#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:1955
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6716,11 +6716,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1707
+#: src/components/chat/AgenticChatPanel.tsx:1722
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1723
+#: src/components/chat/AgenticChatPanel.tsx:1738
 msgid "I applied the goal."
 msgstr ""
 
@@ -6808,7 +6808,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1616
+#: src/components/chat/AgenticChatPanel.tsx:1632
 msgid "Improve my setup"
 msgstr ""
 
@@ -7595,7 +7595,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1606
+#: src/components/chat/AgenticChatPanel.tsx:1622
 msgid "List my conversations"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1607
+#: src/components/chat/AgenticChatPanel.tsx:1623
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1106
+#: src/components/chat/AgenticChatPanel.tsx:1122
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7753,7 +7753,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1549
+#: src/components/chat/AgenticChatPanel.tsx:1565
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11342,7 +11342,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1499
+#: src/components/chat/AgenticChatPanel.tsx:1515
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11771,7 +11771,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1617
+#: src/components/chat/AgenticChatPanel.tsx:1633
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12393,7 +12393,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1958
+#: src/components/chat/AgenticChatPanel.tsx:1973
 msgid "Send"
 msgstr "Send"
 
@@ -14306,7 +14306,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1928
+#: src/components/chat/AgenticChatPanel.tsx:1943
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15164,7 +15164,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:1990
+#: src/components/chat/AgenticChatPanel.tsx:2005
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15762,11 +15762,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1612
+#: src/components/chat/AgenticChatPanel.tsx:1628
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1611
+#: src/components/chat/AgenticChatPanel.tsx:1627
 msgid "What themes came up?"
 msgstr ""
 
@@ -15852,7 +15852,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1589
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15927,7 +15927,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1461
+#: src/components/chat/AgenticChatPanel.tsx:1477
 msgid "Working on your answer..."
 msgstr ""
 


### PR DESCRIPTION
## What I got wrong in #938

#938 keyed the live chip on **the newest node in the timeline**:

```tsx
stillWorking={isNewestNode && isRunInFlight}
```

A run can post an assistant message and then carry on working. So the moment any message rendered beneath the tool group, the group stopped being newest and settled to a green past-tense summary, even though the run was still going.

## Measured on echo-next, after #938 shipped

Sampling every 2.5 seconds during a real run:

- **t+15s to t+28s** — chip yellow, "Working through a couple steps...", matching the yellow composer. This is #938 working.
- **t+31s** — chip flips **green**, "Worked through 4 steps", while the composer still reads **"Working on your answer... Cancel"**.
- They disagreed for at least five seconds.

That is the same contradiction #938 existed to remove, arriving later and milder, since the answer is on screen by then. Milder is not fixed.

## The fix

Key on the newest **tool group** rather than the newest node. It is the group doing the work, wherever it ends up sitting once messages render around it.

```tsx
const newestToolGroupIndex = useMemo(() => {
  for (let index = timelineNodes.length - 1; index >= 0; index -= 1) {
    if (timelineNodes[index].kind === "tool_group") return index;
  }
  return -1;
}, [timelineNodes]);
```

Older groups still settle to their summary. A genuinely running step still wins, so this only fills the gaps between named steps, exactly as before.

## Testing

`tsc --noEmit` clean, `biome lint` clean, catalogs re-extracted (line references shifted, no copy changed).

**Not covered by a test.** No test renders `ToolActivityGroup` and there is no harness for run-in-flight state, so this was verified by reading and by the live measurement above rather than in CI. That gap is real and predates this PR; a harness would be worth its own change, since this is now the second bug in the same three lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)