### PR TITLE
feat(release): keep the video modal off in production for this release

### DIFF
--- a/echo/frontend/src/components/layout/BaseLayout.tsx
+++ b/echo/frontend/src/components/layout/BaseLayout.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react";
 import { Outlet } from "react-router";
 import { useAuthenticated } from "@/components/auth/hooks";
 import { ReleaseVideoModal } from "@/components/release/ReleaseVideoModal";
+import { ENABLE_RELEASE_VIDEO_MODAL } from "@/config";
 import { AppSidebar, useSidebarView } from "@/features/sidebar";
 import { AppBreadcrumbs } from "@/features/sidebar/breadcrumbs/AppBreadcrumbs";
 import { useSidebarState } from "@/features/sidebar/hooks/useSidebarState";
@@ -82,7 +83,7 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 				<Toaster />
 				{/* Inside the curtain provider on purpose: the modal reads
 				    isActive and stays down while a transition is running. */}
-				<ReleaseVideoModal />
+				{ENABLE_RELEASE_VIDEO_MODAL ? <ReleaseVideoModal /> : null}
 			</div>
 		</TransitionCurtainProvider>
 	);

--- a/echo/frontend/src/config.ts
+++ b/echo/frontend/src/config.ts
@@ -204,6 +204,12 @@ export const ENABLE_AGENTATION = byEnv({ next: true }, false);
 export const ENABLE_MONITOR = true;
 // Project Library / dynamic canvases. Off in production this release; on elsewhere.
 export const ENABLE_CANVAS = byEnv({ production: false }, true);
+// The release-video modal. Off in production for this release by Sameer's call:
+// the video is being recorded and the changelog page it links to is not written
+// yet, so a modal pointing at a 404 would reach every host at once. A patch
+// release turns it on once both exist. Everywhere else it stays on, which is
+// how the flow gets tested before it ships.
+export const ENABLE_RELEASE_VIDEO_MODAL = byEnv({ production: false }, true);
 
 export const getProductFeedbackUrl = (locale = "en-US") =>
 	`https://portal.dembrane.com/${locale}/a2b7fbeb-af8d-41c8-b70b-9ff1f3c6d51a/start?theme=dm-sans`;


### PR DESCRIPTION
Sameer's call, ahead of the production promote.

The release-video modal merged in #947 with no environment gate, so it would go live with the rest of this release. Two reasons that is wrong today:

- **The video does not exist yet.** The array still holds a Big Buck Bunny placeholder.
- **The changelog page it links to is not written.** "View earlier" would point at `docs.dembrane.com/changelog.html`, which currently 404s.

Everyone with no stored `release_video_seen` sees the modal on their next load, which is the entire active base at once. A modal in front of every host pointing at a missing page is a bad way to open a release.

```ts
export const ENABLE_RELEASE_VIDEO_MODAL = byEnv({ production: false }, true);
```

Same shape as `ENABLE_CANVAS`. It stays **on** everywhere else, which is the point: the flow gets tested on echo-next with the dummy video, and a patch release flips production once the real video is up and the changelog page is live.

## To turn it on later

One line, `production: true` or drop the `byEnv`, in the patch release that also swaps the dummy `videoUrl` in `components/release/releases.ts`. Frontend flags are compile-time constants, so it needs a build and deploy, which a patch release does anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)