### PR TITLE
fix(goal): the applied card hugs its line, and lets you go see the goal

### DIFF
--- a/echo/frontend/src/components/goal/GoalSuggestionCard.tsx
+++ b/echo/frontend/src/components/goal/GoalSuggestionCard.tsx
@@ -3,12 +3,14 @@ import { Trans } from "@lingui/react/macro";
 import { Badge, Button, Group, Stack, Text } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
+import { useParams } from "react-router";
 import { SuggestionCardFrame } from "@/components/common/SuggestionCardFrame";
 import { toast } from "@/components/common/Toaster";
 import {
 	useProjectGoal,
 	useSaveProjectGoalMutation,
 } from "@/components/goal/hooks";
+import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { testId } from "@/lib/testUtils";
 
 export type GoalSuggestion = {
@@ -25,6 +27,8 @@ export const GoalSuggestionCard = ({
 	chatId?: string;
 	onApplied?: () => void | Promise<void>;
 }) => {
+	const { workspaceId } = useParams<{ workspaceId: string }>();
+	const navigate = useI18nNavigate();
 	const goalQuery = useProjectGoal(suggestion.projectId);
 	const saveGoalMutation = useSaveProjectGoalMutation(suggestion.projectId);
 	const [dismissed, setDismissed] = useState(false);
@@ -59,7 +63,7 @@ export const GoalSuggestionCard = ({
 
 	if (applied) {
 		return (
-			<SuggestionCardFrame compact testId="agentic-goal-suggestion-applied">
+			<SuggestionCardFrame compact tight testId="agentic-goal-suggestion-applied">
 				<Group gap="xs" wrap="nowrap">
 					<IconCheck
 						size={16}
@@ -69,6 +73,20 @@ export const GoalSuggestionCard = ({
 					<Text size="sm">
 						<Trans>Saved as this project's goal.</Trans>
 					</Text>
+					{workspaceId ? (
+						<Button
+							variant="subtle"
+							size="compact-xs"
+							onClick={() =>
+								navigate(
+									`/w/${workspaceId}/projects/${suggestion.projectId}/overview`,
+								)
+							}
+							{...testId("agentic-goal-suggestion-view")}
+						>
+							<Trans>View</Trans>
+						</Button>
+					) : null}
 				</Group>
 			</SuggestionCardFrame>
 		);

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -1634,7 +1634,7 @@ msgstr "Add conversations to your project first"
 msgid "Add Custom Topic"
 msgstr "Add Custom Topic"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2243,7 +2243,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4814,14 +4814,14 @@ msgstr "Discoverable in this organisation"
 #~ msgid "Discoverable in this team"
 #~ msgstr "Discoverable in this team"
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11752,7 +11752,7 @@ msgstr "Review"
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11933,7 +11933,7 @@ msgstr "Save template"
 msgid "Saved"
 msgstr "Saved"
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -13228,7 +13228,7 @@ msgstr "Suggest dynamic suggestions based on your conversation."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15345,6 +15345,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "View"
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -1445,7 +1445,7 @@ msgstr "Fugen Sie zuerst Gesprache zu Ihrem Projekt hinzu"
 msgid "Add Custom Topic"
 msgstr "Benutzerdefiniertes Thema hinzufügen"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4597,14 +4597,14 @@ msgstr ""
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11517,7 +11517,7 @@ msgstr ""
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Überprüfen Sie die Aktivität für Ihren Arbeitsbereich. Filtern Sie nach Sammlung oder Aktion und exportieren Sie die aktuelle Ansicht für weitere Untersuchungen."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11698,7 +11698,7 @@ msgstr "Vorlage speichern"
 msgid "Saved"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -12975,7 +12975,7 @@ msgstr "Dynamische Vorschläge basierend auf Ihrem Gespräch vorschlagen."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15042,6 +15042,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "Ansicht"
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -1634,7 +1634,7 @@ msgstr "Add conversations to your project first"
 msgid "Add Custom Topic"
 msgstr "Add Custom Topic"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr "Add goal text before applying."
 
@@ -2243,7 +2243,7 @@ msgstr "Applies this wording and refresh behavior to the existing canvas."
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4814,14 +4814,14 @@ msgstr "Discoverable in this organisation"
 #~ msgid "Discoverable in this team"
 #~ msgstr "Discoverable in this team"
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11752,7 +11752,7 @@ msgstr "Review"
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11933,7 +11933,7 @@ msgstr "Save template"
 msgid "Saved"
 msgstr "Saved"
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr "Saved as this project's goal."
 
@@ -13228,7 +13228,7 @@ msgstr "Suggest dynamic suggestions based on your conversation."
 #~ msgid "Suggested project changes"
 #~ msgstr "Suggested project changes"
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr "Suggested project goal"
 
@@ -15345,6 +15345,7 @@ msgstr "Very quiet right now. Check the mic isn't muted."
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "View"
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -1445,7 +1445,7 @@ msgstr "Agregue conversaciones a su proyecto primero"
 msgid "Add Custom Topic"
 msgstr "Añadir Tema Personalizado"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4600,14 +4600,14 @@ msgstr ""
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11523,7 +11523,7 @@ msgstr ""
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Revisa la actividad de tu espacio de trabajo. Filtra por colección o acción, y exporta la vista actual para una investigación más detallada."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11704,7 +11704,7 @@ msgstr "Guardar plantilla"
 msgid "Saved"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -12981,7 +12981,7 @@ msgstr "Sugerir sugerencias dinámicas basadas en su conversación."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15046,6 +15046,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "Vista"
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -1460,7 +1460,7 @@ msgstr "Ajoutez d'abord des conversations a votre projet"
 msgid "Add Custom Topic"
 msgstr "Ajouter un sujet personnalisé"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4615,14 +4615,14 @@ msgstr ""
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11538,7 +11538,7 @@ msgstr ""
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Examinez l'activité de votre espace de travail. Filtrez par collection ou action, et exportez la vue actuelle pour une investigation plus approfondie."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11719,7 +11719,7 @@ msgstr "Enregistrer le modèle"
 msgid "Saved"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -12996,7 +12996,7 @@ msgstr "Suggérer des suggestions dynamiques basées sur votre conversation."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15061,6 +15061,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "Vue"
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -1634,7 +1634,7 @@ msgstr "Aggiungi prima delle conversazioni al tuo progetto"
 msgid "Add Custom Topic"
 msgstr "Add Custom Topic"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2243,7 +2243,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4814,14 +4814,14 @@ msgstr ""
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11752,7 +11752,7 @@ msgstr ""
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11933,7 +11933,7 @@ msgstr "Save template"
 msgid "Saved"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -13228,7 +13228,7 @@ msgstr "Suggest dynamic suggestions based on your conversation."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15345,6 +15345,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "View"
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -1229,7 +1229,7 @@ msgstr "Voeg eerst gesprekken toe aan je project"
 msgid "Add Custom Topic"
 msgstr "Aangepast onderwerp toevoegen"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr "Voeg doeltekst toe voordat je dit toepast."
 
@@ -1813,7 +1813,7 @@ msgstr "Past deze formulering en het verversgedrag toe op het bestaande canvas."
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4318,14 +4318,14 @@ msgstr "Vindbaar in deze organisatie"
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr "Negeren"
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11042,7 +11042,7 @@ msgstr "Controleren"
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Bekijk de activiteiten van je werkruimte. Filter op collectie of actie en exporteer de huidige weergave voor verder onderzoek."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11220,7 +11220,7 @@ msgstr "Template opslaan"
 msgid "Saved"
 msgstr "Opgeslagen"
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr "Opgeslagen als doel van dit project."
 
@@ -12452,7 +12452,7 @@ msgstr "Dynamische suggesties voorstellen op basis van uw gesprek."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr "Voorgesteld projectdoel"
 
@@ -14469,6 +14469,7 @@ msgstr "Erg stil op dit moment. Check of de microfoon niet uitstaat."
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "Weergave"
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -1634,7 +1634,7 @@ msgstr "Спочатку додайте розмови до свого прое�
 msgid "Add Custom Topic"
 msgstr "Add Custom Topic"
 
-#: src/components/goal/GoalSuggestionCard.tsx:42
+#: src/components/goal/GoalSuggestionCard.tsx:46
 msgid "Add goal text before applying."
 msgstr ""
 
@@ -2243,7 +2243,7 @@ msgstr ""
 
 #: src/routes/admin/AdminSettingsRoute.tsx:658
 #: src/components/view/CreateViewForm.tsx:153
-#: src/components/goal/GoalSuggestionCard.tsx:122
+#: src/components/goal/GoalSuggestionCard.tsx:140
 #: src/components/common/ImageCropModal.tsx:148
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:225
 #: src/components/chat/CanvasSuggestionCard.tsx:361
@@ -4814,14 +4814,14 @@ msgstr ""
 #~ msgid "Discoverable in this team"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:104
+#: src/components/goal/GoalSuggestionCard.tsx:122
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:782
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:155
 #: src/components/chat/CanvasSuggestionCard.tsx:328
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:86
+#: src/components/goal/GoalSuggestionCard.tsx:104
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:175
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:113
 #: src/components/chat/CanvasSuggestionCard.tsx:256
@@ -11752,7 +11752,7 @@ msgstr ""
 msgid "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 msgstr "Review activity for your workspace. Filter by collection or action, and export the current view for further investigation."
 
-#: src/components/goal/GoalSuggestionCard.tsx:112
+#: src/components/goal/GoalSuggestionCard.tsx:130
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:572
 #: src/components/chat/CustomVerificationTopicSuggestionCard.tsx:164
 #: src/components/chat/CanvasSuggestionCard.tsx:336
@@ -11933,7 +11933,7 @@ msgstr "Save template"
 msgid "Saved"
 msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:70
+#: src/components/goal/GoalSuggestionCard.tsx:74
 msgid "Saved as this project's goal."
 msgstr ""
 
@@ -13228,7 +13228,7 @@ msgstr "Suggest dynamic suggestions based on your conversation."
 #~ msgid "Suggested project changes"
 #~ msgstr ""
 
-#: src/components/goal/GoalSuggestionCard.tsx:82
+#: src/components/goal/GoalSuggestionCard.tsx:100
 msgid "Suggested project goal"
 msgstr ""
 
@@ -15345,6 +15345,7 @@ msgstr ""
 #: src/routes/project/library/ProjectLibraryAspect.tsx:47
 #: src/components/view/View.tsx:62
 #: src/components/report/ConversationStatusTable.tsx:95
+#: src/components/goal/GoalSuggestionCard.tsx:87
 msgid "View"
 msgstr "View"
 


### PR DESCRIPTION
Two things from one screenshot.

**The border floated far past the content.** The applied state is one short sentence, "Saved as this project's goal.", rendered in the default `SuggestionCardFrame`, which stretches to `md:max-w-[80%]` of the chat column. So a full-width bordered box wrapped a half-line of text.

The frame already grew a `tight` variant for precisely this case in #936, where the insight card had the same problem. The goal card never got it. One prop.

**You could not see the goal it saved.** The card told you something happened and gave you no way to look at it. It now carries a **View** that opens the project overview, which is where `ProjectGoalSection` actually renders. Same destination `navigateTo`'s `settings` key resolves to.

## Not in this PR

The screenshot that prompted this also shows a much larger problem: a single assistant turn produced a steps chip, a project-update proposal card, a portal-link chip, a navigation card, and a message containing an explanation, a question, a link and a QR code. Five things, four possible actions, one turn.

That is a prompt problem rather than a component one, and it is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)