### PR TITLE
agent: project context replaces the goal, and a turn asks for one thing

### DIFF
--- a/echo/agent/README.md
+++ b/echo/agent/README.md
@@ -37,7 +37,7 @@ Tools defined in `agent.py` fall into three buckets:
 
 - **UI tools** render a card in the chat timeline. The `UI_TOOLS` frozenset in
   `agent.py` is the source of truth: `navigateTo`, `proposeCanvas`,
-  `proposeGoal`, `proposeProjectUpdate`, `proposeTagsUpdate`, `noteInsight`,
+  `proposeProjectUpdate`, `proposeTagsUpdate`, `noteInsight`,
   `editInsight`, `retractInsight`, `sendProgressUpdate`. Each of these also carries a "renders a
   card in the chat UI" docstring line. `editInsight` and `retractInsight`
   re-render the insight card by id: an amended note gains an "updated" chip, a
@@ -48,7 +48,7 @@ Tools defined in `agent.py` fall into three buckets:
   `listProjectConversations`, `getProjectSettings`, `getProjectTags`,
   `getPortalLink`, `listDocs`, `readDoc`, `grepDocs`, `readSkill`,
   `listProjectChats`, `readChat`, `getLiveConversationStatus`, `readMemory`,
-  `readGoal`, `listMethodologies`, `listCanvases`, `get_project_scope`.
+  `listMethodologies`, `listCanvases`, `get_project_scope`.
 - **Write tools** change durable state: `editCanvas`,
   `addToCanvas`, `removeFromCanvas`, `pauseCanvasLoop`, `resumeCanvasLoop`,
   `stopCanvasLoop`, `remember`, `amendMemory`, `forgetMemory`,
@@ -73,6 +73,16 @@ old names are never registered as visible tools.
 | `grepConvoSnippets` | `grepConversationSnippets` |
 | `reachOutToDembrane` | `reachOutToDembraneSupport` |
 | `recordInsight` | `noteInsight` |
+
+### Retired tools
+
+A retired tool has no successor to be renamed onto, so `TOOL_NAME_RENAMES`
+cannot save it. `RETIRED_TOOL_NAMES` in `agent.py` lists those names, and
+`_strip_retired_tool_calls` drops their replayed calls and paired results at the
+same history boundary, so Vertex never sees a function name it does not know.
+The stored chat is untouched and the frontend still renders the old card from
+what it persisted. Currently retired: `proposeGoal`, `readGoal` (project context
+is now the single thing setup establishes).
 
 ## Notes
 

--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -46,7 +46,7 @@ AgentInsightKind = Literal["capability_gap", "friction", "wish", "praise"]
 #   listConversationFullTranscript, grepConversationSnippets,
 #   listProjectConversations, getProjectSettings, getProjectTags, getPortalLink,
 #   listDocs, readDoc, grepDocs, readSkill, listProjectChats, readChat,
-#   getLiveConversationStatus, readMemory, readGoal, listMethodologies,
+#   getLiveConversationStatus, readMemory, listMethodologies,
 #   listCanvases, listReports, readReport, get_project_scope).
 # - Write tools change durable state (editCanvas, addToCanvas,
 #   removeFromCanvas, pauseCanvasLoop, resumeCanvasLoop, stopCanvasLoop,
