### PR TITLE
fix(chat): one live indicator at the end of the timeline, and old tool groups stay settled

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.test.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.test.tsx
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import {
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import type { AgenticRunEvent, AgenticRunStatus } from "@/lib/api";
+
+/**
+ * A harness for run state, which is the thing this file exists for.
+ *
+ * The live-vs-settled logic in AgenticChatPanel has been wrong twice (#938,
+ * #945) and both times it shipped, because nothing rendered the panel with a
+ * run in flight. Both bugs had the same shape: a tool group from a finished
+ * turn started speaking in the present tense again. So these tests drive the
+ * real panel from real run events and assert what a reader would see.
+ */
+
+const RUN_ID = "run-1";
+
+// vi.mock factories are hoisted above every top-level binding, so the state
+// they close over has to be hoisted with them.
+const { runState, stopAgenticRunMock } = vi.hoisted(() => ({
+	runState: { events: [], status: "running" } as {
+		events: AgenticRunEvent[];
+		status: AgenticRunStatus;
+	},
+	stopAgenticRunMock: vi.fn(async () => ({
+		run_id: "run-1",
+		status: "stopping" as const,
+		turn_seq: 1,
+	})),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api")>();
+	return {
+		...actual,
+		appendAgenticRunMessage: vi.fn(),
+		createAgentInsight: vi.fn(),
+		createAgenticRun: vi.fn(),
+		dismissAgentInsight: vi.fn(),
+		getAgentInsights: vi.fn(async () => []),
+		getAgenticRun: vi.fn(async () => ({
+			id: RUN_ID,
+			status: runState.status,
+		})),
+		getAgenticRunEvents: vi.fn(async (_runId: string, afterSeq: number) => ({
+			done: false,
+			events: runState.events.filter((event) => event.seq > afterSeq),
+			next_seq: runState.events.at(-1)?.seq ?? 0,
+			run_id: RUN_ID,
+			status: runState.status,
+		})),
+		getDismissedAgentInsightIds: vi.fn(async () => []),
+		getLatestAgenticRunForChat: vi.fn(async () => ({
+			id: RUN_ID,
+			status: runState.status,
+		})),
+		stopAgenticRun: stopAgenticRunMock,
+		// Never resolves: an in-flight run is one whose stream is still open, and
+		// resolving would let the panel re-read the status and settle.
+		streamAgenticRun: vi.fn(() => new Promise(() => {})),
+	};
+});
+
+vi.mock("@/components/chat/hooks", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/components/chat/hooks")>();
+	return {
+		...actual,
+		useChat: () => ({ data: undefined }),
+		useChatHistory: () => ({ data: [] }),
+		useProjectChatContext: () => ({ data: { conversations: [] } }),
+		useUpdateChatMutation: () => ({ mutate: vi.fn() }),
+	};
+});
+
+vi.mock("@/components/conversation/hooks", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/components/conversation/hooks")>();
+	return {
+		...actual,
+		useClearChatContextMutation: () => ({ isPending: false, mutate: vi.fn() }),
+		useConversationsByProjectId: () => ({ data: [] }),
+	};
+});
+
+vi.mock("@/hooks/useLanguage", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/hooks/useLanguage")>();
+	return {
+		...actual,
+		useLanguage: () => ({ iso639_1: "en", language: "en-US" }),
+	};
+});
+
+vi.mock("@/hooks/useWorkspace", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/hooks/useWorkspace")>();
+	return {
+		...actual,
+		useWorkspace: () => ({
+			workspace: { id: "workspace-1" },
+			workspaceId: "workspace-1",
+		}),
+	};
+});
+
+vi.mock("@/hooks/useWorkspaceUsage", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@/hooks/useWorkspaceUsage")>();
+	return { ...actual, useWorkspaceUsage: () => ({ freeTier: null }) };
+});
+
+// Children that carry their own data layer and nothing to do with run state.
+vi.mock("./ChatAccordion", () => ({ ChatAccordionItemMenu: () => null }));
+vi.mock("./ChatTemplatesMenuConnected", () => ({
+	ChatTemplatesMenuConnected: () => null,
+}));
+vi.mock("@/components/conversation/ProjectConversationsPanel", () => ({
+	ProjectConversationsPanel: () => null,
+}));
+vi.mock("./ChatHistoryMessage", () => ({
+	ChatHistoryMessage: ({
+		message,
+	}: {
+		message: { content: string; id: string; role: string };
+	}) => (
+		<div data-testid={`chat-message-${message.role}`}>{message.content}</div>
+	),
+}));
+
+import { AgenticChatPanel } from "./AgenticChatPanel";
+
+const at = (seq: number) =>
+	new Date(Date.UTC(2026, 7, 1, 10, seq)).toISOString();
+
+const messageEvent = (
+	seq: number,
+	role: "assistant" | "user",
+	content: string,
+): AgenticRunEvent => ({
+	event_type: role === "user" ? "user.message" : "assistant.message",
+	id: seq,
+	payload: { content },
+	project_agentic_run_id: RUN_ID,
+	seq,
+	timestamp: at(seq),
+});
+
+const toolEvent = (
+	seq: number,
+	phase: "end" | "start",
+	callId: string,
+	toolName = "listProjectConversations",
+): AgenticRunEvent => ({
+	event_type: phase === "start" ? "on_tool_start" : "on_tool_end",
+	id: seq,
+	payload: { name: toolName, run_id: callId },
+	project_agentic_run_id: RUN_ID,
+	seq,
+	timestamp: at(seq),
+});
+
+/** A finished turn: the host asked, three steps ran and closed, the assistant
+ * answered. Nothing here is still working. */
+const FINISHED_TURN: AgenticRunEvent[] = [
+	messageEvent(1, "user", "what came up in the interviews?"),
+	toolEvent(2, "start", "call-a"),
+	toolEvent(3, "end", "call-a"),
+	toolEvent(4, "start", "call-b", "getProjectSettings"),
+	toolEvent(5, "end", "call-b", "getProjectSettings"),
+	toolEvent(6, "start", "call-c", "grepDocs"),
+	toolEvent(7, "end", "call-c", "grepDocs"),
+	messageEvent(8, "assistant", "three themes came up."),
+];
+
+/** The finished turn, plus a second question the run is now working on. */
+const FINISHED_TURN_THEN_NEW_QUESTION: AgenticRunEvent[] = [
+	...FINISHED_TURN,
+	messageEvent(9, "user", "and what did they say about parking?"),
+];
+
+beforeAll(() => {
+	i18n.load("en", {});
+	i18n.activate("en");
+
+	window.matchMedia =
+		window.matchMedia ||
+		((query: string) => ({
+			addEventListener: () => {},
+			addListener: () => {},
+			dispatchEvent: () => false,
+			matches: false,
+			media: query,
+			onchange: null,
+			removeEventListener: () => {},
+			removeListener: () => {},
+		}));
+
+	// jsdom has neither, and useStickToBottom needs both.
+	window.ResizeObserver = class {
+		disconnect() {}
+		observe() {}
+		unobserve() {}
+	} as unknown as typeof ResizeObserver;
+	Element.prototype.scrollTo = Element.prototype.scrollTo ?? (() => {});
+});
+
+beforeEach(() => {
+	window.localStorage.clear();
+	stopAgenticRunMock.mockClear();
+	runState.events = [];
+	runState.status = "running";
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+const renderPanel = () =>
+	render(
+		<MemoryRouter>
+			<I18nProvider i18n={i18n}>
+				<MantineProvider>
+					<QueryClientProvider
+						client={
+							new QueryClient({
+								defaultOptions: { queries: { retry: false } },
+							})
+						}
+					>
+						<AgenticChatPanel chatId="chat-1" projectId="project-1" />
+					</QueryClientProvider>
+				</MantineProvider>
+			</I18nProvider>
+		</MemoryRouter>,
+	);
+
+const settledGroup = async () =>
+	await screen.findByTestId("agentic-tool-group");
+
+describe("AgenticChatPanel, tool groups and the live indicator", () => {
+	it("leaves a finished turn's tool group settled while a later run is in flight", async () => {
+		// The regression from #938 and #945, in one assertion: turn one is over,
+		// turn two has started, and the old group must not go back to the present
+		// tense just because something is running now.
+		runState.events = FINISHED_TURN_THEN_NEW_QUESTION;
+		runState.status = "running";
+		renderPanel();
+
+		const group = await settledGroup();
+		expect(group.textContent).toContain("Worked through 3 steps");
+		expect(group.textContent).not.toContain("Working");
+
+		const dot = group.querySelector<HTMLElement>("[aria-hidden='true']");
+		expect(dot?.className).not.toContain("animate-pulse");
+		expect(dot?.getAttribute("style")).toContain("completed-dot");
+	});
+
+	it("keeps the group settled even when the group is the newest node", async () => {
+		// #945 keyed on "the newest tool group", so a group that is also the last
+		// node was the worst case. It is a finished turn either way.
+		runState.events = FINISHED_TURN.slice(0, 8);
+		runState.status = "running";
+		renderPanel();
+
+		const group = await settledGroup();
+		expect(group.textContent).toContain("Worked through 3 steps");
+	});
+
+	it("still shows a group as running while one of its own steps is running", async () => {
+		// The other direction: a group must not go quiet when a step really is in
+		// progress. This is what #938 was originally protecting.
+		runState.events = [
+			messageEvent(1, "user", "what came up in the interviews?"),
+			toolEvent(2, "start", "call-a"),
+		];
+		runState.status = "running";
+		renderPanel();
+
+		const group = await settledGroup();
+		expect(group.textContent).toContain("Listing conversations");
+
+		const dot = group.querySelector<HTMLElement>("[aria-hidden='true']");
+		expect(dot?.className).toContain("animate-pulse");
+		expect(dot?.getAttribute("style")).toContain("running-dot");
+	});
+
+	it("renders exactly one live indicator, in the timeline, after the newest message", async () => {
+		runState.events = FINISHED_TURN_THEN_NEW_QUESTION;
+		runState.status = "running";
+		renderPanel();
+
+		const indicator = await screen.findByTestId("agentic-run-indicator");
+		// "completely remove the one below": one indicator, not two.
+		expect(screen.getAllByTestId("agentic-run-indicator")).toHaveLength(1);
+		expect(screen.getAllByTestId("chat-stop-button")).toHaveLength(1);
+
+		// A timeline node, not a floating pill: same parent as the tool group, so
+		// it sits in the scrolling thread rather than beside the composer.
+		const group = await settledGroup();
+		expect(indicator.parentElement).toBe(group.parentElement?.parentElement);
+
+		// And last, after the newest user message.
+		const messages = screen.getAllByTestId("chat-message-user");
+		const newestUserMessage = messages[messages.length - 1];
+		expect(
+			newestUserMessage.compareDocumentPosition(indicator) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+		expect(indicator.parentElement?.lastElementChild).toBe(indicator);
+	});
+
+	it("says what the current step is, and stays present tense between steps", async () => {
+		runState.events = [
+			messageEvent(1, "user", "what came up in the interviews?"),
+			toolEvent(2, "start", "call-a"),
+		];
+		runState.status = "running";
+		const running = renderPanel();
+
+		const indicator = await screen.findByTestId("agentic-run-indicator");
+		expect(indicator.textContent).toContain("Listing conversations");
+		running.unmount();
+
+		// Step closed, model now writing: no tool is running, and the honest line
+		// is the general one rather than a count of what is already done.
+		runState.events = FINISHED_TURN_THEN_NEW_QUESTION;
+		renderPanel();
+		const betweenSteps = await screen.findByTestId("agentic-run-indicator");
+		expect(betweenSteps.textContent).toContain("Working on your answer...");
+	});
+
+	it("carries the cancel button, and cancelling stops the run", async () => {
+		runState.events = FINISHED_TURN_THEN_NEW_QUESTION;
+		runState.status = "running";
+		renderPanel();
+
+		const indicator = await screen.findByTestId("agentic-run-indicator");
+		const cancel = screen.getByTestId("chat-stop-button");
+		expect(indicator.contains(cancel)).toBe(true);
+		expect(cancel.textContent).toContain("Cancel");
+
+		// The panel arms the control on pointer down and only then honours a
+		// click, so a stray click cannot kill a run.
+		fireEvent.pointerDown(cancel);
+		fireEvent.click(cancel);
+		await waitFor(() => {
+			expect(stopAgenticRunMock).toHaveBeenCalledWith(RUN_ID);
+		});
+	});
+
+	it("removes the indicator when the run reaches a terminal state", async () => {
+		runState.events = FINISHED_TURN;
+		runState.status = "completed";
+		renderPanel();
+
+		const group = await settledGroup();
+		expect(group.textContent).toContain("Worked through 3 steps");
+		expect(screen.queryByTestId("agentic-run-indicator")).toBeNull();
+		expect(screen.queryByTestId("chat-stop-button")).toBeNull();
+	});
+});

--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -399,7 +399,6 @@ const AGENTIC_TOOL_STATUS_VARS = {
 	"--agentic-tool-status-error-dot": "var(--mantine-color-red-6)",
 	"--agentic-tool-status-error-text": "var(--mantine-color-red-8)",
 	"--agentic-tool-status-running-dot": "var(--mantine-color-yellow-6)",
-	"--agentic-tool-status-running-ping-dot": "var(--mantine-color-yellow-4)",
 	"--agentic-tool-status-running-text": "var(--mantine-color-yellow-8)",
 } as CSSProperties;
 
@@ -532,21 +531,19 @@ const ToolActivityGroup = ({
 	items,
 	expanded,
 	onToggle,
-	stillWorking = false,
 }: {
 	items: ToolActivityItem[];
 	expanded: boolean;
 	onToggle: () => void;
-	/** True for the newest group while the run is still in flight. Between tool
-	 * calls, and while the model writes its answer, no tool has status
-	 * "running", so this group would otherwise settle to a green past-tense
-	 * summary while the composer still says "Working on your answer...". Two
-	 * indicators disagreeing, and the one nearest the answer is the wrong one. */
-	stillWorking?: boolean;
 }) => {
-	const running = items.some((i) => i.status === "running") || stillWorking;
-	const errored = items.some((i) => i.status === "error");
+	// A group speaks only for its own steps. It has no idea whether a run is in
+	// flight, and it must not: twice now a group was handed run state and twice
+	// a finished turn reverted to the present tense when a later turn started.
+	// The live part of the thread is LiveRunIndicator, which renders once, at
+	// the end, and disappears when the run ends. See #938 and #945.
 	const runningItem = items.find((i) => i.status === "running");
+	const running = runningItem !== undefined;
+	const errored = items.some((i) => i.status === "error");
 	const isSingle = items.length === 1;
 	// Steps whose start/end ranges overlap ran at the same time; say so
 	// instead of pretending they were sequential.
@@ -559,12 +556,8 @@ const ToolActivityGroup = ({
 					(item.startSeq < other.endSeq && other.startSeq < item.endSeq),
 			),
 		);
-	const summary = running
-		? // A named step wins. Otherwise the model is thinking or writing between
-			// steps, and the honest line is present tense, not a count of what is
-			// finished.
-			(runningItem?.headline ??
-				(isSingle ? t`Working...` : t`Working through a couple steps...`))
+	const summary = runningItem
+		? runningItem.headline
 		: isSingle
 			? items[0].headline
 			: ranAllAtOnce
@@ -645,6 +638,78 @@ const ToolActivityGroup = ({
 		</Box>
 	);
 };
+
+/** The one live thing in the thread. It is appended at the end of the timeline
+ * while a run is in flight, after the newest user message, so the wait sits in
+ * chronological position instead of floating by the composer. It says what the
+ * current step is when a tool is running, and stays honestly present tense in
+ * the gaps between steps and while the model writes. When the run reaches a
+ * terminal state it disappears, and the completed tool group renders in its
+ * place, which is why it borrows the group's shape: the swap is a settling, not
+ * a jump. Cancel lives here because this is the only place still working. */
+const LiveRunIndicator = ({
+	headline,
+	isStopping,
+	onArmStop,
+	onStop,
+}: {
+	headline: string;
+	isStopping: boolean;
+	onArmStop: () => void;
+	onStop: () => void;
+}) => (
+	<Box className="flex justify-start" {...testId("agentic-run-indicator")}>
+		<Paper
+			withBorder={false}
+			className="w-full max-w-full rounded-md px-2.5 py-1.5 shadow-none md:max-w-[80%]"
+			style={{
+				backgroundColor:
+					"color-mix(in srgb, var(--app-background) 88%, var(--mantine-color-primary-1))",
+			}}
+		>
+			<Group justify="space-between" gap="lg" wrap="nowrap">
+				<Group gap={8} wrap="nowrap" className="min-w-0">
+					<Box
+						aria-hidden="true"
+						className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+						style={{
+							backgroundColor: "var(--agentic-tool-status-running-dot)",
+						}}
+					/>
+					<Text
+						size="xs"
+						fs="italic"
+						className="min-w-0 truncate"
+						aria-live="polite"
+					>
+						{headline}
+					</Text>
+				</Group>
+				<Button
+					type="button"
+					size="compact-xs"
+					radius="xl"
+					variant="subtle"
+					color="red"
+					className="shrink-0"
+					aria-label={t`Cancel current run`}
+					onPointerDown={onArmStop}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" || event.key === " ") {
+							onArmStop();
+						}
+					}}
+					onClick={onStop}
+					disabled={isStopping}
+					leftSection={isStopping ? <Loader size={12} /> : undefined}
+					{...testId("chat-stop-button")}
+				>
+					<Trans>Cancel</Trans>
+				</Button>
+			</Group>
+		</Paper>
+	</Box>
+);
 
 export const AgenticChatPanel = ({
 	chatId,
@@ -745,6 +810,10 @@ export const AgenticChatPanel = ({
 	const threadScrollRef = useRef<HTMLDivElement>(null);
 	const { isAtBottomRef, scrollToBottom, showScrollButton } =
 		useStickToBottom(threadScrollRef);
+	// Declared here rather than next to the render because the stick-to-bottom
+	// effect below depends on it: the live indicator is a timeline node, so its
+	// arrival and departure change the thread's height.
+	const isRunInFlight = isInFlightStatus(runStatus);
 
 	useEffect(() => {
 		currentRunIdRef.current = runId;
@@ -933,22 +1002,6 @@ export const AgenticChatPanel = ({
 		}
 		return nodes;
 	}, [timeline]);
-
-	// Which tool group is allowed to keep showing itself as live.
-	//
-	// A run can post an assistant message and then carry on working, so "the last
-	// node in the timeline" stops being the tool group the moment any message
-	// renders beneath it. Keying on that made the chip settle to a green
-	// past-tense summary mid-run while the composer still read "Working on your
-	// answer...", which is the same contradiction the live chip was added to fix,
-	// arriving a few seconds later. Key on the newest TOOL GROUP instead: it is
-	// the one doing the work, wherever it sits in the list.
-	const newestToolGroupIndex = useMemo(() => {
-		for (let index = timelineNodes.length - 1; index >= 0; index -= 1) {
-			if (timelineNodes[index].kind === "tool_group") return index;
-		}
-		return -1;
-	}, [timelineNodes]);
 
 	// Drop the optimistic echo once the persisted user message arrives.
 	useEffect(() => {
@@ -1296,6 +1349,10 @@ export const AgenticChatPanel = ({
 	//
 	// The reader protection above is unchanged: this still only scrolls when
 	// isAtBottomRef says they are already at the bottom.
+	//
+	// isRunInFlight is a trigger too, because the live indicator is a node at the
+	// end of the thread: it appears when a run starts and is removed when the run
+	// ends, and both change the thread's height without changing the timeline.
 	const tail = timeline.at(-1);
 	const tailKey =
 		tail === undefined
@@ -1303,7 +1360,7 @@ export const AgenticChatPanel = ({
 			: tail.kind === "message"
 				? `m:${tail.id}:${tail.content.length}`
 				: `t:${tail.id}:${tail.status}`;
-	// biome-ignore lint/correctness/useExhaustiveDependencies: tailKey is the trigger, not a read — it exists so a growing tail re-fires this effect
+	// biome-ignore lint/correctness/useExhaustiveDependencies: tailKey and isRunInFlight are triggers, not reads. They exist so a growing tail and the live indicator re-fire this effect.
 	useEffect(() => {
 		if (timeline.length === 0) return;
 		if (!hasScrolledInitiallyRef.current) {
@@ -1318,7 +1375,7 @@ export const AgenticChatPanel = ({
 			// run finishes, a single smooth scroll is the nicer motion.
 			scrollToBottom(isStreaming ? "auto" : "smooth");
 		}
-	}, [timeline.length, tailKey, isStreaming, scrollToBottom]);
+	}, [timeline.length, tailKey, isRunInFlight, isStreaming, scrollToBottom]);
 
 	useEffect(() => {
 		return () => {
@@ -1448,7 +1505,6 @@ export const AgenticChatPanel = ({
 		}
 	};
 
-	const isRunInFlight = isInFlightStatus(runStatus);
 	const chatTitle = chatQuery.data?.name ?? t`Chat`;
 	const updateChatMutation = useUpdateChatMutation();
 	const [isEditingTitle, setIsEditingTitle] = useState(false);
@@ -1647,7 +1703,7 @@ export const AgenticChatPanel = ({
 							</Stack>
 						)}
 
-					{timelineNodes.map((node, nodeIndex) => {
+					{timelineNodes.map((node) => {
 						if (node.kind === "message") {
 							const focusedConversations = (
 								node.item.role === "user"
@@ -1797,7 +1853,6 @@ export const AgenticChatPanel = ({
 								items={node.items}
 								expanded={Boolean(expandedGroupIds[node.id])}
 								onToggle={() => toggleGroupDetails(node.id)}
-								stillWorking={nodeIndex === newestToolGroupIndex && isRunInFlight}
 							/>
 						);
 					})}
@@ -1825,6 +1880,20 @@ export const AgenticChatPanel = ({
 								/>
 							</div>
 						)}
+
+					{/* Last node in the thread, after the newest user message, for as
+					    long as the run is in flight. There is no second indicator by
+					    the composer: one live thing, in the place the eye already is.
+					    Not while the chat is still loading, so the skeleton and the
+					    live line never claim the same space. */}
+					{!showExistingChatLoading && isRunInFlight && (
+						<LiveRunIndicator
+							headline={liveRunStatusText}
+							isStopping={isStopping}
+							onArmStop={armStopControl}
+							onStop={() => void handleStop()}
+						/>
+					)}
 				</Stack>
 			</Box>
 
@@ -1842,64 +1911,6 @@ export const AgenticChatPanel = ({
 							onClick={() => scrollToBottom("smooth")}
 						/>
 					</Group>
-
-					{isRunInFlight && (
-						<Group justify="flex-start">
-							<Paper
-								className="rounded-full px-3 py-1.5 shadow-none"
-								style={{
-									borderColor: "var(--mantine-color-primary-light)",
-								}}
-								{...testId("agentic-run-indicator")}
-							>
-								<Group gap={8} wrap="nowrap">
-									<Box className="relative h-2 w-2 shrink-0">
-										<Box
-											className="absolute inset-0 rounded-full animate-ping"
-											style={{
-												backgroundColor:
-													"var(--agentic-tool-status-running-ping-dot)",
-											}}
-										/>
-										<Box
-											className="relative h-2 w-2 rounded-full"
-											style={{
-												backgroundColor:
-													"var(--agentic-tool-status-running-dot)",
-											}}
-										/>
-									</Box>
-									<Text
-										size="xs"
-										fw={500}
-										className="max-w-[min(70vw,32rem)] truncate"
-									>
-										{liveRunStatusText}
-									</Text>
-									<Button
-										type="button"
-										size="compact-xs"
-										radius="xl"
-										variant="subtle"
-										color="red"
-										aria-label={t`Cancel current run`}
-										onPointerDown={armStopControl}
-										onKeyDown={(event) => {
-											if (event.key === "Enter" || event.key === " ") {
-												armStopControl();
-											}
-										}}
-										onClick={() => void handleStop()}
-										disabled={isStopping}
-										leftSection={isStopping ? <Loader size={12} /> : undefined}
-										{...testId("chat-stop-button")}
-									>
-										<Trans>Cancel</Trans>
-									</Button>
-								</Group>
-							</Paper>
-						</Group>
-					)}
 
 					<ChatTemplatesMenuConnected
 						chatId={chatId}

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr "can read"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4610,7 +4610,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5415,7 +5415,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Error"
 
@@ -5878,11 +5878,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6074,9 +6074,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6627,7 +6627,7 @@ msgstr "Hide projects"
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6720,11 +6720,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7599,7 +7599,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7607,7 +7607,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7757,7 +7757,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10895,7 +10895,7 @@ msgstr ""
 #~ msgstr "Quotes"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11350,7 +11350,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11779,7 +11779,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12405,7 +12405,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Send"
 
@@ -12770,7 +12770,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14318,7 +14318,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15176,7 +15176,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15774,11 +15774,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15864,7 +15864,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15935,21 +15935,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2245,7 +2245,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -2875,7 +2875,7 @@ msgstr "Abbrechen"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3080,7 +3080,7 @@ msgstr "Das Ändern der Sprache während eines aktiven Chats kann unerwartete Er
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4396,7 +4396,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Fehler"
 
@@ -5629,11 +5629,11 @@ msgstr "Ergebnis konnte nicht überarbeitet werden. Bitte versuchen Sie es erneu
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fehler beim Beenden der Aufnahme bei Änderung des Mikrofons. Bitte versuchen Sie es erneut."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5820,9 +5820,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Fokus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6365,7 +6365,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Revisionsdaten verbergen"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6458,11 +6458,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6540,7 +6540,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7327,7 +7327,7 @@ msgstr "Link zur Datenschutzerklärung Ihrer Organisation, die angezeigt wird"
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn-Beitrag (Experimentell)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7335,7 +7335,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7401,7 +7401,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7484,7 +7484,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10674,7 +10674,7 @@ msgstr ""
 #~ msgstr "Zitate"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11122,7 +11122,7 @@ msgstr "Umbenennen"
 #~ msgstr "Umbenennen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Chat umbenennen"
 
@@ -11544,7 +11544,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Dateien vor dem Hochladen überprüfen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12167,7 +12167,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Senden"
 
@@ -12528,7 +12528,7 @@ msgstr "Referenzen anzeigen"
 msgid "Show revision data"
 msgstr "Revisionsdaten anzeigen"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14033,7 +14033,7 @@ msgstr "Zu groß"
 msgid "Too long"
 msgstr "Zu lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14877,7 +14877,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Verwenden Sie Shift + Enter, um eine neue Zeile hinzuzufügen"
 
@@ -15458,11 +15458,11 @@ msgstr "Was soll ECHO aus den Gesprächen analysieren oder generieren?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Worauf soll sich dieser Bericht konzentrieren?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15548,7 +15548,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15619,21 +15619,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 
@@ -2453,7 +2453,7 @@ msgstr "Ask about these"
 #~ msgstr "Ask about your conversations, or type to find an earlier chat"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr "Ask about your conversations..."
 
@@ -3059,7 +3059,7 @@ msgstr "can read"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr "Cancel anytime. You keep access until the period ends."
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr "Cancel current run"
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4610,7 +4610,7 @@ msgstr "dembrane B.V. {0}, all rights reserved."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5415,7 +5415,7 @@ msgstr "Entered details"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Error"
 
@@ -5878,11 +5878,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr "Failed to stop run"
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr "Failed to submit agentic message"
 
@@ -6074,9 +6074,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr "Focus on conversations"
 
@@ -6627,7 +6627,7 @@ msgstr "Hide projects"
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr "Hide steps"
 
@@ -6720,11 +6720,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr "I accept the <0>terms</0>"
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr "I applied the canvas."
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr "I applied the goal."
 
@@ -6812,7 +6812,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr "Image style"
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr "Improve my setup"
 
@@ -7599,7 +7599,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr "List my conversations"
 
@@ -7607,7 +7607,7 @@ msgstr "List my conversations"
 #~ msgid "List project conversations"
 #~ msgstr "List project conversations"
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr "List the conversations in this project."
 
@@ -7674,7 +7674,7 @@ msgstr "Live recordings, transcription progress, and errors show up here as part
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live stream disconnected. Updating on a slower poll until it reconnects."
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live stream interrupted. Falling back to polling."
 
@@ -7757,7 +7757,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr "Loading this chat..."
 
@@ -10895,7 +10895,7 @@ msgstr "Questions about how dembrane works, not only about your data."
 #~ msgstr "Quotes"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr "Ran {0} steps at once"
 
@@ -11350,7 +11350,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11779,7 +11779,7 @@ msgstr "Review before creating."
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr "Review my project settings and suggest improvements."
 
@@ -12405,7 +12405,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Send"
 
@@ -12770,7 +12770,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr "Show steps"
 
@@ -14318,7 +14318,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Too many to list here. The assistant reads through them in batches."
 
@@ -15176,7 +15176,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15774,11 +15774,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr "What themes came up across the conversations in this project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr "What themes came up?"
 
@@ -15864,7 +15864,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr "Where would you like to start?"
 
@@ -15935,21 +15935,21 @@ msgid "Within my organisation"
 msgstr "Within my organisation"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr "Worked through {0} steps"
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr "Working on your answer..."
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr "Working through a couple steps..."
+#~ msgid "Working through a couple steps..."
+#~ msgstr "Working through a couple steps..."
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr "Working..."
+#~ msgid "Working..."
+#~ msgstr "Working..."
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2845,7 +2845,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -2878,7 +2878,7 @@ msgstr "Cancelar"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3083,7 +3083,7 @@ msgstr "Cambiar el idioma durante una conversación activa puede provocar result
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4399,7 +4399,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Error"
 
@@ -5632,11 +5632,11 @@ msgstr "Error al revisar el resultado. Por favor, inténtalo de nuevo."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Error al detener la grabación al cambiar el dispositivo. Por favor, inténtalo de nuevo."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5823,9 +5823,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Enfoque"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6368,7 +6368,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Ocultar datos de revisión"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6461,11 +6461,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6543,7 +6543,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgstr "Enlace a la política de privacidad de tu organización que se mostrará
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publicación LinkedIn (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7404,7 +7404,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7487,7 +7487,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10680,7 +10680,7 @@ msgstr ""
 #~ msgstr "Citas"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11128,7 +11128,7 @@ msgstr "Renombrar"
 #~ msgstr "Renombrar"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Renombrar chat"
 
@@ -11550,7 +11550,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Revisar archivos antes de subir"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12173,7 +12173,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Enviar"
 
@@ -12534,7 +12534,7 @@ msgstr "Mostrar referencias"
 msgid "Show revision data"
 msgstr "Mostrar datos de revisión"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14036,7 +14036,7 @@ msgstr "Demasiado grande"
 msgid "Too long"
 msgstr "Demasiado largo"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14881,7 +14881,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Usa Shift + Enter para agregar una nueva línea"
 
@@ -15462,11 +15462,11 @@ msgstr "¿Qué debe ECHO analizar o generar a partir de las conversaciones?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "¿En qué debe centrarse este informe?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15552,7 +15552,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15623,21 +15623,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -435,7 +435,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2263,7 +2263,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -2860,7 +2860,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -2893,7 +2893,7 @@ msgstr "Annuler"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr "Changer de langue pendant une conversation active peut provoquer des ré
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Discussion"
 
@@ -4414,7 +4414,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5199,7 +5199,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Erreur"
 
@@ -5647,11 +5647,11 @@ msgstr "Échec de la révision du résultat. Veuillez réessayer."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Échec de l'arrêt de l'enregistrement lors du changement de périphérique. Veuillez réessayer."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5838,9 +5838,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6383,7 +6383,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Masquer les données de révision"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6476,11 +6476,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6558,7 +6558,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7345,7 +7345,7 @@ msgstr "Lien vers la politique de confidentialité de votre organisation qui ser
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publication LinkedIn (Expérimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7353,7 +7353,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7419,7 +7419,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7502,7 +7502,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10695,7 +10695,7 @@ msgstr ""
 #~ msgstr "Citations"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11143,7 +11143,7 @@ msgstr "Renommer"
 #~ msgstr "Renommer"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Renommer le chat"
 
@@ -11565,7 +11565,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Examiner les fichiers avant le téléchargement"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12188,7 +12188,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Envoyer"
 
@@ -12549,7 +12549,7 @@ msgstr "Afficher les références"
 msgid "Show revision data"
 msgstr "Afficher les données de révision"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14051,7 +14051,7 @@ msgstr "Trop grande"
 msgid "Too long"
 msgstr "Trop long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14896,7 +14896,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Utilisez Shift + Entrée pour ajouter une nouvelle ligne"
 
@@ -15481,11 +15481,11 @@ msgstr "Que doit ECHO analyser ou générer à partir des conversations ?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Sur quoi ce rapport doit-il se concentrer ?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15571,7 +15571,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15642,21 +15642,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4610,7 +4610,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5415,7 +5415,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Error"
 
@@ -5878,11 +5878,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6074,9 +6074,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6627,7 +6627,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6720,11 +6720,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7599,7 +7599,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7607,7 +7607,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7757,7 +7757,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10895,7 +10895,7 @@ msgstr ""
 #~ msgstr "Quotes"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11350,7 +11350,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11779,7 +11779,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12405,7 +12405,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Send"
 
@@ -12770,7 +12770,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14318,7 +14318,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15176,7 +15176,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15774,11 +15774,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15864,7 +15864,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15935,21 +15935,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -252,7 +252,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# werkruimte} other {# werkruimtes}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focus op # gesprek:} other {Focus op # gesprekken:}}"
 
@@ -1988,7 +1988,7 @@ msgstr "Vragen | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Vraag een organisatie-admin om deze upgrade aan te vragen."
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Stel een vraag over de gesprekken in dit project, of vraag hulp bij het opzetten ervan. Elke wijziging wordt eerst ter beoordeling voorgesteld en er wordt niets opgeslagen totdat je het goedkeurt."
 
@@ -2019,7 +2019,7 @@ msgstr "Hierover vragen"
 #~ msgstr "Vraag iets over je gesprekken, of typ om een eerdere chat te vinden"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr "Vraag iets over je gesprekken..."
 
@@ -2604,7 +2604,7 @@ msgstr "kan lezen"
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -2637,7 +2637,7 @@ msgstr "Annuleren"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr "Annuleer wanneer je wilt. Je houdt toegang tot het einde van de periode."
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr "Huidige run stoppen"
 
@@ -2834,7 +2834,7 @@ msgstr "Wijziging van de taal tijdens een actief gesprek kan onverwachte resulta
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4132,7 +4132,7 @@ msgstr "dembrane B.V. {0}, alle rechten voorbehouden."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane kan fouten maken. Controleer antwoorden altijd even."
 
@@ -4891,7 +4891,7 @@ msgstr "Gegevens ingevuld"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Fout"
 
@@ -5326,11 +5326,11 @@ msgstr "Fout bij het herzien van het resultaat. Probeer het opnieuw."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fout bij het stoppen van de opname bij wijziging van het apparaat. Probeer het opnieuw."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr "De run stoppen is mislukt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr "Bericht versturen is mislukt"
 
@@ -5517,9 +5517,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr "Focus op gesprekken"
 
@@ -6040,7 +6040,7 @@ msgstr "Projecten verbergen"
 msgid "Hide revision data"
 msgstr "Revisiegegevens verbergen"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr "Stappen verbergen"
 
@@ -6125,11 +6125,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr "Ik heb het canvas toegepast."
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr "Ik heb het doel toegepast."
 
@@ -6205,7 +6205,7 @@ msgstr "Als je je bij een bestaande organisatie wilt aansluiten, maak dan geen n
 msgid "Image style"
 msgstr "Beeldstijl"
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr "Verbeter mijn instellingen"
 
@@ -6959,7 +6959,7 @@ msgstr "Link naar de privacyverklaring van uw organisatie die aan deelnemers wor
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimenteel)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr "Toon mijn gesprekken"
 
@@ -6967,7 +6967,7 @@ msgstr "Toon mijn gesprekken"
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr "Toon de gesprekken in dit project."
 
@@ -7033,7 +7033,7 @@ msgstr "Live opnames, voortgang van transcriptie en fouten verschijnen hier zodr
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live verbinding verbroken. We werken minder vaak bij tot de verbinding terug is."
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live verbinding onderbroken. We halen updates nu periodiek op."
 
@@ -7114,7 +7114,7 @@ msgstr "Projecten laden..."
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr "Deze chat laden..."
 
@@ -10235,7 +10235,7 @@ msgstr "Vragen over hoe dembrane werkt, niet alleen over je data."
 #~ msgstr "Quotes"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr "{0} stappen tegelijk uitgevoerd"
 
@@ -10667,7 +10667,7 @@ msgstr "Naam wijzigen"
 #~ msgstr "Naam wijzigen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Chat hernoemen"
 
@@ -11068,7 +11068,7 @@ msgstr "Controleer voordat je aanmaakt."
 msgid "Review files before uploading"
 msgstr "Bestanden bekijken voordat u uploadt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr "Bekijk mijn projectinstellingen en stel verbeteringen voor."
 
@@ -11686,7 +11686,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Verzenden"
 
@@ -12027,7 +12027,7 @@ msgstr "Toon referenties"
 msgid "Show revision data"
 msgstr "Revisiegegevens tonen"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr "Stappen tonen"
 
@@ -13481,7 +13481,7 @@ msgstr "Te groot"
 msgid "Too long"
 msgstr "Te lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Te veel om hier te tonen. De assistent leest ze in delen door."
 
@@ -14305,7 +14305,7 @@ msgstr "Gebruik deze cyclus"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Gebruik Shift + Enter om een nieuwe regel toe te voegen"
 
@@ -14861,11 +14861,11 @@ msgstr "Wat moet ECHO analyseren of genereren uit de gesprekken?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Waar moet dit rapport zich op richten?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr "Welke thema's kwamen naar voren in de gesprekken in dit project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr "Welke thema's kwamen naar voren?"
 
@@ -14947,7 +14947,7 @@ msgid "Where would you like to go?"
 msgstr "Waar wil je naartoe?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr "Waar wil je beginnen?"
 
@@ -15012,21 +15012,21 @@ msgid "Within my organisation"
 msgstr "Binnen mijn organisatie"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr "{0} stappen doorlopen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr "Bezig met je antwoord..."
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr "Bezig..."
+#~ msgid "Working..."
+#~ msgstr "Bezig..."
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1927
+#: src/components/chat/AgenticChatPanel.tsx:1938
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1608
+#: src/components/chat/AgenticChatPanel.tsx:1664
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1987
+#: src/components/chat/AgenticChatPanel.tsx:1998
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr ""
 #: src/components/common/FeedbackPortalModal.tsx:124
 #: src/components/common/ConfirmModal.tsx:44
 #: src/components/chat/ProjectUpdateSuggestionCard.tsx:722
-#: src/components/chat/AgenticChatPanel.tsx:1897
+#: src/components/chat/AgenticChatPanel.tsx:707
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -3092,7 +3092,7 @@ msgstr "Cancel"
 msgid "Cancel anytime. You keep access until the period ends."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1885
+#: src/components/chat/AgenticChatPanel.tsx:695
 msgid "Cancel current run"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1452
+#: src/components/chat/AgenticChatPanel.tsx:1508
 msgid "Chat"
 msgstr "Chat"
 
@@ -4610,7 +4610,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2008
+#: src/components/chat/AgenticChatPanel.tsx:2019
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5415,7 +5415,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1554
+#: src/components/chat/AgenticChatPanel.tsx:1610
 msgid "Error"
 msgstr "Error"
 
@@ -5878,11 +5878,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1444
+#: src/components/chat/AgenticChatPanel.tsx:1501
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1403
+#: src/components/chat/AgenticChatPanel.tsx:1460
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6074,9 +6074,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
-#: src/components/chat/AgenticChatPanel.tsx:1955
-#: src/components/chat/AgenticChatPanel.tsx:2018
+#: src/components/chat/AgenticChatPanel.tsx:1965
+#: src/components/chat/AgenticChatPanel.tsx:1966
+#: src/components/chat/AgenticChatPanel.tsx:2029
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6627,7 +6627,7 @@ msgstr ""
 msgid "Hide revision data"
 msgstr "Hide revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Hide steps"
 msgstr ""
 
@@ -6720,11 +6720,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1722
+#: src/components/chat/AgenticChatPanel.tsx:1778
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1738
+#: src/components/chat/AgenticChatPanel.tsx:1794
 msgid "I applied the goal."
 msgstr ""
 
@@ -6812,7 +6812,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1632
+#: src/components/chat/AgenticChatPanel.tsx:1688
 msgid "Improve my setup"
 msgstr ""
 
@@ -7599,7 +7599,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1622
+#: src/components/chat/AgenticChatPanel.tsx:1678
 msgid "List my conversations"
 msgstr ""
 
@@ -7607,7 +7607,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1623
+#: src/components/chat/AgenticChatPanel.tsx:1679
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1122
+#: src/components/chat/AgenticChatPanel.tsx:1175
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7757,7 +7757,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1565
+#: src/components/chat/AgenticChatPanel.tsx:1621
 msgid "Loading this chat..."
 msgstr ""
 
@@ -10895,7 +10895,7 @@ msgstr ""
 #~ msgstr "Quotes"
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:571
+#: src/components/chat/AgenticChatPanel.tsx:564
 msgid "Ran {0} steps at once"
 msgstr ""
 
@@ -11350,7 +11350,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1515
+#: src/components/chat/AgenticChatPanel.tsx:1571
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11779,7 +11779,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1633
+#: src/components/chat/AgenticChatPanel.tsx:1689
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12405,7 +12405,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1973
+#: src/components/chat/AgenticChatPanel.tsx:1984
 msgid "Send"
 msgstr "Send"
 
@@ -12770,7 +12770,7 @@ msgstr "Show references"
 msgid "Show revision data"
 msgstr "Show revision data"
 
-#: src/components/chat/AgenticChatPanel.tsx:600
+#: src/components/chat/AgenticChatPanel.tsx:593
 msgid "Show steps"
 msgstr ""
 
@@ -14318,7 +14318,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1943
+#: src/components/chat/AgenticChatPanel.tsx:1954
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15176,7 +15176,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2005
+#: src/components/chat/AgenticChatPanel.tsx:2016
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15774,11 +15774,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1628
+#: src/components/chat/AgenticChatPanel.tsx:1684
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1627
+#: src/components/chat/AgenticChatPanel.tsx:1683
 msgid "What themes came up?"
 msgstr ""
 
@@ -15864,7 +15864,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1605
+#: src/components/chat/AgenticChatPanel.tsx:1661
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15935,21 +15935,21 @@ msgid "Within my organisation"
 msgstr ""
 
 #. placeholder {0}: items.length
-#: src/components/chat/AgenticChatPanel.tsx:572
+#: src/components/chat/AgenticChatPanel.tsx:565
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1477
+#: src/components/chat/AgenticChatPanel.tsx:1533
 msgid "Working on your answer..."
 msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working through a couple steps..."
-msgstr ""
+#~ msgid "Working through a couple steps..."
+#~ msgstr ""
 
 #: src/components/chat/AgenticChatPanel.tsx:567
-msgid "Working..."
-msgstr ""
+#~ msgid "Working..."
+#~ msgstr ""
 
 #: src/routes/organisation/OrganisationRoute.tsx:749
 msgid "workspace"


### PR DESCRIPTION
## What a user sees

Sameer's screenshot: a yellow **"Working through a couple steps..."** at 7:45, the assistant's finished answer rendered *below* it, and a separate **"Working on your answer... Cancel"** pill down by the composer. Two indicators, and the one sitting in the timeline was lying about a turn that had already finished.

The mechanism: ask a second question, and a tool group from the *first* turn goes back to the present tense. "Worked through 3 steps" reverts to "Working through a couple steps...". Nothing about that turn changed. Only the fact that a new run started.

## This is the third go at these three lines

**#938** made a tool group stay live while the run was in flight, keyed on `isNewestNode`, the last node in the whole timeline. It fixed the original complaint, a group going green and past tense while the model was still writing.

**#945** found that #938 settled too early: a run can post an assistant message and carry on working, and the moment that message rendered beneath the group, the group stopped being newest and went green mid-run. It re-keyed on the newest **tool group**.

**Both were wrong in the same way.** They gave a tool group knowledge of run state. A group from a previous turn is still "the newest tool group", so the third bug fell straight out of the second fix.

## The fix

`ToolActivityGroup` keys purely on its own items again. It has no prop through which run state can reach it, so a settled group cannot un-settle. `stillWorking` and `newestToolGroupIndex` are deleted rather than patched.

The live part of the thread is a new node, `LiveRunIndicator`, appended at the end of the timeline after the newest user message for as long as the run is in flight. It shows the running step's headline when a tool is running, and stays present tense with the existing `Working on your answer...` between steps and while the model writes. Yellow dot, pulsing. It carries the Cancel button.

The composer-adjacent pill is **deleted**. One indicator, in the place the eye already is.

It borrows the tool group's shape on purpose: when the run ends the indicator disappears and the completed group renders in its place, so the swap reads as a settling rather than a jump.

Two smaller things that follow from making it a timeline node: `isRunInFlight` is now a trigger for the stick-to-bottom effect, since the node's arrival and departure change the thread's height without changing the timeline; and the indicator is suppressed while the chat is still loading, so the skeleton and the live line never claim the same space. The reader protection is untouched, it still only scrolls someone who is already at the bottom.

Two strings leave the catalogs: `Working...` and `Working through a couple steps...`, both added by #938. A group no longer narrates the run, so it no longer needs a present tense.

## Testing

**There is now a test, and this is the part that matters.** Nothing rendered this panel with a run in flight, which is exactly why the same three lines shipped wrong twice. `AgenticChatPanel.test.tsx` drives the real panel from real run events with a mocked data layer, and covers:

- a finished turn's tool group stays settled while a later run is in flight, the regression that shipped twice
- the same, when the group is also the last node, which was #945's best case and still wrong
- a group **does** show as running while one of its own steps is running, so the fix cannot over-correct into silence
- exactly one live indicator and exactly one Cancel button exist, the indicator shares a parent with the tool group (a timeline node, not a floating pill), and it is last, after the newest user message
- the indicator names the current step while a tool runs, and falls back to `Working on your answer...` between steps
- Cancel calls `stopAgenticRun`, through the same arm-then-click guard as before
- the indicator disappears at a terminal status

Checked against the pre-fix code: three of the seven fail on `main`, with `expected 'Working through a couple steps...' to contain 'Worked through 3 steps'`. It reproduces the shipped bug.

`tsc --noEmit` clean, `biome lint --diagnostic-level=error` clean, catalogs extracted and compiled last, idempotent on a second run. The cypress selectors `agentic-run-indicator` and `chat-stop-button` are preserved, so `36-agentic-chat-local` and `stopGeneration()` still find them.

## The failure mode I would still watch

The indicator is driven by `runStatus` alone. If the stream ever drops without the status reaching a terminal state, the indicator stays up with a Cancel button on a run nobody is running, which is a quieter lie than this bug but the same kind. That path is not touched here, and it is not new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
