### PR TITLE
ECHO-917 ECHO-918 fix(agentic): stop empty model turns from 400ing Vertex, and sweep abandoned runs

### DIFF
--- a/echo/agent/agent.py
+++ b/echo/agent/agent.py
@@ -798,6 +798,55 @@ def _normalize_message_tool_names(message: Any, tool_names: set[str]) -> Any:
     return _normalize_fused_tool_calls(message, tool_names)
 
 
+# Blocks that produce no Vertex Part on their own. Verified against the
+# connector's serializer in tests/test_vertex_part_contract.py: a signature
+# block only rides along with a tool call, it never becomes a part itself.
+_PARTLESS_CONTENT_BLOCK_TYPES = {"function_call_signature"}
+
+
+def _message_has_tool_calls(message: Any) -> bool:
+    tool_calls = getattr(message, "tool_calls", None)
+    return isinstance(tool_calls, list) and len(tool_calls) > 0
+
+
+def _is_blank_content_block(item: Any) -> bool:
+    """True when this content block contributes no Vertex Part.
+
+    Unknown block types return False (assume they render), so widening this
+    can only ever keep a turn, never silently delete a real one."""
+    if isinstance(item, str):
+        return not item.strip()
+    if isinstance(item, dict):
+        block_type = item.get("type")
+        if block_type in _PARTLESS_CONTENT_BLOCK_TYPES:
+            return True
+        if block_type == "text":
+            text = item.get("text")
+            return not isinstance(text, str) or not text.strip()
+    return False
+
+
+def _is_empty_ai_turn(message: Any) -> bool:
+    """True when this AI turn would serialize to a Vertex Content with zero
+    parts, which the API rejects outright with "must include at least one parts
+    field", killing the stream. Gemini answers the automatic nudge that way
+    sometimes. Such a turn carries nothing, so drop it rather than invent
+    placeholder text. Turns with tool calls always produce parts, so they are
+    never dropped."""
+    if getattr(message, "type", None) != "ai":
+        return False
+    if _message_has_tool_calls(message):
+        return False
+    content = getattr(message, "content", None)
+    if not content:
+        return True
+    if isinstance(content, str):
+        return not content.strip()
+    if isinstance(content, list):
+        return all(_is_blank_content_block(item) for item in content)
+    return False
+
+
 AUTOMATIC_NUDGE_TOOL_CALL_INTERVAL = 6
 AUTOMATIC_NUDGE_TEMPLATE = (
     "<Automatic Nudge> This is a system reminder, not a message from the host. "
@@ -927,10 +976,6 @@ def create_agent_graph(
 
         automatic_nudge_milestones.add(milestone)
         return AUTOMATIC_NUDGE_TEMPLATE.format(tool_call_count=milestone), milestone
-
-    def _message_has_tool_calls(message: Any) -> bool:
-        tool_calls = getattr(message, "tool_calls", None)
-        return isinstance(tool_calls, list) and len(tool_calls) > 0
 
     def _keyword_guardrail_result(
         *,
@@ -2454,6 +2499,7 @@ def create_agent_graph(
                 _with_placeholder_content(message), recognized_tool_names
             )
             for message in raw_messages
+            if not _is_empty_ai_turn(message)
         ]
         memory_section = await _load_ambient_memory_section()
         canvas_activity_section = await _load_canvas_activity_section()
@@ -2488,7 +2534,8 @@ def create_agent_graph(
         if should_retry_after_nudge:
             nudge_retry_milestones.add(nudge_milestone)
             retry_messages = list(invocation_messages)
-            retry_messages.append(response)
+            if not _is_empty_ai_turn(response):
+                retry_messages.append(response)
             retry_messages.append(SystemMessage(content=POST_NUDGE_CONTINUATION_SYSTEM_PROMPT))
             response = _normalize_fused_tool_calls(
                 await llm_with_tools.ainvoke(retry_messages),

--- a/echo/agent/tests/test_agent_graph.py
+++ b/echo/agent/tests/test_agent_graph.py
@@ -378,6 +378,167 @@ async def test_model_never_sees_its_own_empty_tool_call_turns():
         assert turn.tool_calls, "tool_calls must be preserved on the placeholder turn"
 
 
+def _empty_ai_turns(invocation: list[object]) -> list[object]:
+    return [
+        message
+        for message in invocation
+        if getattr(message, "type", None) == "ai"
+        and not getattr(message, "tool_calls", None)
+        and not getattr(message, "content", None)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_empty_nudge_reply_is_not_sent_back_in_the_retry_invocation():
+    """Regression: an AI turn with no content and no tool calls serializes to a
+    Vertex Content with zero parts, which 400s and kills the stream. Gemini
+    returns exactly that shape to the automatic nudge sometimes."""
+    llm = SequenceLLM(
+        responses=[
+            _tool_call_response(1),
+            _tool_call_response(2),
+            _tool_call_response(3),
+            _tool_call_response(4),
+            _tool_call_response(5),
+            _tool_call_response(6),
+            AIMessage(content=""),
+            AIMessage(content="done"),
+        ]
+    )
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=MemoryClientFactory(),
+    )
+
+    await graph.ainvoke(
+        {"messages": [HumanMessage(content="hello")]},
+        config={"configurable": {"thread_id": "thread-empty-nudge-reply"}},
+    )
+
+    assert _count_corrective_retry_invocations(llm.invocations) == 1
+    for invocation in llm.invocations:
+        assert not _empty_ai_turns(invocation), "empty AI turn reached the model"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        "   ",
+        [],
+        [""],
+        [{"type": "text", "text": ""}],
+        [{"type": "function_call_signature", "signature": "YWJj", "index": 0}],
+    ],
+    ids=[
+        "empty-str",
+        "blank-str",
+        "empty-list",
+        "list-of-empty-str",
+        "empty-text-block",
+        "signature-only-block",
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_zero_part_content_shape_is_kept_out_of_the_model_input(content):
+    """Each of these shapes serializes to a Vertex Content with zero parts
+    (verified against langchain_google_vertexai), so each is the same 400."""
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=MemoryClientFactory(),
+    )
+
+    await graph.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="hello"),
+                AIMessage(content=content),
+                HumanMessage(content="are you there?"),
+            ]
+        },
+        config={"configurable": {"thread_id": f"thread-zero-parts-{content!r}"}},
+    )
+
+    # History holds exactly one AI turn, the zero-part one. It must be gone,
+    # so the model input carries no AI turn at all.
+    assert llm.invocations
+    replayed_ai_turns = [
+        message for message in llm.invocations[0] if getattr(message, "type", None) == "ai"
+    ]
+    assert not replayed_ai_turns, f"zero-part AI turn {content!r} reached the model"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        [{"type": "text", "text": "real answer"}],
+        ["", {"type": "text", "text": "still says something"}],
+        [{"type": "some_future_block"}],
+    ],
+    ids=["text-block", "mixed-blank-and-text", "unknown-block"],
+)
+@pytest.mark.asyncio
+async def test_ai_turns_that_still_carry_a_part_are_not_dropped(content):
+    """The drop must be narrow: anything that serializes to at least one part
+    has to survive, or replayed history loses real turns."""
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=MemoryClientFactory(),
+    )
+
+    await graph.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="hello"),
+                AIMessage(content=content),
+                HumanMessage(content="are you there?"),
+            ]
+        },
+        config={"configurable": {"thread_id": f"thread-keeps-parts-{content!r}"}},
+    )
+
+    replayed_ai_turns = [
+        message for message in llm.invocations[0] if getattr(message, "type", None) == "ai"
+    ]
+    assert len(replayed_ai_turns) == 1, f"dropped an AI turn that still had parts: {content!r}"
+
+
+@pytest.mark.asyncio
+async def test_empty_ai_turn_in_replayed_history_never_reaches_the_model():
+    """Same 400, other entry point: an empty AI turn already in the thread's
+    history must be dropped when the next turn replays it."""
+    llm = SequenceLLM(responses=[AIMessage(content="done")])
+    graph = create_agent_graph(
+        project_id="project-1",
+        bearer_token="token-1",
+        llm=llm,
+        echo_client_factory=MemoryClientFactory(),
+    )
+
+    await graph.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="hello"),
+                AIMessage(content=""),
+                HumanMessage(content="are you there?"),
+            ]
+        },
+        config={"configurable": {"thread_id": "thread-empty-history-turn"}},
+    )
+
+    assert llm.invocations
+    for invocation in llm.invocations:
+        assert not _empty_ai_turns(invocation), "empty AI turn reached the model"
+
+
 @pytest.mark.asyncio
 async def test_ambient_memory_is_injected_into_first_model_invocation():
     llm = SequenceLLM(responses=[AIMessage(content="done")])

