### PR TITLE
fix(reports): a canvas is not a report, so stop charging the free tier for one

### DIFF
--- a/echo/server/dembrane/api/participant.py
+++ b/echo/server/dembrane/api/participant.py
@@ -967,6 +967,9 @@ async def get_public_report_latest(
     project_id: str,
 ) -> Optional[PublicReportLatestResponse]:
     """Get the latest published report for a project. No auth required."""
+    # kind matters here: a canvas is a project_report row created
+    # status='published', so the newest one would shadow the host's actual
+    # published report and the portal would offer participants an empty page.
     reports = await run_in_thread_pool(
         directus.get_items,
         "project_report",
@@ -974,6 +977,7 @@ async def get_public_report_latest(
             "query": {
                 "filter": {
                     "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
                     "status": {"_eq": "published"},
                 },
                 "fields": ["id", "status", "project_id", "show_portal_link"],
@@ -999,6 +1003,7 @@ async def get_public_report_detail(
                 "filter": {
                     "id": {"_eq": report_id},
                     "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
                     "status": {"_eq": "published"},
                 },
                 "fields": ["id", "content", "status", "project_id", "show_portal_link"],
@@ -1057,6 +1062,7 @@ async def create_public_report_metric(
                 "filter": {
                     "id": {"_eq": body.project_report_id},
                     "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
                     "status": {"_eq": "published"},
                 },
                 "fields": ["id"],

--- a/echo/server/dembrane/api/project.py
+++ b/echo/server/dembrane/api/project.py
@@ -525,6 +525,7 @@ async def create_report(
                 "query": {
                     "filter": {
                         "project_id": {"_eq": project_id},
+                        "kind": {"_eq": "report"},
                         "status": {"_eq": "draft"},
                         "deleted_at": {"_null": True},
                     },
@@ -660,6 +661,7 @@ async def list_project_reports(
             "query": {
                 "filter": {
                     "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
                     "status": {"_in": ["archived", "published", "scheduled", "draft"]},
                     "deleted_at": {"_null": True},
                 },
@@ -708,6 +710,7 @@ async def get_latest_report(
             "query": {
                 "filter": {
                     "project_id": {"_eq": project_id},
+                    "kind": {"_eq": "report"},
                     "deleted_at": {"_null": True},
                 },
                 "fields": [
@@ -816,7 +819,9 @@ async def update_report(
     if not payload:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    # Auto-unpublish other reports when publishing this one
+    # Auto-unpublish other reports when publishing this one. Canvases are
+    # created status='published' too, so without the kind filter this archives
+    # every canvas in the project as a side effect of publishing a report.
     if payload.get("status") == "published":
         other_published = await run_in_thread_pool(
             directus.get_items,
@@ -825,6 +830,7 @@ async def update_report(
                 "query": {
                     "filter": {
                         "project_id": {"_eq": project_id},
+                        "kind": {"_eq": "report"},
                         "status": {"_eq": "published"},
                         "id": {"_neq": report_id},
                         "deleted_at": {"_null": True},

--- a/echo/server/dembrane/api/v2/bff/reports.py
+++ b/echo/server/dembrane/api/v2/bff/reports.py
@@ -64,7 +64,9 @@ async def list_reports(
         if fields
         else default_fields
     )
-    filt = filter_exclude_deleted({"project_id": {"_eq": project_id}})
+    filt = filter_exclude_deleted(
+        {"project_id": {"_eq": project_id}, "kind": {"_eq": "report"}}
+    )
 
     rows = await async_directus.get_items(
         "project_report",
@@ -119,7 +121,7 @@ async def get_report_timeline(
         {
             "query": {
                 "filter": filter_exclude_deleted(
-                    {"project_id": {"_eq": project_id_str}}
+                    {"project_id": {"_eq": project_id_str}, "kind": {"_eq": "report"}}
                 ),
                 "fields": ["id", "date_created"],
                 "sort": ["date_created"],

--- a/echo/server/dembrane/free_tier.py
+++ b/echo/server/dembrane/free_tier.py
@@ -183,6 +183,15 @@ async def count_chat_user_turns(chat_id: str) -> int:
     )
 
 
+# A canvas is stored as a project_report row with kind='canvas', so every
+# report count and resolver here must say which kind it means. Without the
+# filter a free workspace spends its single lifetime report allowance the
+# moment the host opens a canvas, and the "primary" report the upgrade
+# prompt points at can be a canvas the host never thinks of as a report.
+# `kind` is NOT NULL with default 'report', so _eq hides nothing.
+REPORT_KIND_FILTER = {"kind": {"_eq": "report"}}
+
+
 async def count_workspace_reports(
     workspace_id: Optional[str], project_ids: Optional[list[str]] = None
 ) -> int:
@@ -191,7 +200,11 @@ async def count_workspace_reports(
         return 0
     return await _agg_count(
         "project_report",
-        {"project_id": {"_in": project_ids}, "deleted_at": {"_null": True}},
+        {
+            "project_id": {"_in": project_ids},
+            "deleted_at": {"_null": True},
+            **REPORT_KIND_FILTER,
+        },
     )
 
 
@@ -203,7 +216,11 @@ async def resolve_workspace_primary_report_id(
         return None
     return await _oldest_id(
         "project_report",
-        {"project_id": {"_in": project_ids}, "deleted_at": {"_null": True}},
+        {
+            "project_id": {"_in": project_ids},
+            "deleted_at": {"_null": True},
+            **REPORT_KIND_FILTER,
+        },
         "date_created",
     )
 

--- a/echo/server/tests/test_canvas_not_a_report.py
+++ b/echo/server/tests/test_canvas_not_a_report.py
@@ -1,0 +1,120 @@
+"""A canvas is a project_report row with kind='canvas'.
+
+Every endpoint that means "reports" must say so, or canvases leak into the
+host's report list, become the project's "latest report", and shadow the
+published report the participant portal serves. See the note in
+dembrane/api/agentic.py, which filtered `kind` correctly from the start.
+"""
+
+from unittest.mock import Mock, AsyncMock, patch
+
+import pytest
+
+
+def _capturing_directus(captured: dict, rows: list | None = None):
+    """A stand-in for the sync `directus` client that records the filter of
+    each get_items call against project_report."""
+    client = Mock()
+
+    def _get_items(collection, params=None, *a, **k):
+        if collection == "project_report":
+            captured.setdefault("filters", []).append(
+                (params or {}).get("query", {}).get("filter")
+            )
+        return list(rows or [])
+
+    client.get_items = Mock(side_effect=_get_items)
+    return client
+
+
+REPORT_KIND = {"_eq": "report"}
+
+
+class TestParticipantPortal:
+    """These two are unauthenticated. A canvas is created status='published'
+    and is newer than the host's real report, so without the kind filter the
+    portal serves participants a blank page in place of the actual report."""
+
+    @pytest.mark.asyncio
+    async def test_public_latest_asks_for_a_report(self):
+        from dembrane.api.participant import get_public_report_latest
+
+        captured: dict = {}
+        with patch(
+            "dembrane.api.participant.directus", _capturing_directus(captured)
+        ):
+            assert await get_public_report_latest("proj-1") is None
+        assert captured["filters"][0].get("kind") == REPORT_KIND
+
+    @pytest.mark.asyncio
+    async def test_public_detail_asks_for_a_report(self):
+        from fastapi import HTTPException
+
+        from dembrane.api.participant import get_public_report_detail
+
+        captured: dict = {}
+        with patch(
+            "dembrane.api.participant.directus", _capturing_directus(captured)
+        ), pytest.raises(HTTPException):
+            await get_public_report_detail("proj-1", 7)
+        assert captured["filters"][0].get("kind") == REPORT_KIND
+
+
+class TestHostReportList:
+    """The host's Reports sidebar renders a title-less canvas as "Untitled
+    report", and because it sorts newest-first the canvas can become the
+    selected report and blank the main pane."""
+
+    @pytest.mark.asyncio
+    async def test_list_project_reports_asks_for_reports(self):
+        from dembrane.api.project import list_project_reports
+
+        captured: dict = {}
+        with patch(
+            "dembrane.api.project._verify_project_access", AsyncMock(return_value={})
+        ), patch("dembrane.directus.directus", _capturing_directus(captured)):
+            assert await list_project_reports("proj-1", auth=Mock()) == []
+        assert captured["filters"][0].get("kind") == REPORT_KIND
+
+    @pytest.mark.asyncio
+    async def test_latest_report_asks_for_a_report(self):
+        from dembrane.api.project import get_latest_report
+
+        captured: dict = {}
+        with patch(
+            "dembrane.api.project._verify_project_access", AsyncMock(return_value={})
+        ), patch("dembrane.directus.directus", _capturing_directus(captured)):
+            assert await get_latest_report("proj-1", auth=Mock()) is None
+        assert captured["filters"][0].get("kind") == REPORT_KIND
+
+
+class TestBffReportList:
+    @pytest.mark.asyncio
+    async def test_bff_list_reports_asks_for_reports(self):
+        from dembrane.api.v2.bff.reports import list_reports
+
+        captured: dict = {}
+
+        async def _get_items(collection, params=None, *a, **k):
+            captured["filter"] = (params or {}).get("query", {}).get("filter")
+            return []
+
+        async_client = AsyncMock()
+        async_client.get_items = AsyncMock(side_effect=_get_items)
+
+        access = Mock()
+        access.require = Mock(return_value=None)
+
+        with patch(
+            "dembrane.api.v2.bff.reports.resolve_project_access",
+            AsyncMock(return_value=access),
+        ), patch("dembrane.api.v2.bff.reports.async_directus", async_client):
+            # fields/limit are passed explicitly: calling the endpoint function
+            # directly skips FastAPI's Query default resolution.
+            assert (
+                await list_reports(
+                    auth=Mock(), project_id="proj-1", fields=None, limit=1000
+                )
+                == []
+            )
+        assert captured["filter"].get("kind") == REPORT_KIND

--- a/echo/server/tests/test_free_tier.py
+++ b/echo/server/tests/test_free_tier.py
@@ -201,6 +201,111 @@ class TestPrimaryReportId:
             assert await resolve_workspace_primary_report_id("w1") == "rep-old"
 
 
+def _project_report_rows(rows: list[dict]):
+    """A `project_report` handler that honours the `kind` clause the way
+    Directus would, so a dropped filter fails the test instead of passing.
+    Supports the two query shapes free_tier issues: an aggregate count and an
+    oldest-first single row."""
+
+    def _handler(query: dict):
+        filt = query.get("filter") or {}
+        kept = list(rows)
+        kind = filt.get("kind")
+        if kind is not None:
+            kept = [r for r in kept if r.get("kind") == kind["_eq"]]
+        if query.get("aggregate"):
+            return [{"count": {"id": len(kept)}}]
+        kept.sort(key=lambda r: r["date_created"])
+        return [{"id": r["id"]} for r in kept[: (query.get("limit") or len(kept))]]
+
+    return _handler
+
+
+class TestCanvasesDoNotCountAsReports:
+    """A canvas is a project_report row with kind='canvas'. If the free-tier
+    counters don't say which kind they mean, a host who opens a canvas spends
+    the single lifetime report a free workspace gets, without ever generating
+    a report."""
+
+    @pytest.mark.asyncio
+    async def test_canvas_alone_does_not_consume_the_free_report(self):
+        mock = _mock_directus(
+            {
+                "project": lambda _q: [{"id": "p1"}],
+                "project_report": _project_report_rows(
+                    [{"id": "canvas-1", "kind": "canvas", "date_created": "2026-01-01"}]
+                ),
+            }
+        )
+        with patch("dembrane.directus_async.async_directus", mock):
+            assert await count_workspace_reports("w1") == 0
+
+    @pytest.mark.asyncio
+    async def test_only_real_reports_are_counted(self):
+        mock = _mock_directus(
+            {
+                "project": lambda _q: [{"id": "p1"}],
+                "project_report": _project_report_rows(
+                    [
+                        {"id": "canvas-1", "kind": "canvas", "date_created": "2026-01-01"},
+                        {"id": "rep-1", "kind": "report", "date_created": "2026-01-02"},
+                        {"id": "canvas-2", "kind": "canvas", "date_created": "2026-01-03"},
+                    ]
+                ),
+            }
+        )
+        with patch("dembrane.directus_async.async_directus", mock):
+            assert await count_workspace_reports("w1") == 1
+
+    @pytest.mark.asyncio
+    async def test_primary_report_skips_an_older_canvas(self):
+        # The canvas is the oldest row, so an unfiltered "oldest" resolver
+        # would point the upgrade prompt at a canvas.
+        mock = _mock_directus(
+            {
+                "project": lambda _q: [{"id": "p1"}],
+                "project_report": _project_report_rows(
+                    [
+                        {"id": "canvas-1", "kind": "canvas", "date_created": "2026-01-01"},
+                        {"id": "rep-1", "kind": "report", "date_created": "2026-01-02"},
+                    ]
+                ),
+            }
+        )
+        with patch("dembrane.directus_async.async_directus", mock):
+            assert await resolve_workspace_primary_report_id("w1") == "rep-1"
+
+    @pytest.mark.asyncio
+    async def test_count_filter_names_the_kind(self):
+        captured: dict = {}
+
+        def _handler(q):
+            captured["filter"] = q.get("filter")
+            return [{"count": {"id": 0}}]
+
+        mock = _mock_directus(
+            {"project": lambda _q: [{"id": "p1"}], "project_report": _handler}
+        )
+        with patch("dembrane.directus_async.async_directus", mock):
+            await count_workspace_reports("w1")
+        assert captured["filter"].get("kind") == {"_eq": "report"}
+
+    @pytest.mark.asyncio
+    async def test_primary_report_filter_names_the_kind(self):
+        captured: dict = {}
+
+        def _handler(q):
+            captured["filter"] = q.get("filter")
+            return []
+
+        mock = _mock_directus(
+            {"project": lambda _q: [{"id": "p1"}], "project_report": _handler}
+        )
+        with patch("dembrane.directus_async.async_directus", mock):
+            await resolve_workspace_primary_report_id("w1")
+        assert captured["filter"].get("kind") == {"_eq": "report"}
+
+
 class TestCountOrgWorkspaces:
     @pytest.mark.asyncio
     async def test_counts_workspaces(self):


### PR DESCRIPTION
## The harm

A free workspace gets **one report, ever**. Opening a canvas silently spent it.

A canvas is not a separate table: it is a `project_report` row with `kind='canvas'`. `count_workspace_reports` in `free_tier.py` filtered on `project_id` and `deleted_at` and nothing else, so it counted canvases as reports. A host on the free tier who created a canvas hit the report paywall on their first real report, and there is no way to earn the allowance back. `resolve_workspace_primary_report_id` had the same gap, so the "your one report" that the upgrade prompt points at could be a canvas the host never thinks of as a report.

**How many hosts this actually hit: I could not determine a number, and I did not query production.** What the repo does say is that canvas is gated twice, and both gates are shut: the global `ENABLE_CANVAS` flag (`settings.py` notes production sets it to `0` this release) and a per-project `is_canvas_enabled` toggle that defaults to false. So this only ever bit a project that deliberately turned canvas on, and on current production settings that population should be zero. It is a latent bug that would have gone live with the flag, not an ongoing one.

## The rest of it

While confirming the three sites I was pointed at, I found the same omission in six more. These cost visibility rather than money. A canvas is created `status='published'` with empty `content` (`canvas/service.py`), so it sorts to the front of anything ordered by `date_created`:

| Where | What the user saw |
| --- | --- |
| `project.py` host report list | The canvas rendered as **"Untitled report"** with a green Published badge, inflating the count. Being newest it could become the selected report and blank the main pane. |
| `project.py` `get_latest_report` | Returned the canvas as the project's latest report. Feeds the project home title and the report navigation button. |
| `participant.py` `report/latest` (**no auth**) | Served the canvas in place of the host's actual published report. Participants got a blank page with no QR call to action. |
| `participant.py` `report/{id}/detail` and `report/metric` | Would serve and meter a canvas through the public report route. |
| `project.py` auto-unpublish sweep | Publishing a report set every canvas in the project to `archived`, as a side effect. This one is a write. |
| `v2/bff/reports.py` list and timeline | Canvas appeared as a sibling report in the list and on the timeline. |

I also added the filter to the "is a report already generating" guard in `create_report`. Canvases are never `status='draft'` today so it cannot currently fire, but the guard means reports and should say so.

## Verification

**Is `_eq` safe?** Yes. `kind` is `is_nullable: false` with `default_value: "report"` in `directus/sync/snapshot/fields/project_report/kind.json`, added that way by `add_smart_loop_phase0_schema.py`, so Postgres backfilled existing rows on the ALTER. No row can have `kind` null, and the filter hides nothing.

**Left alone deliberately:** `resolve_report_access` in `v2/bff/_access.py` is shared by `bff/canvases.py`, which legitimately resolves a canvas row. It wants both kinds, and filtering it would break the canvas endpoints.

Also left alone: the by-id `get_item` calls in `project.py` (report detail, delete, cancel-schedule), `tasks.py` and `service/webhook.py`. Those are id-addressed and already project-scoped, so reaching a canvas through them means the host passing their own canvas's id to a report route. Fixing them means a guard clause rather than a filter, which is a different change.

One thing I noticed and did not touch, because it is unrelated to `kind`: the three participant report queries filter on `status` but not on `deleted_at`, so a soft-deleted published report still appears to be publicly readable. Worth a separate look.

## Tests

`tests/test_free_tier.py` gains `TestCanvasesDoNotCountAsReports`, built on a fake Directus handler that honours the `kind` clause so it tests the semantics and not just the filter string: a workspace whose only row is a canvas counts **0** reports, a mixed project counts only the real one, and the primary-report resolver skips a canvas even when the canvas is the oldest row.

`tests/test_canvas_not_a_report.py` is new and pins the filter on the five endpoints, including both unauthenticated participant ones.

All ten new tests were confirmed to **fail against the unfixed code** and pass with it.

- `uv run pytest -q tests/ -k "free_tier or report"` gives 82 passed, up from 72 before this change
- `uv run ruff check .` gives All checks passed
- Full unit suite: 45 pre-existing failures, identical set and count on a clean `origin/main` checkout, none in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