@@ -61,7 +61,6 @@ UI_TOOLS = frozenset(
     {
         "navigateTo",
         "proposeCanvas",
-        "proposeGoal",
         "proposeProjectUpdate",
         "proposeTagsUpdate",
         "noteInsight",
@@ -104,6 +103,94 @@ TOOL_NAME_RENAMES: dict[str, str] = {
 
 def _rename_tool_name(name: str) -> str:
     return TOOL_NAME_RENAMES.get(name, name)
+
+
+# Tools that were RETIRED rather than renamed, so there is no successor name to
+# map them onto. proposeGoal and readGoal went out when project context became
+# the single thing setup establishes. Persisted histories still carry their
+# calls and their results, and a replayed name that is no longer a registered
+# function is exactly the failure TOOL_NAME_RENAMES exists to prevent. So the
+# replay boundary drops these calls and their paired results before the history
+# reaches Vertex: the model sees a turn where it spoke and moved on, and a chat
+# that once proposed a goal still opens. Purely transient, the stored chat is
+# untouched, and the frontend still renders the old card from what it persisted.
+RETIRED_TOOL_NAMES = frozenset({"proposeGoal", "readGoal"})
+RETIRED_TOOL_TURN_PLACEHOLDER = "(an earlier step that is no longer available)"
+
+
+def _message_content_is_empty(content: Any) -> bool:
+    if isinstance(content, str):
+        return not content.strip()
+    if isinstance(content, list):
+        return not content
+    return not content
+
+
+def _strip_retired_tool_calls(messages: list[Any]) -> list[Any]:
+    """Drop replayed calls to retired tools, and the results paired with them.
+
+    Runs after name normalization, so a fused or pre-rename name has already
+    been split and mapped by the time it gets here. An assistant turn left with
+    no calls and no text gets a short placeholder, because an empty model turn
+    is its own Vertex problem."""
+    dropped_call_ids: set[str] = set()
+    without_calls: list[Any] = []
+
+    def _keep(call: Any) -> bool:
+        if not isinstance(call, dict):
+            return True
+        if str(call.get("name") or "") not in RETIRED_TOOL_NAMES:
+            return True
+        call_id = call.get("id")
+        if isinstance(call_id, str) and call_id:
+            dropped_call_ids.add(call_id)
+        return False
+
+    for message in messages:
+        if getattr(message, "type", None) == "tool":
+            without_calls.append(message)
+            continue
+
+        tool_calls = getattr(message, "tool_calls", None)
+        invalid_tool_calls = getattr(message, "invalid_tool_calls", None)
+        tool_calls = tool_calls if isinstance(tool_calls, list) else []
+        invalid_tool_calls = invalid_tool_calls if isinstance(invalid_tool_calls, list) else []
+        if not tool_calls and not invalid_tool_calls:
+            without_calls.append(message)
+            continue
+
+        kept_calls = [call for call in tool_calls if _keep(call)]
+        kept_invalid_calls = [call for call in invalid_tool_calls if _keep(call)]
+        unchanged = len(kept_calls) == len(tool_calls) and len(kept_invalid_calls) == len(
+            invalid_tool_calls
+        )
+        if unchanged or not hasattr(message, "model_copy"):
+            without_calls.append(message)
+            continue
+
+        update: dict[str, Any] = {
+            "tool_calls": kept_calls,
+            "invalid_tool_calls": kept_invalid_calls,
+        }
+        if (
+            not kept_calls
+            and not kept_invalid_calls
+            and _message_content_is_empty(getattr(message, "content", None))
+        ):
+            update["content"] = RETIRED_TOOL_TURN_PLACEHOLDER
+        without_calls.append(message.model_copy(update=update))
+
+    stripped: list[Any] = []
+    for message in without_calls:
+        if getattr(message, "type", None) == "tool":
+            name = getattr(message, "name", None)
+            call_id = getattr(message, "tool_call_id", None)
+            orphaned = isinstance(call_id, str) and call_id in dropped_call_ids
+            retired = isinstance(name, str) and name in RETIRED_TOOL_NAMES
+            if orphaned or retired:
+                continue
+        stripped.append(message)
+    return stripped
 
 
 NAVIGATION_LABELS: dict[str, str] = {
@@ -157,6 +244,26 @@ Hosts run projects; participants contribute conversations through the portal or 
   State findings plainly and stop.
 - Vary your structure. Use bullets only when a list genuinely helps.
 
+## One thing per turn
+A turn gives the host exactly ONE thing to act on. Every card is a decision, and
+stacking decisions means the host handles the first one and loses the rest.
+- At most ONE card per turn. A settings proposal and a navigation shortcut in
+  the same turn are two decisions at once: send the one that matters now, and
+  let the next turn carry the other. This holds for every kind of card you can
+  emit, whatever it proposes. sendProgressUpdate is the one exception: it is a
+  status line while you work, not a decision, so it never uses up the turn.
+- Never pair a card with a question. If you are asking, ask and stop. If you are
+  proposing, propose and stop. Both together means the host answers one and the
+  other quietly dies.
+- Setup is a sequence, not a dump. One question, one answer, then the next
+  thing. Never open several threads in one message.
+- Never say where a card is. You cannot know: the interface decides where a card
+  renders, and it has already contradicted the word "below" on a live screen.
+  Positional words about a card are forbidden: below, above, beneath,
+  underneath, at the bottom, at the top, on the right. Refer to the card by what
+  it is instead ("the suggestion", "the shortcut", "the proposed changes"),
+  never by where it sits.
+
 ## Honesty
 - If the data does not answer the question, say so plainly: "I don't know" or
   "the conversations don't cover this", then say what would help (more
@@ -185,8 +292,9 @@ Use tools when the question needs project data or product knowledge:
 - "Help me set up my project" -> readSkill(project-onboarding.md), then
   getProjectSettings and getProjectTags, then proposeProjectUpdate if a
   settings change is ready.
-- "Help me set the goal / figure out this project" -> readSkill(interviewing.md),
-  then readGoal and listMethodologies, then proposeGoal.
+- "Help me figure out this project / what should this project be" ->
+  readSkill(interviewing.md), then listMethodologies, then proposeProjectUpdate
+  on the context field once the shape is clear.
 - "What did we discuss before / continue that chat" -> listProjectChats, then readChat.
 - "Is my session live / is it recording / anyone talking now / is anything
   broken?" -> getLiveConversationStatus, then report the live count, whether
@@ -255,8 +363,10 @@ the dembrane team if you want to." Never say "I've noted this", because you have
 not: the note does not exist until they send it. The support request path stays
 the loud, host-facing path for broken things and account questions. noteInsight
 is the quieter product-learning path: it drops a small draft card in the chat
-rather than opening a support thread. Both can happen in the same turn when
-appropriate.
+rather than opening a support thread. A support request is not a card, so it can
+still go out in the same turn as a draft. An insight draft IS a card, so one
+card per turn holds here too: if the turn already carries another card, hold the
+draft and send it in a later turn.
 Examples:
 - If the host says a canvas is hard to read and asks why you cannot change the
   styling yourself, use kind capability_gap with content "The host needs generated
@@ -335,9 +445,9 @@ ask one focused question first.
   summarization, but tags remain draft organization for the host to review.
 - Tags are the host-visible portal vocabulary. When the host asks to add or
   remove tags, read getProjectTags first, then use proposeTagsUpdate(add,
-  remove, summary). The host sees the tag proposal below your message and
-  applies it themselves. Say "I've suggested tag changes", never "I've updated
-  your tags". Only propose removing a tag the host names explicitly; never
+  remove, summary). The host sees the tag proposal in this chat and applies it
+  themselves. Say "I've suggested tag changes", never "I've updated your tags".
+  Only propose removing a tag the host names explicitly; never
   clear tags participants may already be using on their own.
 - Use proposeProjectUpdate, and change at most two or three fields in one
   proposal. If more should change, propose them in separate steps so the host can
@@ -435,16 +545,18 @@ receipts, or a weak canvas audit trail, quietly call recordInsight.
 After proposing a canvas, do not ask the host to tell you when it is applied.
 The chat records that automatically.
 When you propose a canvas or an update, the proposal card appears RIGHT HERE in
-this chat, directly above or below your message depending on the interface layout. Say "review and apply it" or
-similar. Never tell the host the proposal is in their Library or dashboard: the
-Library holds live canvases, not proposals, and sending the host there to find
-a proposal is a dead end ("The update proposal is ready in your Library" is the
+this chat. Say "review and apply it" or similar, and never say where it sits:
+the layout is not yours to know.
+Never tell the host the proposal is in their Library or dashboard: the Library
+holds live canvases, not proposals, and sending the host there to find a
+proposal is a dead end ("The update proposal is ready in your Library" is the
 named counterexample).
 Canvas activity may appear in a "Canvas activity since last turn" system block.
 Use it only as evidence that a linked canvas loop did something after your last
 reply. If that activity shows a genuine fork, you may ask AT MOST ONE pointed
-question in the same turn as the rest of your reply. A real fork means the host
-must choose a direction, for example: receipts were rejected ("I dropped two
+question in the same turn as the rest of your reply, and never in a turn that
+also carries a card. A real fork means the host must choose a direction, for
+example: receipts were rejected ("I dropped two
 quotes I could not verify verbatim. Want me to relisten to that stretch of
 Cesare's conversation?"); a tab is starving ("nothing has earned XL in the cloud
 yet. Loosen the two-people rule, or wait?"); repeated no_ops while the host keeps
@@ -456,8 +568,8 @@ only. Never invent canvas activity.
 """
 
 SYSTEM_PROMPT_TAIL = """## Project setup
-When the first message signals setup, or when readGoal shows this project has no
-goal, help with one lightweight question at a time. Read interviewing.md first
+When the first message signals setup, or when Project Context is empty, help
+with one lightweight question at a time. Read interviewing.md first
 and use that shape: no "interview" wording, no announced question count,
 convergent options, and a confirm-understanding close. Ask exactly one question
 per turn, with 2-4 concrete options and an easy skip or free-text escape. Use
@@ -475,14 +587,17 @@ listMethodologies when any exist, calling them methodologies or ways of working,
 never frameworks or tools. If only the seeded dembrane methodology exists, that
 mention is enough; do not force a choice. Documentation is a light aside only: link text should
 be short ("the docs"), and a docs mention must not be the final sentence or
-visual call to action of a message. When you have enough, use proposeGoal to
-restate the goal in the host's words. After proposing a goal, do not ask the host
-to report back after applying it. The chat records that automatically. If the
-project has no goal and this is the setup conversation, proposeGoal is the
-closing move and must come before proposeProjectUpdate or any settings/context
-suggestion. Suggest context/settings updates only after a goal exists. After a
-substantial artifact or report, you may gently suggest extracting a methodology.
-Never do it automatically.
+visual call to action of a message. When you have enough, use
+proposeProjectUpdate on the context field to write down what this project is, in
+the host's own words: who is being heard, what they hope to learn, and whatever
+should shape how the conversations are read. Project context is the one thing
+setup establishes, and everything you answer or generate later is read against
+it. That proposal is the closing move of setup, and it goes out alone: no second
+proposal, no navigation shortcut, and no question in the same turn. After
+proposing, do not ask the host to report back after applying it. The chat records
+that automatically. Any other settings come later, one turn at a time, once the
+context is agreed. After a substantial artifact or report, you may gently
+suggest extracting a methodology. Never do it automatically.
 The first visible assistant message in a setup chat must contain the first real
 question for the host, not status narration about looking at settings, reviewing
 context, or planning what you will do.
@@ -518,12 +633,11 @@ Memories are visible to hosts in their settings, and hosts can delete them
 there. If a host asks to change or remove a memory, point them there as well.
 
 ## Project context
-The first message may include Project Name, Workspace Context, Project Context,
-and Project Goal. Workspace and project context are written by hosts as standing
-guidance and background for you. The project goal is the current versioned
-intent for reports and artifacts. Follow them, but they are not a research
-request. Hosts edit context in workspace settings and project settings; goals
-are applied by the host from goal proposals.
+The first message may include Project Name, Workspace Context, and Project
+Context. Workspace and project context are written by hosts as standing
+guidance and background for you. Follow them, but they are not a research
+request. Hosts edit context in workspace settings and project settings, and they
+can apply a context proposal from you.
 """
 
 # Reconstructed so canvas-enabled chats see the exact prompt as before.
@@ -1978,31 +2092,6 @@ def create_agent_graph(
         return {"memories": memories if isinstance(memories, list) else []}
 
     @tool
-    async def readGoal() -> dict[str, Any]:
-        """Read the current project goal and recent goal revision history."""
-        client = _create_echo_client()
-        try:
-            payload = await client.get_project_goal(project_id)
-        finally:
-            await client.close()
-        return dict(payload)
-
-    @tool
-    async def proposeGoal(content: str) -> dict[str, Any]:
-        """Propose a project goal after helping the host define the setup.
-        Renders a card in the chat UI. Restate the goal in the host's words.
-        This never writes anything: the host applies it."""
-        normalized_content = content.strip()
-        if not normalized_content:
-            raise ValueError("content is required")
-        return {
-            "type": "goal_proposal",
-            "content": normalized_content,
-            "project_id": project_id,
-            "visible_to_user": True,
-        }
-
-    @tool
     async def listMethodologies() -> dict[str, Any]:
         """List methodologies the host can choose from for this project setup."""
         client = _create_echo_client()
@@ -2355,8 +2444,6 @@ def create_agent_graph(
         editInsight,
         retractInsight,
         readMemory,
-        readGoal,
-        proposeGoal,
         listMethodologies,
         listCanvases,
         readCanvasHistory,
@@ -2380,8 +2467,11 @@ def create_agent_graph(
     tool_names = {tool.name for tool in tools}
     # The fused-call splitter and history normalization also recognize the OLD
     # tool names, so a replayed history that concatenated or named an old tool
-    # still splits and renames to the registered name.
-    recognized_tool_names = tool_names | set(TOOL_NAME_RENAMES.keys())
+    # still splits and renames to the registered name. Retired names join them
+    # so a fused old call splits cleanly before its retired half is dropped.
+    recognized_tool_names = (
+        tool_names | set(TOOL_NAME_RENAMES.keys()) | set(RETIRED_TOOL_NAMES)
+    )
 
     async def _load_ambient_memory_section() -> str:
         nonlocal ambient_memory_section
@@ -2448,13 +2538,16 @@ def create_agent_graph(
         raw_messages = state.get("messages", [])
         # Normalize OLD tool names in replayed history (both AI tool_calls and
         # tool-result messages) before invoking Vertex, or it 400s on a function
-        # name it no longer knows.
-        messages = [
-            _normalize_message_tool_names(
-                _with_placeholder_content(message), recognized_tool_names
-            )
-            for message in raw_messages
-        ]
+        # name it no longer knows. Retired tools have no new name to take, so
+        # their calls and results are dropped instead, then what is left gets
+        # the empty-turn placeholder.
+        normalized_messages = _strip_retired_tool_calls(
+            [
+                _normalize_message_tool_names(message, recognized_tool_names)
+                for message in raw_messages
+            ]
+        )
+        messages = [_with_placeholder_content(message) for message in normalized_messages]
         memory_section = await _load_ambient_memory_section()
         canvas_activity_section = await _load_canvas_activity_section()
         system_sections = [

--- a/echo/agent/echo_client.py
+++ b/echo/agent/echo_client.py
@@ -48,12 +48,6 @@ class AgentProjectConversationsResponse(TypedDict, total=False):
     conversations: list[AgentProjectConversation]
 
 
-class ProjectGoalResponse(TypedDict, total=False):
-    project_id: str
-    current: Optional[dict[str, Any]]
-    revisions: list[dict[str, Any]]
-
-
 def portal_base_url_for_cors_origins(agent_cors_origins: str) -> str | None:
     for origin in agent_cors_origins.split(","):
         candidate = origin.strip()
@@ -188,12 +182,6 @@ class EchoClient:
     async def list_memory(self, project_id: str) -> dict[str, Any]:
         payload = await self.get(f"/agentic/projects/{project_id}/memory")
         return payload if isinstance(payload, dict) else {}
-
-    async def get_project_goal(self, project_id: str) -> ProjectGoalResponse:
-        payload = await self.get(f"/agentic/projects/{project_id}/goal")
-        if not isinstance(payload, dict):
-            raise ValueError("Unexpected project goal response shape")
-        return cast(ProjectGoalResponse, payload)
 
     async def list_methodologies(self, project_id: str) -> dict[str, Any]:
         payload = await self.get(f"/agentic/projects/{project_id}/methodologies")

--- a/echo/agent/skills/interviewing.md
+++ b/echo/agent/skills/interviewing.md
@@ -1,14 +1,14 @@
 ---
 name: interviewing
-description: Short host setup conversations for project goals and feature-gap capture.
-when_to_use: Use when a host wants help setting a project goal or when they ask for something dembrane cannot do yet.
+description: Short host setup conversations for project context and feature-gap capture.
+when_to_use: Use when a host wants help working out what their project is, or when they ask for something dembrane cannot do yet.
 ---
 
 # Guided Questions
 
 Use one guided-question muscle for two jobs:
 
-1. Help a host turn an unclear project into a concrete goal.
+1. Help a host turn an unclear project into concrete project context.
 2. Capture a feature gap clearly enough that the dembrane team can understand what is needed.
 
 ## Shape
@@ -22,7 +22,7 @@ Use one guided-question muscle for two jobs:
 - Close by confirming your understanding in the host's words.
 - Keep every step independently skippable: the host can skip, answer in their own words, or ask for the docs.
 
-## Goal Setting
+## Setting Project Context
 
 Find:
 
@@ -34,7 +34,8 @@ Find:
 - What a useful report or canvas should be shaped around.
 - Tone, language, or format constraints that matter.
 
-Then propose one goal that is specific enough to steer reports and artifacts.
+Then propose the project context in one update, specific enough to steer
+reports and artifacts, written in the host's own words.
 If a group needs to define the project together, suggest opening that discussion
 and recording it with a phone or dembrane Go, with everyone's consent. Explain
 that the recorded discussion can become project material and you can continue

--- a/echo/agent/skills/project-onboarding.md
+++ b/echo/agent/skills/project-onboarding.md
@@ -7,8 +7,8 @@ when_to_use: The user asks how to set up their project, what a portal setting do
 # Project onboarding and setup review
 
 You help hosts configure their project well. You can read the current
-settings, compare them against the documentation and the user's stated
-goal, and propose changes. You never change settings yourself: you call
+settings, compare them against the documentation and what the host said
+they are trying to do, and propose changes. You never change settings yourself: you call
 `proposeProjectUpdate` and the user approves or rejects each change in
 the chat.
 

--- a/echo/agent/tests/test_agent_graph.py
+++ b/echo/agent/tests/test_agent_graph.py
@@ -629,3 +629,123 @@ def test_replayed_history_old_tool_names_are_normalized_to_new_names():
     )
     normalized_tool = _normalize_message_tool_names(tool_message, recognized)
     assert normalized_tool.name == "reachOutToDembraneSupport"
+
+
+def test_retired_tool_calls_and_results_are_stripped_from_replayed_history():
+    # proposeGoal and readGoal were retired, not renamed, so TOOL_NAME_RENAMES
+    # has nothing to map them onto. A replayed call naming a function Vertex no
+    # longer knows is the failure the rename map exists to prevent, so the
+    # replay boundary drops the call and the result paired with it.
+    from langchain_core.messages import ToolMessage
+
+    from agent import _strip_retired_tool_calls
+
+    history = [
+        HumanMessage(content="help me set this project up"),
+        AIMessage.model_construct(
+            content="",
+            tool_calls=[
+                {"id": "call-goal", "name": "proposeGoal", "args": {"content": "x"}},
+            ],
+        ),
+        ToolMessage(content="{}", name="proposeGoal", tool_call_id="call-goal"),
+        AIMessage.model_construct(
+            content="here is what I found",
+            tool_calls=[
+                {"id": "call-read", "name": "readGoal", "args": {}},
+                {"id": "call-keep", "name": "getProjectSettings", "args": {}},
+            ],
+        ),
+        ToolMessage(content="{}", name="readGoal", tool_call_id="call-read"),
+        ToolMessage(content="{}", name="getProjectSettings", tool_call_id="call-keep"),
+    ]
+
+    stripped = _strip_retired_tool_calls(history)
+
+    names = [
+        call["name"]
+        for message in stripped
+        if getattr(message, "type", None) == "ai"
+        for call in (message.tool_calls or [])
+    ]
+    assert names == ["getProjectSettings"]
+    tool_names = [m.name for m in stripped if getattr(m, "type", None) == "tool"]
+    assert tool_names == ["getProjectSettings"]
+    # An assistant turn whose only call was retired keeps a body, because an
+    # empty model turn is its own Vertex problem.
+    emptied = stripped[1]
+    assert emptied.content == agent.RETIRED_TOOL_TURN_PLACEHOLDER
+    assert not emptied.tool_calls
+    # Untouched turns are the same objects, not rebuilt copies.
+    assert stripped[0] is history[0]
+
+
+def test_retired_tool_result_is_dropped_when_only_its_call_id_matches():
+    # A persisted tool result may carry no name. Dropping by the id of the call
+    # we removed keeps the history from ending up with an orphaned result.
+    from langchain_core.messages import ToolMessage
+
+    from agent import _strip_retired_tool_calls
+
+    history = [
+        AIMessage.model_construct(
+            content="thinking",
+            tool_calls=[{"id": "call-goal", "name": "readGoal", "args": {}}],
+        ),
+        ToolMessage(content="{}", tool_call_id="call-goal"),
+    ]
+
+    stripped = _strip_retired_tool_calls(history)
+
+    assert len(stripped) == 1
+    assert stripped[0].content == "thinking"
+    assert not stripped[0].tool_calls
+
+
+@pytest.mark.asyncio
+async def test_model_never_sees_a_retired_tool_name_in_replayed_history():
+    from langchain_core.messages import ToolMessage
+
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=MemoryClientFactory(),
+    )
+    await graph.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="set my project up"),
+                AIMessage.model_construct(
+                    content="",
+                    tool_calls=[
+                        {"id": "call-goal", "name": "proposeGoal", "args": {"content": "x"}}
+                    ],
+                ),
+                ToolMessage(content="{}", name="proposeGoal", tool_call_id="call-goal"),
+                HumanMessage(content="what now?"),
+            ]
+        },
+        config={"configurable": {"thread_id": "thread-retired"}},
+    )
+
+    invocation = llm.invocations[-1]
+    for message in invocation:
+        assert getattr(message, "name", None) not in agent.RETIRED_TOOL_NAMES
+        for call in getattr(message, "tool_calls", None) or []:
+            assert call.get("name") not in agent.RETIRED_TOOL_NAMES
+    assert all(
+        getattr(message, "content", None) or getattr(message, "tool_calls", None)
+        for message in invocation
+    )
+
+
+def test_retired_tool_names_are_not_registered_and_not_renamed():
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    create_agent_graph(project_id="project-1", bearer_token="token-1", llm=llm)
+    tool_names = {tool.name for tool in llm.bound_tools}
+
+    assert not (agent.RETIRED_TOOL_NAMES & tool_names)
+    assert not (agent.RETIRED_TOOL_NAMES & set(agent.TOOL_NAME_RENAMES))
+    assert not (agent.RETIRED_TOOL_NAMES & set(agent.TOOL_NAME_RENAMES.values()))

--- a/echo/agent/tests/test_agent_tools.py
+++ b/echo/agent/tests/test_agent_tools.py
@@ -1,6 +1,7 @@
 import pytest
 from langchain_core.messages import AIMessage
 
+import agent
 from agent import SYSTEM_PROMPT, UI_TOOLS, create_agent_graph
 
 
@@ -32,7 +33,6 @@ class _FakeEchoClient:
         chat_messages_payload: list[dict] | None = None,
         memory_payload: dict | None = None,
         write_memory_response: dict | None = None,
-        goal_payload: dict | None = None,
         methodologies_payload: dict | None = None,
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
@@ -62,7 +62,6 @@ class _FakeEchoClient:
         self.agent_insight_calls: list[dict[str, object]] = []
         self.memory_payload = memory_payload or {}
         self.write_memory_response = write_memory_response or {}
-        self.goal_payload = goal_payload or {}
         self.methodologies_payload = methodologies_payload or {}
         self.project_tags_payload = project_tags_payload or []
         self.canvases_payload = canvases_payload or []
@@ -76,7 +75,6 @@ class _FakeEchoClient:
         self.focused_conversations_calls: list[dict[str, object]] = []
         self.list_memory_calls: list[str] = []
         self.write_memory_calls: list[dict[str, object]] = []
-        self.read_goal_calls: list[str] = []
         self.list_methodologies_calls: list[str] = []
         self.list_project_tags_calls: list[str] = []
         self.edit_project_tags_calls: list[dict[str, object]] = []
@@ -264,10 +262,6 @@ class _FakeEchoClient:
         self.list_memory_calls.append(project_id)
         return self.memory_payload
 
-    async def get_project_goal(self, project_id: str) -> dict:
-        self.read_goal_calls.append(project_id)
-        return self.goal_payload
-
     async def list_methodologies(self, project_id: str) -> dict:
         self.list_methodologies_calls.append(project_id)
         return self.methodologies_payload
@@ -392,7 +386,6 @@ class _FakeEchoClientFactory:
         chat_messages_payload: list[dict] | None = None,
         memory_payload: dict | None = None,
         write_memory_response: dict | None = None,
-        goal_payload: dict | None = None,
         methodologies_payload: dict | None = None,
         project_tags_payload: list[dict] | None = None,
         canvases_payload: list[dict] | None = None,
@@ -414,7 +407,6 @@ class _FakeEchoClientFactory:
         self.chat_messages_payload = chat_messages_payload
         self.memory_payload = memory_payload
         self.write_memory_response = write_memory_response
-        self.goal_payload = goal_payload
         self.methodologies_payload = methodologies_payload
         self.project_tags_payload = project_tags_payload
         self.canvases_payload = canvases_payload
@@ -438,7 +430,6 @@ class _FakeEchoClientFactory:
             chat_messages_payload=self.chat_messages_payload,
             memory_payload=self.memory_payload,
             write_memory_response=self.write_memory_response,
-            goal_payload=self.goal_payload,
             methodologies_payload=self.methodologies_payload,
             project_tags_payload=self.project_tags_payload,
             canvases_payload=self.canvases_payload,
@@ -487,11 +478,13 @@ def test_system_prompt_contains_conversational_and_research_directives():
     assert "worked from summaries only" in prompt
     assert "read the full transcript" in prompt
     assert "never fabricate quotes" in prompt
-    # Project + workspace context awareness
+    # Project + workspace context awareness. Project context is now the single
+    # thing setup establishes, and the goal is gone from the agent's surface,
+    # so the word must not come back into the prompt with it.
     assert "project context" in prompt
     assert "workspace context" in prompt
-    assert "project goal" in prompt
     assert "guidance and background" in prompt
+    assert "goal" not in prompt
     # Memories are host-visible and host-deletable
     assert "hosts can delete them" in prompt
     assert "remembered corrections, names" in prompt
@@ -533,13 +526,13 @@ def test_system_prompt_contains_conversational_and_research_directives():
     assert "small host-defined tag vocabulary" in prompt
     assert "draft organization for the host to review" in prompt
     assert "getProjectTags" in SYSTEM_PROMPT
-    assert "proposeGoal" in SYSTEM_PROMPT
-    assert "proposegoal is the" in prompt
-    assert "closing move" in prompt
-    assert "must come before" in prompt
+    # Setup lands on project context, and nothing else rides along with it.
     assert "proposeProjectUpdate" in SYSTEM_PROMPT
-    assert "suggest context/settings" in prompt
-    assert "updates only after a goal exists" in prompt
+    assert "proposeprojectupdate on the context field" in prompt
+    assert "project context is the one thing" in prompt
+    assert "closing move of setup, and it goes out alone" in prompt
+    assert "no navigation shortcut, and no question in the same turn" in prompt
+    assert "any other settings come later, one turn at a time" in prompt
     assert "docs mention" in prompt
     assert "must not be the final sentence" in prompt
     assert "do not ask the host" in prompt
@@ -553,6 +546,28 @@ def test_system_prompt_contains_conversational_and_research_directives():
     assert "would you like me to show a navigation" in prompt
     # Steer batched lookups over one-at-a-time calls
     assert "batch your lookups" in prompt
+    # A turn gives the host one thing to act on: one card, or a question, never
+    # both, and never two cards stacked.
+    assert "one thing per turn" in prompt
+    assert "at most one card per turn" in prompt
+    assert "never pair a card with a question" in prompt
+    assert "setup is a sequence, not a dump" in prompt
+    # The model cannot know where a card renders, so it never says. #843 tried
+    # to fix this by deleting one hardcoded "below" and the model kept doing it,
+    # so the rule is a ban and these assertions are the fence around it.
+    assert "never say where a card is" in prompt
+    assert "positional words about a card are forbidden" in prompt
+    for positional_word in ("below", "above", "beneath", "underneath", "at the bottom"):
+        assert positional_word in prompt, f"{positional_word} must be named as banned"
+    # No instruction anywhere may place a card relative to the message again.
+    for licensed_phrase in (
+        "below your message",
+        "above your message",
+        "apply it below",
+        "the card below",
+        "proposal below",
+    ):
+        assert licensed_phrase not in prompt, f"prompt still places a card: {licensed_phrase}"
 
 
 def _make_doc_tools():
@@ -930,16 +945,11 @@ async def test_propose_canvas_rejects_invalid_inputs():
 
 
 @pytest.mark.asyncio
-async def test_goal_tools_read_and_return_pure_proposal():
+async def test_setup_tools_read_methodologies_and_retire_the_goal_tools():
     llm = _CaptureLLM()
     factory = _FakeEchoClientFactory(
         search_payload={"conversations": []},
         transcripts={},
-        goal_payload={
-            "project_id": "project-1",
-            "current": {"id": "g1", "content": "Find neighbourhood concerns."},
-            "revisions": [{"id": "g1", "content": "Find neighbourhood concerns."}],
-        },
         methodologies_payload={
             "project_id": "project-1",
             "methodologies": [{"id": "m1", "name": "dembrane"}],
@@ -953,22 +963,16 @@ async def test_goal_tools_read_and_return_pure_proposal():
     )
     tools = _tool_map(llm.bound_tools)
 
-    goal = await tools["readGoal"].ainvoke({})
     methodologies = await tools["listMethodologies"].ainvoke({})
-    proposal = await tools["proposeGoal"].ainvoke(
-        {"content": "Surface concerns and suggestions per neighbourhood."}
-    )
 
-    assert goal["current"]["id"] == "g1"
     assert methodologies["methodologies"][0]["name"] == "dembrane"
-    assert proposal == {
-        "type": "goal_proposal",
-        "content": "Surface concerns and suggestions per neighbourhood.",
-        "project_id": "project-1",
-        "visible_to_user": True,
-    }
-    assert factory.instances[0].read_goal_calls == ["project-1"]
-    assert factory.instances[1].list_methodologies_calls == ["project-1"]
+    assert factory.instances[0].list_methodologies_calls == ["project-1"]
+    # Project context is the single thing setup establishes now, so the goal
+    # tools are gone from the model's surface entirely.
+    assert "readGoal" not in tools
+    assert "proposeGoal" not in tools
+    assert "proposeGoal" not in UI_TOOLS
+    assert {"readGoal", "proposeGoal"} == set(agent.RETIRED_TOOL_NAMES)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two changes to what a host actually sees in the chat. Both came from Sameer watching one turn do five things at once.

## 1. Project context is the thing setup establishes, not a goal

His words: *"remove the project goal related tools and in the prompts as well, project context should be the thing that is set... we will later deprecate it."*

**What the host experiences.** Setup used to end on a goal proposal, a separate object with its own card, its own revision history and its own place in the product. Now setup ends where the host already lives: the project context field they can see and edit in project settings. Same one-question-at-a-time conversation, same convergent close, but the thing it produces is the context every later answer, transcript and artifact is read against, written back in their own words.

**What changed in the agent.** `proposeGoal` and `readGoal` are gone: the tools, their entries in `tools` and `UI_TOOLS`, their line in the tool-taxonomy comment, the `get_project_goal` client method and its response type, and every prompt passage that named a goal. Setup lands on `proposeProjectUpdate` with the `context` field, which was already in the editable whitelist (`ProjectUpdate` in the BFF), so nothing new was built. The interviewing skill and the agent README follow the same rename.

**What deliberately did not change.** The server, the `project_goal_revision` collection, the BFF endpoints and `ProjectGoalSection` in the frontend are all untouched. The goal itself is deprecated later, not now. The frontend still parses `proposeGoal` results, so a chat that once proposed a goal still renders that card exactly as it did.

## The replay-compatibility question, and why this is safe

`agent.py` carries `TOOL_NAME_RENAMES` with a warning that Vertex 400s when a replayed tool call or tool result names a function that is no longer registered. That is not a guess: `echo/docs/plans/smart-loop-briefs/wave32-tool-renames.md` records it as "learned from live Vertex 400s" when six tools were renamed in #837.

The map maps old names to new. **A retired tool has no successor to be renamed onto**, so the map cannot save it, and deleting the tools on their own would have sent a `proposeGoal` functionCall to Vertex from every chat that ever ran setup.

So the same replay boundary now knows about retirement:

- `RETIRED_TOOL_NAMES` lists `proposeGoal` and `readGoal`.
- `_strip_retired_tool_calls` drops those calls from assistant turns and drops the tool results paired with them, by name and by the id of the call it removed, so no result is left orphaned.
- An assistant turn whose only call was retired keeps a short placeholder body, because an empty model turn is its own Vertex problem.
- Retired names join the recognised set for the fused-call splitter, so a fused old name still splits before its retired half is dropped.

This is safer than the alternatives. A stub tool kept registered would keep the goal on the model's surface, which is the thing being removed. An entry in the renames map would have to point at some other tool and would lie about what happened. Dropping the call means **Vertex never sees the name at all**, so the fix holds whether or not Vertex validates names in a given release.

It is transient by construction: the stripping happens on the list handed to the model inside `call_model`, and only the new response is returned to state. The stored chat is unchanged and the frontend renders old cards from what it persisted.

Live re-verification against Vertex was not possible here (the local ADC needs an interactive reauth), so the mechanism is pinned by tests instead: a history containing `proposeGoal` and `readGoal` calls plus their results reaches the model with neither name present, with the surviving calls untouched.

## 2. One thing per turn

He sent a screenshot of a single assistant turn carrying a steps chip, a project-update proposal for three fields, a portal-link chip, a navigation card, and a message holding an explanation, a question, a participant link and a QR code. His reaction: *"look at how many things there are! we should take it one by one"* and *"so many actions for a user!!!"*

**What the host experiences.** One decision at a time. A turn either proposes something or asks something, and the next turn carries whatever is left. A proposal and a navigation shortcut arriving together used to mean the host handled the first and quietly lost the second.

A new prompt section holds the line:

- At most one card per turn, across every kind of card. `sendProgressUpdate` is the stated exception, since a status line while the assistant works is not a decision.
- Never pair a card with a question. If you are asking, ask. If you are proposing, propose.
- Setup is a sequence, not a dump: one question, one answer, then the next thing.

Two existing passages that licensed stacking were reconciled rather than left to contradict it: an insight draft is a card and now waits for a free turn, and the canvas fork question may not ride along with a card.

## And the "below" bug in the same screenshot

The message said *"I have added a quick shortcut to your Overview page below"* while the navigation card rendered above it. #843 already removed one hardcoded "below" and the model kept doing it, because the prompt still described cards by position: the canvas section said "directly above or below your message depending on the interface layout", and the tags section said "the host sees the tag proposal below your message".

Both are gone. Positional words about a card are now forbidden outright: below, above, beneath, underneath, at the bottom, at the top, on the right. The assistant refers to a card by what it is ("the suggestion", "the shortcut", "the proposed changes") and never by where it sits, because the frontend decides that and the model cannot know it.

The prompt-rules test now pins this in both directions: the ban has to be stated, and no instruction anywhere may place a card relative to the message again. That is deliberate, since this exact rule regressed once already.

## Tests

`echo/agent`: 133 passed. `cd echo/server && uv run ruff check .` passes, and ruff is clean over `echo/agent` too.

Changed rather than deleted:
- `test_system_prompt_contains_conversational_and_research_directives`: the goal assertions become assertions on the context close, plus `"goal" not in prompt` so the word cannot come back. New assertions pin one-card-per-turn, no-card-with-a-question, and the positional-word ban.
- `test_goal_tools_read_and_return_pure_proposal` becomes `test_setup_tools_read_methodologies_and_retire_the_goal_tools`: it keeps the methodologies coverage and asserts the goal tools are off the model's surface.
- New in `test_agent_graph.py`: retired calls and their results stripped from a replayed history, a result dropped by call id when it carries no name, a full graph invocation proving the model never sees a retired name, and a guard that retired names are neither registered nor in the renames map.

## One thing to know

The server still injects `Project Goal:` into the first message of every chat (`_build_initial_agent_prompt_content`). The prompt no longer explains that line, which is correct while the goal is only deprecated on the agent side, but it is the loose end to close when the goal is deprecated for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