--- a/echo/agent/tests/test_vertex_part_contract.py
+++ b/echo/agent/tests/test_vertex_part_contract.py
@@ -1,0 +1,116 @@
+"""Pins the langchain_google_vertexai assumption that _is_empty_ai_turn rests on.
+
+Vertex rejects any request containing a Content with zero parts ("must include
+at least one parts field") and that kills the whole stream. _is_empty_ai_turn
+drops exactly the AI turns that would serialize that way, which means its
+correctness depends on the connector's part-building, not on our own code. This
+file asserts that dependency directly, so a connector upgrade that changes which
+shapes produce parts fails here instead of in production.
+
+The connector entry point is private. If an upgrade renames it these tests skip
+rather than fail red, since a rename is not by itself a behavior change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage, HumanMessage
+
+from agent import _is_empty_ai_turn
+
+_parse_chat_history_gemini = pytest.importorskip(
+    "langchain_google_vertexai.chat_models"
+).__dict__.get("_parse_chat_history_gemini")
+ImageBytesLoader = pytest.importorskip("langchain_google_vertexai._image_utils").__dict__.get(
+    "ImageBytesLoader"
+)
+
+pytestmark = pytest.mark.skipif(
+    _parse_chat_history_gemini is None or ImageBytesLoader is None,
+    reason="connector serializer moved; part-count contract cannot be checked",
+)
+
+# Shapes that serialize to zero parts, so Vertex 400s on them.
+ZERO_PART_CONTENT: list[Any] = [
+    "",
+    [],
+    [""],
+    [{"type": "text", "text": ""}],
+    [{"type": "function_call_signature", "signature": "YWJj", "index": 0}],
+]
+
+# Shapes that still carry a part, so dropping them would lose a real turn.
+PART_BEARING_CONTENT: list[Any] = [
+    "real answer",
+    [{"type": "text", "text": "real answer"}],
+    ["", {"type": "text", "text": "still says something"}],
+]
+
+# Deliberate over-strictness: the connector keeps whitespace as a part, we drop
+# it anyway. A whitespace-only turn carries no information, so this loses
+# nothing. Listed here so the mismatch stays intentional rather than accidental.
+DROPPED_DESPITE_HAVING_A_PART: list[Any] = ["   ", ["  "]]
+
+
+def _model_content_parts(content: Any) -> int:
+    """Serialize an AI turn the way the connector would and count its parts.
+
+    The turn follows a tool result so it starts its own model Content; appended
+    after another model turn the connector would merge it and hide the problem.
+    """
+    history = [
+        HumanMessage(content="hi"),
+        AIMessage(content="", tool_calls=[{"id": "1", "name": "t", "args": {}}]),
+        ToolMessage(content="result", tool_call_id="1", name="t"),
+        AIMessage(content=content),
+    ]
+    result = _parse_chat_history_gemini(history, ImageBytesLoader())
+    messages = result[1] if isinstance(result, tuple) else result
+    last = messages[-1]
+    assert last.role == "model", "expected the AI turn to be its own model Content"
+    return len(last.parts)
+
+
+@pytest.mark.parametrize("content", ZERO_PART_CONTENT, ids=repr)
+def test_zero_part_shapes_are_still_zero_part(content: Any):
+    assert _model_content_parts(content) == 0
+
+
+@pytest.mark.parametrize("content", ZERO_PART_CONTENT, ids=repr)
+def test_every_zero_part_shape_is_dropped_by_the_guard(content: Any):
+    assert _is_empty_ai_turn(AIMessage(content=content)), (
+        "this shape would 400 but the guard lets it through"
+    )
+
+
+@pytest.mark.parametrize("content", PART_BEARING_CONTENT, ids=repr)
+def test_part_bearing_shapes_still_carry_a_part(content: Any):
+    assert _model_content_parts(content) >= 1
+
+
+@pytest.mark.parametrize("content", PART_BEARING_CONTENT, ids=repr)
+def test_the_guard_keeps_every_part_bearing_shape(content: Any):
+    assert not _is_empty_ai_turn(AIMessage(content=content)), (
+        "the guard dropped a turn that Vertex would have accepted"
+    )
+
+
+@pytest.mark.parametrize("content", DROPPED_DESPITE_HAVING_A_PART, ids=repr)
+def test_whitespace_only_content_is_dropped_on_purpose(content: Any):
+    assert _model_content_parts(content) >= 1
+    assert _is_empty_ai_turn(AIMessage(content=content))
+
+
+def test_a_turn_with_tool_calls_is_never_dropped():
+    """Tool calls always produce parts, and dropping one would orphan its
+    ToolMessage."""
+    message = AIMessage(content="", tool_calls=[{"id": "1", "name": "t", "args": {}}])
+    assert _model_content_parts(message.content) == 0, "content alone is partless here"
+    assert not _is_empty_ai_turn(message)
+
+
+def test_unknown_block_types_are_assumed_to_render():
+    """Fail-safe direction: an unrecognized block keeps the turn alive."""
+    assert not _is_empty_ai_turn(AIMessage(content=[{"type": "some_future_block"}]))

--- a/echo/server/dembrane/scheduler.py
+++ b/echo/server/dembrane/scheduler.py
@@ -144,6 +144,14 @@ scheduler.add_job(
     replace_existing=True,
 )
 
+scheduler.add_job(
+    func="dembrane.tasks:task_fail_abandoned_agentic_runs.send",
+    trigger=CronTrigger(minute="*/5"),
+    id="task_fail_abandoned_agentic_runs",
+    name="Fail agentic runs whose executor died mid-turn (stuck in running)",
+    replace_existing=True,
+)
+
 logger = getLogger("dembrane.scheduler")
 
 # Start the scheduler when this module is run directly

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E402
+import json
 import logging
 from typing import Any, Optional
 from logging import getLogger
@@ -24,6 +25,7 @@ from dramatiq.results.backends.redis import RedisBackend as ResultsRedisBackend
 
 from dembrane.utils import generate_uuid, get_utc_timestamp
 from dembrane.sentry import init_sentry
+from dembrane.service import agentic_run_service
 from dembrane.directus import (
     DirectusBadRequest,
     DirectusServerError,
@@ -32,6 +34,7 @@ from dembrane.directus import (
 from dembrane.settings import get_settings
 from dembrane.transcribe import transcribe_conversation_chunk
 from dembrane.async_helpers import run_async_in_new_loop
+from dembrane.agentic_runtime import publish_live_event, get_turn_lease_owner
 from dembrane.conversation_utils import (
     collect_unfinished_conversations,
     collect_unsummarized_conversations,
@@ -3039,6 +3042,105 @@ def _resolve_app_user_id_for_directus_user_id(directus_user_id: object) -> Optio
         return None
     app_user_id = rows[0].get("id")
     return str(app_user_id) if app_user_id else None
+
+
+ABANDONED_AGENTIC_RUN_QUIET_SECONDS = 5 * 60
+AGENT_ABANDONED_ERROR_CODE = "AGENT_ABANDONED"
+AGENT_ABANDONED_MESSAGE = "This run stopped before it finished. Please send your message again."
+
+
+def _agentic_run_looks_alive(run_id: str, quiet_cutoff: datetime) -> bool:
+    """Two independent liveness signals, cheapest first.
+
+    Age is deliberately not one of them: nothing caps a turn's wall-clock time,
+    so an hour-old run can still be healthy.
+    """
+    latest_event = agentic_run_service.get_latest_event(run_id)
+    if latest_event is not None:
+        timestamp = _parse_iso(latest_event.get("timestamp"))
+        if timestamp is not None and timestamp > quiet_cutoff:
+            return True
+
+    # Quiet for a while: a long tool call persists nothing, so fall back to the
+    # turn lease, which the executor refreshes for as long as it lives.
+    turn = agentic_run_service.get_latest_event(run_id, event_type="user.message")
+    turn_seq = int(turn.get("seq") or 0) if turn else 0
+    if turn_seq <= 0:
+        return False
+
+    owner = run_async_in_new_loop(lambda: get_turn_lease_owner(run_id, turn_seq))
+    return owner is not None
+
+
+def _fail_abandoned_agentic_run(run_id: str) -> bool:
+    """Force the same terminal shape the worker's own failure path produces, so
+    the chat settles instead of showing "working" until a reload."""
+    run = agentic_run_service.get_by_id_or_raise(run_id)
+    if run.get("status") != "running":
+        return False
+
+    event = agentic_run_service.append_event(
+        run_id,
+        "run.failed",
+        {
+            "error_code": AGENT_ABANDONED_ERROR_CODE,
+            "message": AGENT_ABANDONED_MESSAGE,
+        },
+    )
+    try:
+        run_async_in_new_loop(
+            lambda: publish_live_event(run_id, json.dumps(event, default=str))
+        )
+    except Exception:
+        logger.warning("failed to publish abandon event for run %s", run_id, exc_info=True)
+
+    agentic_run_service.set_status(
+        run_id,
+        "failed",
+        latest_error=AGENT_ABANDONED_MESSAGE,
+        latest_error_code=AGENT_ABANDONED_ERROR_CODE,
+    )
+    return True
+
+
+@dramatiq.actor(queue_name="network", priority=40)
+def task_fail_abandoned_agentic_runs() -> None:
+    """Terminate agentic runs whose executor died mid-turn.
+
+    A turn runs in-process on the API pod, not in a worker. Every exception path
+    in process_agentic_run sets a terminal status, but a pod restart or OOM kill
+    runs none of them, and reconnects only re-drive `queued` runs. Without this
+    sweep the row stays `running` forever and the chat never settles.
+    """
+    task_logger = getLogger("dembrane.tasks.task_fail_abandoned_agentic_runs")
+    quiet_cutoff = get_utc_timestamp() - timedelta(seconds=ABANDONED_AGENTIC_RUN_QUIET_SECONDS)
+
+    with directus_client_context() as client:
+        running = client.get_items(
+            "project_agentic_run",
+            {
+                "query": {
+                    "filter": {"status": {"_eq": "running"}},
+                    "fields": ["id"],
+                    "limit": -1,
+                }
+            },
+        )
+
+    if not isinstance(running, list) or not running:
+        return
+
+    for row in running:
+        run_id = str(row.get("id") or "")
+        if not run_id:
+            continue
+        try:
+            if _agentic_run_looks_alive(run_id, quiet_cutoff):
+                continue
+            if _fail_abandoned_agentic_run(run_id):
+                task_logger.info("failed abandoned agentic run %s", run_id)
+        except Exception:
+            task_logger.warning("could not sweep agentic run %s", run_id, exc_info=True)
 
 
 @dramatiq.actor(queue_name="network", priority=100)

--- a/echo/server/tests/test_agentic_run_sweep.py
+++ b/echo/server/tests/test_agentic_run_sweep.py
@@ -1,0 +1,152 @@
+"""Tests for task_fail_abandoned_agentic_runs.
+
+A turn executes in-process on the API pod, so a restart or OOM kill leaves the
+run row in `running` forever (no exception handler runs, and reconnects only
+re-drive `queued` runs). The sweep must terminate those, and must NOT terminate
+a healthy long run: there is no wall-clock cap on a turn, so liveness comes from
+the Redis turn lease plus recent events, never from age alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from dembrane.utils import get_utc_timestamp
+
+
+def _iso(delta_seconds: int) -> str:
+    return (get_utc_timestamp() + timedelta(seconds=delta_seconds)).isoformat()
+
+
+class _FakeRunService:
+    def __init__(
+        self,
+        *,
+        latest_event: dict[str, Any] | None,
+        latest_user_message: dict[str, Any] | None,
+        status: str = "running",
+    ) -> None:
+        self._latest_event = latest_event
+        self._latest_user_message = latest_user_message
+        self._status = status
+        self.appended: list[tuple[str, str, dict[str, Any]]] = []
+        self.statuses: list[tuple[str, str]] = []
+
+    def get_latest_event(self, run_id: str, *, event_type: str | None = None):
+        if event_type == "user.message":
+            return self._latest_user_message
+        return self._latest_event
+
+    def get_by_id_or_raise(self, run_id: str) -> dict[str, Any]:
+        return {"id": run_id, "status": self._status}
+
+    def append_event(self, run_id: str, event_type: str, payload: dict[str, Any]):
+        self.appended.append((run_id, event_type, payload))
+        return {"id": "event-1", "seq": 9, "event_type": event_type, "payload": payload}
+
+    def set_status(self, run_id: str, status: str, **_kwargs: Any) -> dict[str, Any]:
+        self.statuses.append((run_id, status))
+        return {"id": run_id, "status": status}
+
+
+def _run_sweep(
+    *,
+    service: _FakeRunService,
+    lease_owner: str | None,
+    running_rows: list[dict[str, Any]] | None = None,
+):
+    from dembrane import tasks as tasks_mod
+
+    client = MagicMock()
+    client.get_items.return_value = (
+        running_rows if running_rows is not None else [{"id": "run-1"}]
+    )
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=client)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch.object(tasks_mod, "directus_client_context", return_value=ctx),
+        patch.object(tasks_mod, "agentic_run_service", service),
+        patch.object(tasks_mod, "run_async_in_new_loop", return_value=lease_owner),
+    ):
+        tasks_mod.task_fail_abandoned_agentic_runs.fn()
+
+    return client
+
+
+def test_only_running_runs_are_considered():
+    service = _FakeRunService(latest_event=None, latest_user_message=None)
+    client = _run_sweep(service=service, lease_owner=None, running_rows=[])
+
+    query = client.get_items.call_args[0][1]["query"]
+    assert query["filter"]["status"] == {"_eq": "running"}
+
+
+def test_run_with_recent_event_is_left_alone():
+    """Events still arriving means the executor is alive."""
+    service = _FakeRunService(
+        latest_event={"seq": 8, "timestamp": _iso(-30)},
+        latest_user_message={"seq": 1, "timestamp": _iso(-600)},
+    )
+    _run_sweep(service=service, lease_owner=None)
+
+    assert service.statuses == []
+    assert service.appended == []
+
+
+def test_quiet_run_holding_its_lease_is_left_alone():
+    """A long tool call can go minutes without persisting an event; the live
+    lease proves the executor is still there."""
+    service = _FakeRunService(
+        latest_event={"seq": 8, "timestamp": _iso(-1800)},
+        latest_user_message={"seq": 1, "timestamp": _iso(-1900)},
+    )
+    _run_sweep(service=service, lease_owner="owner-token-1")
+
+    assert service.statuses == []
+    assert service.appended == []
+
+
+def test_quiet_run_without_a_lease_is_failed_with_an_event():
+    service = _FakeRunService(
+        latest_event={"seq": 8, "timestamp": _iso(-1800)},
+        latest_user_message={"seq": 1, "timestamp": _iso(-1900)},
+    )
+    _run_sweep(service=service, lease_owner=None)
+
+    assert service.statuses == [("run-1", "failed")]
+    assert len(service.appended) == 1
+    run_id, event_type, payload = service.appended[0]
+    assert run_id == "run-1"
+    assert event_type == "run.failed"
+    assert payload["error_code"] == "AGENT_ABANDONED"
+
+
+def test_run_that_reached_a_terminal_status_mid_sweep_is_skipped():
+    service = _FakeRunService(
+        latest_event={"seq": 8, "timestamp": _iso(-1800)},
+        latest_user_message={"seq": 1, "timestamp": _iso(-1900)},
+        status="completed",
+    )
+    _run_sweep(service=service, lease_owner=None)
+
+    assert service.statuses == []
+    assert service.appended == []
+
+
+def test_scheduler_registers_the_sweep():
+    from dembrane import scheduler
+
+    job = scheduler.scheduler.get_job("task_fail_abandoned_agentic_runs")
+    assert job is not None
+
+
+def test_failure_copy_follows_the_style_guide():
+    from dembrane.tasks import AGENT_ABANDONED_MESSAGE
+
+    assert "—" not in AGENT_ABANDONED_MESSAGE
+    assert "successfully" not in AGENT_ABANDONED_MESSAGE.lower()
+    assert " AI " not in f" {AGENT_ABANDONED_MESSAGE} "


### PR DESCRIPTION
Vertex 400 (2 of 5 runs):
- Gemini answers the automatic nudge with a turn that has no content and no tool calls. It serializes to a Content with zero parts, which Vertex rejects and the stream dies.
- Reached the model two ways: the post-nudge retry appended the empty response, and an already-retried milestone left it in state to 400 on the next turn.
- Drop partless AI turns instead of injecting placeholder text. Turns with tool calls are never dropped, so no ToolMessage is orphaned.
- Which shapes are partless belongs to langchain_google_vertexai, so a contract test pins it against the connector's serializer. It caught two shapes we had missed: a list-of-empty-string and a signature-only block.

Stuck runs (1 of 5):
- Turns execute in-process on the API pod, so a restart or OOM kill skips every terminal-status path. Reconnects only re-drive `queued`, so the row stays `running` forever and the chat never settles.
- Add task_fail_abandoned_agentic_runs, every 5 minutes.
- Liveness is a recent event, else the Redis turn lease (refreshed every 10s against a 30s TTL). Not age: nothing caps a turn's wall clock, so an age cutoff would kill healthy long runs.
- Reuses the terminal shape stop_run already produces (run.failed, published, status failed), re-reads status before flipping, and skips the run on any liveness-check error.