### PR TITLE
fix(nav): Documentation opens docs.dembrane.com, not the old Notion hub

### DIFF
--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -167,11 +167,14 @@ export const CHANGELOG_DOCS_URL =
 export const COMMUNITY_SLACK_URL =
 	"https://join.slack.com/t/dembranecommunity/shared_invite/zt-3qzvryh8l-M6w3u5BvuM8LssOhMbJGgQ";
 
-// Info Hub (documentation): published Notion pages, locale-aware.
-export const DOCS_URL_EN =
-	"https://dembrane.notion.site/Info-Hub-Welcome-to-dembrane-26f9cd84270580049be7cb1e7a472162" as const;
-export const DOCS_URL_NL =
-	"https://dembrane.notion.site/Welkom-bij-het-info-portaal-van-dembrane-2959cd842705804c815ac315464b6fa0" as const;
+// Documentation, locale-aware. Points at docs.dembrane.com, the one published
+// corpus since #907 cut it over to docs/ on GitHub Pages. The Notion Info Hub
+// these used to point at is the old home; the deep links above (ASK_DOCS_URL,
+// TRANSCRIPT_TROUBLESHOOTING_DOCS_URL) already moved and this one did not, so
+// the sidebar sent people somewhere the rest of the app had left.
+// Dutch lives at index.nl-NL.html, not README.nl-NL.html; both verified live.
+export const DOCS_URL_EN = "https://docs.dembrane.com/" as const;
+export const DOCS_URL_NL = "https://docs.dembrane.com/index.nl-NL.html" as const;
 
 export const getDocumentationUrl = (locale = "en-US") =>
 	locale === "nl-NL" ? DOCS_URL_NL : DOCS_URL_EN;


### PR DESCRIPTION
Clicking **Documentation** in the sidebar's HELP group opened the Notion Info Hub.

`#907` cut `docs.dembrane.com` over to the `docs/` corpus on GitHub Pages, and the two deep links in this same file moved with it:

- `ASK_DOCS_URL` → `docs.dembrane.com/users/host/chat-and-ask.html`
- `TRANSCRIPT_TROUBLESHOOTING_DOCS_URL` → `docs.dembrane.com/users/host/troubleshooting-transcripts-and-summaries.html`

`DOCS_URL_EN` and `DOCS_URL_NL` did not. So the app's main documentation nav pointed at the old home while its deep links pointed at the new one.

Both roots verified live before use: `https://docs.dembrane.com/` returns 200, and Dutch is at `index.nl-NL.html` (200), **not** `README.nl-NL.html` (404).

## Left alone deliberately

Three Notion links remain and none is documentation nav:

- `PRIVACY_STATEMENT_URL` (`config.ts:139`) and the participant onboarding privacy link. These are legal documents; moving them is a legal call, not a routing one.
- Microphone permission troubleshooting in `PermissionErrorModal.tsx`. **There is no equivalent page in `docs/`** — I looked. Moving it would mean writing the page first.

Worth doing, worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)