### PR TITLE
ECHO-922 feat(agentic): stream assistant text live, stop persisting token chunks

### DIFF
--- a/echo/frontend/src/components/chat/AgenticChatPanel.test.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.test.tsx
@@ -4,6 +4,7 @@ import { I18nProvider } from "@lingui/react";
 import { MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+	act,
 	cleanup,
 	fireEvent,
 	render,
@@ -36,7 +37,7 @@ const RUN_ID = "run-1";
 
 // vi.mock factories are hoisted above every top-level binding, so the state
 // they close over has to be hoisted with them.
-const { runState, stopAgenticRunMock } = vi.hoisted(() => ({
+const { runState, stopAgenticRunMock, streamOptionsRef } = vi.hoisted(() => ({
 	runState: { events: [], status: "running" } as {
 		events: AgenticRunEvent[];
 		status: AgenticRunStatus;
@@ -46,6 +47,14 @@ const { runState, stopAgenticRunMock } = vi.hoisted(() => ({
 		status: "stopping" as const,
 		turn_seq: 1,
 	})),
+	// The live stream's callbacks, captured so tests can drive draft
+	// snapshots and durable events into the panel by hand.
+	streamOptionsRef: {
+		current: null as null | {
+			onEvent: (event: AgenticRunEvent) => void;
+			onDraft?: (draft: { message_id: string; text: string }) => void;
+		},
+	},
 }));
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -76,7 +85,13 @@ vi.mock("@/lib/api", async (importOriginal) => {
 		stopAgenticRun: stopAgenticRunMock,
 		// Never resolves: an in-flight run is one whose stream is still open, and
 		// resolving would let the panel re-read the status and settle.
-		streamAgenticRun: vi.fn(() => new Promise(() => {})),
+		streamAgenticRun: vi.fn(
+			(...args: Parameters<typeof actual.streamAgenticRun>) => {
+				streamOptionsRef.current =
+					args[1] as unknown as typeof streamOptionsRef.current;
+				return new Promise(() => {});
+			},
+		),
 	};
 });
 
@@ -225,6 +240,7 @@ beforeAll(() => {
 beforeEach(() => {
 	window.localStorage.clear();
 	stopAgenticRunMock.mockClear();
+	streamOptionsRef.current = null;
 	runState.events = [];
 	runState.status = "running";
 });
@@ -375,5 +391,57 @@ describe("AgenticChatPanel, tool groups and the live indicator", () => {
 		expect(group.textContent).toContain("Worked through 3 steps");
 		expect(screen.queryByTestId("agentic-run-indicator")).toBeNull();
 		expect(screen.queryByTestId("chat-stop-button")).toBeNull();
+	});
+});
+
+describe("AgenticChatPanel, live draft streaming", () => {
+	it("renders a growing draft bubble and swaps it for the durable message", async () => {
+		runState.status = "running";
+		runState.events = [messageEvent(1, "user", "hello")];
+
+		renderPanel();
+
+		await waitFor(() => expect(streamOptionsRef.current).not.toBeNull());
+
+		// First snapshot appears as an assistant bubble.
+		act(() => {
+			streamOptionsRef.current?.onDraft?.({
+				message_id: "m-1",
+				text: "Working through",
+			});
+		});
+		expect(await screen.findByText(/Working through/)).toBeTruthy();
+
+		// A later snapshot replaces the bubble's text, it does not append one.
+		act(() => {
+			streamOptionsRef.current?.onDraft?.({
+				message_id: "m-1",
+				text: "Working through the transcripts now.",
+			});
+		});
+		expect(
+			await screen.findByText(/Working through the transcripts now\./),
+		).toBeTruthy();
+		expect(screen.queryAllByText(/Working through/)).toHaveLength(1);
+
+		// The durable copy replaces the draft: same text, exactly one bubble.
+		act(() => {
+			streamOptionsRef.current?.onEvent({
+				event_type: "assistant.message",
+				id: 2,
+				payload: {
+					content: "Working through the transcripts now.",
+					message_id: "m-1",
+				},
+				project_agentic_run_id: RUN_ID,
+				seq: 2,
+				timestamp: at(2),
+			});
+		});
+		await waitFor(() =>
+			expect(
+				screen.queryAllByText(/Working through the transcripts now\./),
+			).toHaveLength(1),
+		);
 	});
 });

--- a/echo/frontend/src/components/chat/AgenticChatPanel.tsx
+++ b/echo/frontend/src/components/chat/AgenticChatPanel.tsx
@@ -796,6 +796,13 @@ export const AgenticChatPanel = ({
 	const [isStreaming, setIsStreaming] = useState(false);
 	const [isHydratingStoredRun, setIsHydratingStoredRun] = useState(false);
 	const [streamFailureCount, setStreamFailureCount] = useState(0);
+	// Snapshot of the message being written; the durable assistant.message
+	// with the same message_id replaces it in place.
+	const [liveDraft, setLiveDraft] = useState<{
+		messageId: string;
+		text: string;
+		timestamp: string;
+	} | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [expandedGroupIds, setExpandedGroupIds] = useState<
 		Record<string, boolean>
@@ -818,6 +825,10 @@ export const AgenticChatPanel = ({
 	useEffect(() => {
 		currentRunIdRef.current = runId;
 	}, [runId]);
+
+	useEffect(() => {
+		if (!isRunInFlight) setLiveDraft(null);
+	}, [isRunInFlight]);
 
 	useEffect(() => {
 		if (queryPrefillStartedRef.current) return;
@@ -845,6 +856,30 @@ export const AgenticChatPanel = ({
 		}
 		return names;
 	}, [conversationsQuery.data]);
+
+	// Renders only until its durable copy is in the event log.
+	const liveDraftMessage = useMemo(() => {
+		if (!liveDraft) return null;
+		const durable = events.some(
+			(event) =>
+				event.event_type === "assistant.message" &&
+				asObject(event.payload)?.message_id === liveDraft.messageId,
+		);
+		if (durable) return null;
+		return {
+			content: enrichAgenticContent({
+				content: liveDraft.text,
+				conversationNames,
+				language,
+				projectId,
+				workspaceId: workspaceId ?? "",
+			}),
+			id: "live-draft",
+			role: "assistant" as const,
+			sortSeq: Number.MAX_SAFE_INTEGER,
+			timestamp: liveDraft.timestamp,
+		};
+	}, [liveDraft, events, conversationNames, language, projectId, workspaceId]);
 
 	const timeline = useMemo(() => {
 		const sorted = [...events].sort((a, b) => a.seq - b.seq);
@@ -1150,11 +1185,35 @@ export const AgenticChatPanel = ({
 			try {
 				await streamAgenticRun(targetRunId, {
 					afterSeq: fromSeq,
+					onDraft: (draft) => {
+						if (currentRunIdRef.current !== targetRunId) return;
+						setLiveDraft((previous) => ({
+							messageId: draft.message_id,
+							text: draft.text,
+							timestamp:
+								previous?.messageId === draft.message_id
+									? previous.timestamp
+									: new Date().toISOString(),
+						}));
+					},
 					onEvent: (event) => {
 						if (currentRunIdRef.current !== targetRunId) return;
 						mergeEvents([event]);
 						setAfterSeq((previous) => Math.max(previous, event.seq));
 						setStreamFailureCount(0);
+						if (event.event_type === "assistant.message") {
+							// Same React batch as the merge: draft and durable swap in one paint.
+							const payload = asObject(event.payload);
+							const durableMessageId =
+								typeof payload?.message_id === "string"
+									? payload.message_id
+									: null;
+							setLiveDraft((previous) =>
+								previous && previous.messageId === durableMessageId
+									? null
+									: previous,
+							);
+						}
 						if (event.event_type === "run.failed") {
 							setRunStatus("failed");
 						}
@@ -1213,6 +1272,7 @@ export const AgenticChatPanel = ({
 		setIsSubmitting(false);
 		setIsHydratingStoredRun(false);
 		setStreamFailureCount(0);
+		setLiveDraft(null);
 	}, [chatId, stopStream]);
 
 	useEffect(() => {
@@ -1360,7 +1420,11 @@ export const AgenticChatPanel = ({
 			: tail.kind === "message"
 				? `m:${tail.id}:${tail.content.length}`
 				: `t:${tail.id}:${tail.status}`;
-	// biome-ignore lint/correctness/useExhaustiveDependencies: tailKey and isRunInFlight are triggers, not reads. They exist so a growing tail and the live indicator re-fire this effect.
+	// The draft renders outside the timeline, so it needs its own growth key.
+	const draftKey = liveDraftMessage
+		? `d:${liveDraftMessage.timestamp}:${liveDraftMessage.content.length}`
+		: "";
+	// biome-ignore lint/correctness/useExhaustiveDependencies: tailKey, draftKey and isRunInFlight are triggers, not reads. They exist so a growing tail (timeline or draft) and the live indicator re-fire this effect.
 	useEffect(() => {
 		if (timeline.length === 0) return;
 		if (!hasScrolledInitiallyRef.current) {
@@ -1375,7 +1439,14 @@ export const AgenticChatPanel = ({
 			// run finishes, a single smooth scroll is the nicer motion.
 			scrollToBottom(isStreaming ? "auto" : "smooth");
 		}
-	}, [timeline.length, tailKey, isRunInFlight, isStreaming, scrollToBottom]);
+	}, [
+		timeline.length,
+		tailKey,
+		draftKey,
+		isRunInFlight,
+		isStreaming,
+		scrollToBottom,
+	]);
 
 	useEffect(() => {
 		return () => {
@@ -1404,6 +1475,7 @@ export const AgenticChatPanel = ({
 		setError(null);
 		setIsSubmitting(true);
 		setInput("");
+		setLiveDraft(null);
 		setPendingUserMessage({
 			content: message,
 			focusedConversations: focusedContextConversations,
@@ -1881,11 +1953,19 @@ export const AgenticChatPanel = ({
 							</div>
 						)}
 
-					{/* Last node in the thread, after the newest user message, for as
-					    long as the run is in flight. There is no second indicator by
-					    the composer: one live thing, in the place the eye already is.
-					    Not while the chat is still loading, so the skeleton and the
-					    live line never claim the same space. */}
+					{liveDraftMessage && isRunInFlight && (
+						<div key="live-draft">
+							<ChatHistoryMessage
+								message={toHistoryMessage(liveDraftMessage)}
+								chatMode="agentic"
+							/>
+						</div>
+					)}
+
+					{/* Last node in the thread, below the draft bubble when one is
+					    streaming; hosts the stop control. Not while the chat is still
+					    loading, so the skeleton and the live line never claim the
+					    same space. */}
 					{!showExistingChatLoading && isRunInFlight && (
 						<LiveRunIndicator
 							headline={liveRunStatusText}

--- a/echo/frontend/src/components/chat/agenticToolActivity.test.ts
+++ b/echo/frontend/src/components/chat/agenticToolActivity.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { parseInsightNote, type ToolActivity } from "./agenticToolActivity";
+import { i18n } from "@lingui/core";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { AgenticRunEvent } from "@/lib/api";
+
+import {
+	extractTopLevelToolActivity,
+	parseInsightNote,
+	type ToolActivity,
+} from "./agenticToolActivity";
 
 const baseActivity = (
 	overrides: Partial<ToolActivity> = {},
@@ -144,5 +151,38 @@ describe("parseInsightNote", () => {
 		});
 		const note = parseInsightNote(baseActivity({ rawOutput }));
 		expect(note?.suggestedCapability).toBeNull();
+	});
+});
+
+describe("extractTopLevelToolActivity", () => {
+	// buildHeadline goes through Lingui, which needs an active locale.
+	beforeAll(() => {
+		i18n.load("en", {});
+		i18n.activate("en");
+	});
+
+	const toolEvent = (
+		seq: number,
+		phase: "end" | "start",
+		toolName: string,
+	): AgenticRunEvent => ({
+		event_type: phase === "start" ? "on_tool_start" : "on_tool_end",
+		id: seq,
+		payload: { name: toolName, run_id: `call-${toolName}` },
+		project_agentic_run_id: "run-1",
+		seq,
+		timestamp: "2026-07-09T00:00:00Z",
+	});
+
+	it("hides sendProgressUpdate steps; its output is already a chat message", () => {
+		const activities = extractTopLevelToolActivity([
+			toolEvent(1, "start", "listProjectConversations"),
+			toolEvent(2, "end", "listProjectConversations"),
+			toolEvent(3, "start", "sendProgressUpdate"),
+			toolEvent(4, "end", "sendProgressUpdate"),
+		]);
+
+		expect(activities).toHaveLength(1);
+		expect(activities[0]?.toolName).toBe("listProjectConversations");
 	});
 });

--- a/echo/frontend/src/components/chat/agenticToolActivity.ts
+++ b/echo/frontend/src/components/chat/agenticToolActivity.ts
@@ -203,6 +203,9 @@ const parseToolEvent = (event: AgenticRunEvent): ParsedToolEvent | null => {
 			data?.name,
 			outputKwargs?.name,
 		) ?? "tool";
+	// Its output already appears in the thread as a message; a step row
+	// would say the same thing twice.
+	if (toolName === "sendProgressUpdate") return null;
 	const callId = firstString(
 		payload?.run_id,
 		payload?.runId,

--- a/echo/frontend/src/lib/api.ts
+++ b/echo/frontend/src/lib/api.ts
@@ -1201,6 +1201,12 @@ export type AgenticRunEvent = {
 	timestamp: string;
 };
 
+// Streaming snapshot of the assistant message being written; ephemeral, no seq.
+export type AgenticDraftPayload = {
+	message_id: string;
+	text: string;
+};
+
 export type AgenticRunEventsResponse = {
 	run_id: string;
 	status: AgenticRunStatus;
@@ -1260,6 +1266,7 @@ type StreamAgenticRunOptions = {
 	afterSeq?: number;
 	signal?: AbortSignal;
 	onEvent: (event: AgenticRunEvent) => void;
+	onDraft?: (draft: AgenticDraftPayload) => void;
 	onHeartbeat?: () => void;
 };
 
@@ -1333,6 +1340,23 @@ export const streamAgenticRun = async (
 				if (parsed) {
 					if (parsed.eventType === "heartbeat") {
 						options.onHeartbeat?.();
+					} else if (parsed.eventType === "assistant.draft") {
+						// Drafts have no seq and must never reach the onEvent merge map.
+						if (parsed.data) {
+							try {
+								const frame = JSON.parse(parsed.data) as {
+									payload?: AgenticDraftPayload;
+								};
+								if (
+									typeof frame.payload?.message_id === "string" &&
+									typeof frame.payload?.text === "string"
+								) {
+									options.onDraft?.(frame.payload);
+								}
+							} catch {
+								// Ignore malformed frames and continue streaming.
+							}
+						}
 					} else if (parsed.data) {
 						try {
 							const event = JSON.parse(parsed.data) as AgenticRunEvent;

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4614,7 +4614,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5419,7 +5419,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Error"
 
@@ -5882,11 +5882,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6078,9 +6078,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6724,11 +6724,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6816,7 +6816,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7761,7 +7761,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11354,7 +11354,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11783,7 +11783,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12409,7 +12409,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Send"
 
@@ -14322,7 +14322,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15180,7 +15180,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15779,11 +15779,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15869,7 +15869,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15944,7 +15944,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2245,7 +2245,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3080,7 +3080,7 @@ msgstr "Das Ändern der Sprache während eines aktiven Chats kann unerwartete Er
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4400,7 +4400,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Fehler"
 
@@ -5633,11 +5633,11 @@ msgstr "Ergebnis konnte nicht überarbeitet werden. Bitte versuchen Sie es erneu
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fehler beim Beenden der Aufnahme bei Änderung des Mikrofons. Bitte versuchen Sie es erneut."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5824,9 +5824,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Fokus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6462,11 +6462,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6544,7 +6544,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7331,7 +7331,7 @@ msgstr "Link zur Datenschutzerklärung Ihrer Organisation, die angezeigt wird"
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn-Beitrag (Experimentell)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7339,7 +7339,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7405,7 +7405,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7488,7 +7488,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11126,7 +11126,7 @@ msgstr "Umbenennen"
 #~ msgstr "Umbenennen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Chat umbenennen"
 
@@ -11548,7 +11548,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Dateien vor dem Hochladen überprüfen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12171,7 +12171,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Senden"
 
@@ -14037,7 +14037,7 @@ msgstr "Zu groß"
 msgid "Too long"
 msgstr "Zu lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14881,7 +14881,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Verwenden Sie Shift + Enter, um eine neue Zeile hinzuzufügen"
 
@@ -15463,11 +15463,11 @@ msgstr "Was soll ECHO aus den Gesprächen analysieren oder generieren?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Worauf soll sich dieser Bericht konzentrieren?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15553,7 +15553,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15628,7 +15628,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 
@@ -2424,7 +2424,7 @@ msgstr "Ask | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Ask a organisation admin to request this upgrade."
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 
@@ -2453,7 +2453,7 @@ msgstr "Ask about these"
 #~ msgstr "Ask about your conversations, or type to find an earlier chat"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr "Ask about your conversations..."
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4614,7 +4614,7 @@ msgstr "dembrane B.V. {0}, all rights reserved."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
@@ -5419,7 +5419,7 @@ msgstr "Entered details"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Error"
 
@@ -5882,11 +5882,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr "Failed to stop run"
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr "Failed to submit agentic message"
 
@@ -6078,9 +6078,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr "Focus on conversations"
 
@@ -6724,11 +6724,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr "I accept the <0>terms</0>"
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr "I applied the canvas."
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr "I applied the goal."
 
@@ -6816,7 +6816,7 @@ msgstr "If you're trying to join an existing organization, you should not create
 msgid "Image style"
 msgstr "Image style"
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr "Improve my setup"
 
@@ -7603,7 +7603,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr "List my conversations"
 
@@ -7611,7 +7611,7 @@ msgstr "List my conversations"
 #~ msgid "List project conversations"
 #~ msgstr "List project conversations"
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr "List the conversations in this project."
 
@@ -7678,7 +7678,7 @@ msgstr "Live recordings, transcription progress, and errors show up here as part
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live stream disconnected. Updating on a slower poll until it reconnects."
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live stream interrupted. Falling back to polling."
 
@@ -7761,7 +7761,7 @@ msgstr "Loading projects..."
 #~ msgid "Loading projects…"
 #~ msgstr "Loading projects…"
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr "Loading this chat..."
 
@@ -11354,7 +11354,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11783,7 +11783,7 @@ msgstr "Review before creating."
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr "Review my project settings and suggest improvements."
 
@@ -12409,7 +12409,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Send"
 
@@ -14322,7 +14322,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Too many to list here. The assistant reads through them in batches."
 
@@ -15180,7 +15180,7 @@ msgstr "Usage this cycle"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15779,11 +15779,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr "What themes came up across the conversations in this project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr "What themes came up?"
 
@@ -15869,7 +15869,7 @@ msgid "Where would you like to go?"
 msgstr "Where would you like to go?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr "Where would you like to start?"
 
@@ -15944,7 +15944,7 @@ msgstr "Within my organisation"
 msgid "Worked through {0} steps"
 msgstr "Worked through {0} steps"
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr "Working on your answer..."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -420,7 +420,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2219,7 +2219,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3083,7 +3083,7 @@ msgstr "Cambiar el idioma durante una conversación activa puede provocar result
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4403,7 +4403,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5188,7 +5188,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Error"
 
@@ -5636,11 +5636,11 @@ msgstr "Error al revisar el resultado. Por favor, inténtalo de nuevo."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Error al detener la grabación al cambiar el dispositivo. Por favor, inténtalo de nuevo."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5827,9 +5827,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Enfoque"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6465,11 +6465,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6547,7 +6547,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7334,7 +7334,7 @@ msgstr "Enlace a la política de privacidad de tu organización que se mostrará
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publicación LinkedIn (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7342,7 +7342,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7408,7 +7408,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7491,7 +7491,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11132,7 +11132,7 @@ msgstr "Renombrar"
 #~ msgstr "Renombrar"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Renombrar chat"
 
@@ -11554,7 +11554,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Revisar archivos antes de subir"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12177,7 +12177,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Enviar"
 
@@ -14040,7 +14040,7 @@ msgstr "Demasiado grande"
 msgid "Too long"
 msgstr "Demasiado largo"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14885,7 +14885,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Usa Shift + Enter para agregar una nueva línea"
 
@@ -15467,11 +15467,11 @@ msgstr "¿Qué debe ECHO analizar o generar a partir de las conversaciones?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "¿En qué debe centrarse este informe?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15557,7 +15557,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15632,7 +15632,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -435,7 +435,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2263,7 +2263,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr "Changer de langue pendant une conversation active peut provoquer des ré
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Discussion"
 
@@ -4418,7 +4418,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5203,7 +5203,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Erreur"
 
@@ -5651,11 +5651,11 @@ msgstr "Échec de la révision du résultat. Veuillez réessayer."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Échec de l'arrêt de l'enregistrement lors du changement de périphérique. Veuillez réessayer."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -5842,9 +5842,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6480,11 +6480,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6562,7 +6562,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7349,7 +7349,7 @@ msgstr "Lien vers la politique de confidentialité de votre organisation qui ser
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "Publication LinkedIn (Expérimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7357,7 +7357,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7423,7 +7423,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7506,7 +7506,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11147,7 +11147,7 @@ msgstr "Renommer"
 #~ msgstr "Renommer"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Renommer le chat"
 
@@ -11569,7 +11569,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Examiner les fichiers avant le téléchargement"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12192,7 +12192,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Envoyer"
 
@@ -14055,7 +14055,7 @@ msgstr "Trop grande"
 msgid "Too long"
 msgstr "Trop long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -14900,7 +14900,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Utilisez Shift + Entrée pour ajouter une nouvelle ligne"
 
@@ -15486,11 +15486,11 @@ msgstr "Que doit ECHO analyser ou générer à partir des conversations ?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Sur quoi ce rapport doit-il se concentrer ?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15576,7 +15576,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15651,7 +15651,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4614,7 +4614,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5419,7 +5419,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Error"
 
@@ -5882,11 +5882,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6078,9 +6078,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6724,11 +6724,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6816,7 +6816,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7761,7 +7761,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11354,7 +11354,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11783,7 +11783,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12409,7 +12409,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Send"
 
@@ -14322,7 +14322,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15180,7 +15180,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15779,11 +15779,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15869,7 +15869,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15944,7 +15944,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -252,7 +252,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr "{0, plural, one {# werkruimte} other {# werkruimtes}}"
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr "{0, plural, one {Focus op # gesprek:} other {Focus op # gesprekken:}}"
 
@@ -1988,7 +1988,7 @@ msgstr "Vragen | dembrane"
 msgid "Ask a organisation admin to request this upgrade."
 msgstr "Vraag een organisatie-admin om deze upgrade aan te vragen."
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr "Stel een vraag over de gesprekken in dit project, of vraag hulp bij het opzetten ervan. Elke wijziging wordt eerst ter beoordeling voorgesteld en er wordt niets opgeslagen totdat je het goedkeurt."
 
@@ -2019,7 +2019,7 @@ msgstr "Hierover vragen"
 #~ msgstr "Vraag iets over je gesprekken, of typ om een eerdere chat te vinden"
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr "Vraag iets over je gesprekken..."
 
@@ -2834,7 +2834,7 @@ msgstr "Wijziging van de taal tijdens een actief gesprek kan onverwachte resulta
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4136,7 +4136,7 @@ msgstr "dembrane B.V. {0}, alle rechten voorbehouden."
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane kan fouten maken. Controleer antwoorden altijd even."
 
@@ -4895,7 +4895,7 @@ msgstr "Gegevens ingevuld"
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Fout"
 
@@ -5330,11 +5330,11 @@ msgstr "Fout bij het herzien van het resultaat. Probeer het opnieuw."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Fout bij het stoppen van de opname bij wijziging van het apparaat. Probeer het opnieuw."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr "De run stoppen is mislukt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr "Bericht versturen is mislukt"
 
@@ -5521,9 +5521,9 @@ msgstr "Fixture"
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr "Focus op gesprekken"
 
@@ -6129,11 +6129,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr "Ik heb het canvas toegepast."
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr "Ik heb het doel toegepast."
 
@@ -6209,7 +6209,7 @@ msgstr "Als je je bij een bestaande organisatie wilt aansluiten, maak dan geen n
 msgid "Image style"
 msgstr "Beeldstijl"
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr "Verbeter mijn instellingen"
 
@@ -6963,7 +6963,7 @@ msgstr "Link naar de privacyverklaring van uw organisatie die aan deelnemers wor
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimenteel)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr "Toon mijn gesprekken"
 
@@ -6971,7 +6971,7 @@ msgstr "Toon mijn gesprekken"
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr "Toon de gesprekken in dit project."
 
@@ -7037,7 +7037,7 @@ msgstr "Live opnames, voortgang van transcriptie en fouten verschijnen hier zodr
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr "Live verbinding verbroken. We werken minder vaak bij tot de verbinding terug is."
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live verbinding onderbroken. We halen updates nu periodiek op."
 
@@ -7118,7 +7118,7 @@ msgstr "Projecten laden..."
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr "Deze chat laden..."
 
@@ -10671,7 +10671,7 @@ msgstr "Naam wijzigen"
 #~ msgstr "Naam wijzigen"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Chat hernoemen"
 
@@ -11072,7 +11072,7 @@ msgstr "Controleer voordat je aanmaakt."
 msgid "Review files before uploading"
 msgstr "Bestanden bekijken voordat u uploadt"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr "Bekijk mijn projectinstellingen en stel verbeteringen voor."
 
@@ -11690,7 +11690,7 @@ msgstr "Self-serve"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Verzenden"
 
@@ -13485,7 +13485,7 @@ msgstr "Te groot"
 msgid "Too long"
 msgstr "Te lang"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr "Te veel om hier te tonen. De assistent leest ze in delen door."
 
@@ -14309,7 +14309,7 @@ msgstr "Gebruik deze cyclus"
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Gebruik Shift + Enter om een nieuwe regel toe te voegen"
 
@@ -14866,11 +14866,11 @@ msgstr "Wat moet ECHO analyseren of genereren uit de gesprekken?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "Waar moet dit rapport zich op richten?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr "Welke thema's kwamen naar voren in de gesprekken in dit project?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr "Welke thema's kwamen naar voren?"
 
@@ -14952,7 +14952,7 @@ msgid "Where would you like to go?"
 msgstr "Waar wil je naartoe?"
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr "Waar wil je beginnen?"
 
@@ -15021,7 +15021,7 @@ msgstr "Binnen mijn organisatie"
 msgid "Worked through {0} steps"
 msgstr "{0} stappen doorlopen"
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr "Bezig met je antwoord..."
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -596,7 +596,7 @@ msgid "{0, plural, one {# workspace} other {# workspaces}}"
 msgstr ""
 
 #. placeholder {0}: focusedContextConversations.length
-#: src/components/chat/AgenticChatPanel.tsx:1938
+#: src/components/chat/AgenticChatPanel.tsx:2018
 msgid "{0, plural, one {Focusing on # conversation:} other {Focusing on # conversations:}}"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Ask a organisation admin to request this upgrade."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1664
+#: src/components/chat/AgenticChatPanel.tsx:1736
 msgid "Ask a question about the conversations in this project, or get help setting it up. Any change is proposed for review first, and nothing is saved until it's approved."
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:542
-#: src/components/chat/AgenticChatPanel.tsx:1998
+#: src/components/chat/AgenticChatPanel.tsx:2078
 msgid "Ask about your conversations..."
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr "Changing language during an active chat may lead to unexpected results. 
 #: src/features/sidebar/hooks/useSearchHits.ts:256
 #: src/features/sidebar/hooks/useSearchHits.ts:257
 #: src/features/sidebar/hooks/useSearchHits.ts:262
-#: src/components/chat/AgenticChatPanel.tsx:1508
+#: src/components/chat/AgenticChatPanel.tsx:1580
 msgid "Chat"
 msgstr "Chat"
 
@@ -4614,7 +4614,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:982
 #: src/routes/project/chat/ProjectChatRoute.tsx:992
-#: src/components/chat/AgenticChatPanel.tsx:2019
+#: src/components/chat/AgenticChatPanel.tsx:2099
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
@@ -5419,7 +5419,7 @@ msgstr ""
 #: src/components/dropzone/UploadConversationDropzone.tsx:842
 #: src/components/conversation/LiveMonitorSection.tsx:269
 #: src/components/chat/AgenticChatPanel.tsx:386
-#: src/components/chat/AgenticChatPanel.tsx:1610
+#: src/components/chat/AgenticChatPanel.tsx:1682
 msgid "Error"
 msgstr "Error"
 
@@ -5882,11 +5882,11 @@ msgstr "Failed to revise outcome. Please try again."
 msgid "Failed to stop recording on device change. Please try again."
 msgstr "Failed to stop recording on device change. Please try again."
 
-#: src/components/chat/AgenticChatPanel.tsx:1501
+#: src/components/chat/AgenticChatPanel.tsx:1573
 msgid "Failed to stop run"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1460
+#: src/components/chat/AgenticChatPanel.tsx:1532
 msgid "Failed to submit agentic message"
 msgstr ""
 
@@ -6078,9 +6078,9 @@ msgstr ""
 msgid "Focus"
 msgstr "Focus"
 
-#: src/components/chat/AgenticChatPanel.tsx:1965
-#: src/components/chat/AgenticChatPanel.tsx:1966
-#: src/components/chat/AgenticChatPanel.tsx:2029
+#: src/components/chat/AgenticChatPanel.tsx:2045
+#: src/components/chat/AgenticChatPanel.tsx:2046
+#: src/components/chat/AgenticChatPanel.tsx:2109
 msgid "Focus on conversations"
 msgstr ""
 
@@ -6724,11 +6724,11 @@ msgstr ""
 #~ msgid "I accept the <0>terms</0>"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1778
+#: src/components/chat/AgenticChatPanel.tsx:1850
 msgid "I applied the canvas."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1794
+#: src/components/chat/AgenticChatPanel.tsx:1866
 msgid "I applied the goal."
 msgstr ""
 
@@ -6816,7 +6816,7 @@ msgstr ""
 msgid "Image style"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1688
+#: src/components/chat/AgenticChatPanel.tsx:1760
 msgid "Improve my setup"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr "Link to your organisation's privacy policy that will be shown to partici
 #~ msgid "LinkedIn Post (Experimental)"
 #~ msgstr "LinkedIn Post (Experimental)"
 
-#: src/components/chat/AgenticChatPanel.tsx:1678
+#: src/components/chat/AgenticChatPanel.tsx:1750
 msgid "List my conversations"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgstr ""
 #~ msgid "List project conversations"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1679
+#: src/components/chat/AgenticChatPanel.tsx:1751
 msgid "List the conversations in this project."
 msgstr ""
 
@@ -7678,7 +7678,7 @@ msgstr ""
 msgid "Live stream disconnected. Updating on a slower poll until it reconnects."
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1175
+#: src/components/chat/AgenticChatPanel.tsx:1234
 msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
@@ -7761,7 +7761,7 @@ msgstr ""
 #~ msgid "Loading projects…"
 #~ msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1621
+#: src/components/chat/AgenticChatPanel.tsx:1693
 msgid "Loading this chat..."
 msgstr ""
 
@@ -11354,7 +11354,7 @@ msgstr "Rename"
 #~ msgstr "Rename"
 
 #: src/components/chat/ChatAccordion.tsx:153
-#: src/components/chat/AgenticChatPanel.tsx:1571
+#: src/components/chat/AgenticChatPanel.tsx:1643
 msgid "Rename chat"
 msgstr "Rename chat"
 
@@ -11783,7 +11783,7 @@ msgstr ""
 msgid "Review files before uploading"
 msgstr "Review files before uploading"
 
-#: src/components/chat/AgenticChatPanel.tsx:1689
+#: src/components/chat/AgenticChatPanel.tsx:1761
 msgid "Review my project settings and suggest improvements."
 msgstr ""
 
@@ -12409,7 +12409,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:942
 #: src/routes/project/chat/NewChatRoute.tsx:521
-#: src/components/chat/AgenticChatPanel.tsx:1984
+#: src/components/chat/AgenticChatPanel.tsx:2064
 msgid "Send"
 msgstr "Send"
 
@@ -14322,7 +14322,7 @@ msgstr "Too large"
 msgid "Too long"
 msgstr "Too long"
 
-#: src/components/chat/AgenticChatPanel.tsx:1954
+#: src/components/chat/AgenticChatPanel.tsx:2034
 msgid "Too many to list here. The assistant reads through them in batches."
 msgstr ""
 
@@ -15180,7 +15180,7 @@ msgstr ""
 
 #: src/routes/project/chat/ProjectChatRoute.tsx:979
 #: src/routes/project/chat/ProjectChatRoute.tsx:989
-#: src/components/chat/AgenticChatPanel.tsx:2016
+#: src/components/chat/AgenticChatPanel.tsx:2096
 msgid "Use Shift + Enter to add a new line"
 msgstr "Use Shift + Enter to add a new line"
 
@@ -15779,11 +15779,11 @@ msgstr "What should ECHO analyse or generate from the conversations?"
 #~ msgid "What should this report focus on?"
 #~ msgstr "What should this report focus on?"
 
-#: src/components/chat/AgenticChatPanel.tsx:1684
+#: src/components/chat/AgenticChatPanel.tsx:1756
 msgid "What themes came up across the conversations in this project?"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1683
+#: src/components/chat/AgenticChatPanel.tsx:1755
 msgid "What themes came up?"
 msgstr ""
 
@@ -15869,7 +15869,7 @@ msgid "Where would you like to go?"
 msgstr ""
 
 #: src/routes/project/chat/NewChatRoute.tsx:471
-#: src/components/chat/AgenticChatPanel.tsx:1661
+#: src/components/chat/AgenticChatPanel.tsx:1733
 msgid "Where would you like to start?"
 msgstr ""
 
@@ -15944,7 +15944,7 @@ msgstr ""
 msgid "Worked through {0} steps"
 msgstr ""
 
-#: src/components/chat/AgenticChatPanel.tsx:1533
+#: src/components/chat/AgenticChatPanel.tsx:1605
 msgid "Working on your answer..."
 msgstr ""
 

--- a/echo/server/dembrane/agentic_worker.py
+++ b/echo/server/dembrane/agentic_worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import json
+import time
 import asyncio
 from uuid import UUID
 from typing import Any, Optional, AsyncGenerator
@@ -25,6 +26,21 @@ logger = getLogger("dembrane.agentic_worker")
 AGENT_CANCELLED_ERROR_CODE = "AGENT_CANCELLED"
 AGENT_CANCELLED_MESSAGE = "Run cancelled by user"
 MAX_TOOL_CALLS_PER_TURN = 20
+# Full-text snapshots are quadratic in message length, so throttle and back
+# off as the text grows; on_chat_model_end always flushes the final snapshot.
+DRAFT_PUBLISH_INTERVAL_SECONDS = 0.15
+DRAFT_PUBLISH_MEDIUM_TEXT_CHARS = 2_000
+DRAFT_PUBLISH_MEDIUM_INTERVAL_SECONDS = 0.5
+DRAFT_PUBLISH_LONG_TEXT_CHARS = 8_000
+DRAFT_PUBLISH_LONG_INTERVAL_SECONDS = 1.0
+
+
+def _draft_publish_interval(text_length: int) -> float:
+    if text_length >= DRAFT_PUBLISH_LONG_TEXT_CHARS:
+        return DRAFT_PUBLISH_LONG_INTERVAL_SECONDS
+    if text_length >= DRAFT_PUBLISH_MEDIUM_TEXT_CHARS:
+        return DRAFT_PUBLISH_MEDIUM_INTERVAL_SECONDS
+    return DRAFT_PUBLISH_INTERVAL_SECONDS
 MAX_TOOL_CALLS_PER_RUN = MAX_TOOL_CALLS_PER_TURN * 10
 TOOL_LIMIT_EXEMPT_TOOL_NAMES = {"sendProgressUpdate"}
 # Host-facing, in the agent's own voice. "Tool calls" are an internal concept
@@ -189,6 +205,40 @@ def _extract_tool_call_name(value: Any) -> Optional[str]:
             if isinstance(nested_name, str) and nested_name.strip():
                 return nested_name.strip()
     return None
+
+
+def _coerce_chunk_text(value: Any) -> str:
+    """Whitespace-preserving _coerce_text: chunk boundaries fall on spaces."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _extract_stream_chunk(event: dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    """Return (chunk_text, model_invocation_id) for an on_chat_model_stream event."""
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return None, None
+    chunk = data.get("chunk")
+    if not isinstance(chunk, dict):
+        return None, None
+    kwargs = chunk.get("kwargs")
+    if not isinstance(kwargs, dict):
+        return None, None
+    text = _coerce_chunk_text(kwargs.get("content"))
+    message_id = str(event.get("run_id") or "") or None
+    return (text or None), message_id
 
 
 def _extract_model_text_and_tool_calls(event: dict[str, Any]) -> tuple[Optional[str], set[str]]:
@@ -501,6 +551,18 @@ async def _append_event_and_publish(
         logger.warning("Failed to publish live event for run %s: %s", run_id, exc)
 
 
+async def _publish_draft_snapshot(run_id: str, message_id: str, text: str) -> None:
+    """Ephemeral streaming snapshot: Redis pub/sub only, never persisted."""
+    payload = json.dumps(
+        {"event_type": "assistant.draft", "payload": {"message_id": message_id, "text": text}},
+        default=str,
+    )
+    try:
+        await publish_live_event(run_id, payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to publish draft snapshot for run %s: %s", run_id, exc)
+
+
 async def _raise_if_cancelled(run_id: str, turn_seq: int) -> None:
     if await is_cancel_requested(run_id, turn_seq):
         raise AgenticRunCancelledError(AGENT_CANCELLED_MESSAGE)
@@ -512,17 +574,21 @@ async def _append_assistant_message(
     run_id: str,
     content: str,
     project_chat_id: str,
+    message_id: Optional[str] = None,
 ) -> Optional[str]:
     # Never emit or persist internal placeholders / empty turns as host-facing
     # messages — they only fragment the chat and leak the Gemini crutch text.
     sanitized_content = _sanitize_host_visible_assistant_content(content)
     if sanitized_content is None:
         return None
+    event_payload: dict[str, Any] = {"content": sanitized_content}
+    if message_id:
+        event_payload["message_id"] = message_id
     await _append_event_and_publish(
         svc,
         run_id,
         "assistant.message",
-        {"content": sanitized_content},
+        event_payload,
     )
     if not project_chat_id:
         return sanitized_content
@@ -692,6 +758,36 @@ async def process_agentic_run(
             run_id=run_id,
         )
         canvas_enabled = await project_canvas_enabled(project_id)
+        # Streamed text per model invocation; its run_id doubles as message_id.
+        draft_texts: dict[str, str] = {}
+        draft_last_publish_at: dict[str, float] = {}
+        draft_published_texts: dict[str, str] = {}
+        # Model turn whose narration a pending sendProgressUpdate result replaces.
+        pending_progress_message_id: Optional[str] = None
+
+        async def _maybe_publish_draft(message_id: str, *, flush: bool = False) -> None:
+            now = time.monotonic()
+            last_publish_at = draft_last_publish_at.get(message_id)
+            if (
+                not flush
+                and last_publish_at is not None
+                and now - last_publish_at
+                < _draft_publish_interval(len(draft_texts[message_id]))
+            ):
+                return
+            sanitized = _sanitize_host_visible_assistant_content(draft_texts[message_id])
+            if not sanitized or sanitized == draft_published_texts.get(message_id):
+                return
+            if any(
+                placeholder.startswith(sanitized)
+                for placeholder in INTERNAL_PLACEHOLDER_CONTENTS
+            ):
+                # A growing draft hits placeholder prefixes ("(calling") before
+                # the sanitizer can match the full string; hold those back.
+                return
+            draft_last_publish_at[message_id] = now
+            draft_published_texts[message_id] = sanitized
+            await _publish_draft_snapshot(run_id, message_id, sanitized)
 
         async for event in _stream_with_overflow_retry(
             project_id=project_id,
@@ -707,26 +803,43 @@ async def process_agentic_run(
             await _raise_if_cancelled(run_id, turn_seq)
             event_type = str(event.get("type") or event.get("event") or "agent.event")
 
+            if event_type == "on_chat_model_stream":
+                # Redis only, never persisted: one Directus row per chunk is bloat.
+                chunk_text, stream_message_id = _extract_stream_chunk(event)
+                if chunk_text and stream_message_id:
+                    draft_texts[stream_message_id] = (
+                        draft_texts.get(stream_message_id, "") + chunk_text
+                    )
+                    await _maybe_publish_draft(stream_message_id)
+                continue
+
             model_text, model_tool_calls = _extract_model_text_and_tool_calls(event)
-            model_has_tool_calls = len(model_tool_calls) > 0
+            model_message_id = (
+                str(event.get("run_id") or "") or None
+                if event_type == "on_chat_model_end"
+                else None
+            )
+            if model_message_id and model_message_id in draft_texts:
+                # Flush the throttled tail; the final snapshot carries the full text.
+                await _maybe_publish_draft(model_message_id, flush=True)
             model_has_progress_tool_call = "sendProgressUpdate" in model_tool_calls
+            if model_has_progress_tool_call:
+                # The tool's output is this turn's visible message; sharing the
+                # message_id lets the streamed narration draft resolve into it.
+                pending_progress_message_id = model_message_id
             if model_text:
-                if model_has_tool_calls:
-                    # The model's pre-tool "planning" prose used to be persisted
-                    # as its own bubble, which fragmented the aggregated activity
-                    # strip (and, with the placeholder crutch, spammed the thread
-                    # with "(calling tools)"). Suppress it: the host sees the
-                    # aggregated tool activity plus the final summary. We do NOT
-                    # reset the nudge counter here, so visible-progress nudges
-                    # (sendProgressUpdate) still fire on long runs.
-                    if model_has_progress_tool_call:
-                        has_sent_progress_intro = True
+                if model_has_progress_tool_call:
+                    # The narration repeats the tool's words; keeping both double-posts.
+                    has_sent_progress_intro = True
                 else:
+                    # Text shown as a draft must get a durable copy (no flicker),
+                    # even when the turn ends in tool calls.
                     persisted_content = await _append_assistant_message(
                         svc=svc,
                         run_id=run_id,
                         content=model_text,
                         project_chat_id=project_chat_id,
+                        message_id=model_message_id,
                     )
                     if persisted_content is not None:
                         latest_output = persisted_content
@@ -823,7 +936,9 @@ async def process_agentic_run(
                         run_id=run_id,
                         content=progress_message,
                         project_chat_id=project_chat_id,
+                        message_id=pending_progress_message_id,
                     )
+                    pending_progress_message_id = None
                     if persisted_content is not None:
                         tool_calls_without_assistant_message = 0
                         nudged_tool_call_milestones.clear()

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -2641,6 +2641,10 @@ async def _stream_live_events(run_id: str, after_seq: int) -> AsyncIterator[str]
                         event = None
 
                     if isinstance(event, dict):
+                        if event.get("event_type") == "assistant.draft":
+                            # Ephemeral: forwarded live, never replayed, no cursor.
+                            yield f"event: assistant.draft\ndata: {live_payload}\n\n"
+                            continue
                         seq = int(event.get("seq") or 0)
                         if seq > cursor:
                             cursor = seq

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 import asyncio
 from types import SimpleNamespace
@@ -2970,3 +2971,105 @@ def test_strip_focus_blocks_removes_a_real_block_and_keeps_the_message() -> None
     content = f"{FOCUS_BLOCK_OPEN}\n- id: conv-1\n{FOCUS_BLOCK_CLOSE}\n\nUser Message: hello"
 
     assert strip_focus_blocks(content) == "User Message: hello"
+
+
+@pytest.mark.asyncio
+async def test_stream_live_events_forwards_drafts_without_cursor_advance(monkeypatch) -> None:
+    """Drafts pass through with no id line; the cursor advances only on seq events."""
+    run_id = "run-draft-1"
+
+    draft_payload = json.dumps(
+        {"event_type": "assistant.draft", "payload": {"message_id": "m-1", "text": "Hel"}}
+    )
+    durable_event = {
+        "event_type": "assistant.message",
+        "seq": 3,
+        "payload": {"content": "Hello", "message_id": "m-1"},
+    }
+    durable_payload = json.dumps(durable_event)
+
+    live_queue = [draft_payload, durable_payload]
+
+    class _FakePubSub:
+        pass
+
+    @asynccontextmanager
+    async def _fake_subscribe(_run_id: str):
+        yield _FakePubSub()
+
+    async def _fake_read(_pubsub: Any, timeout_seconds: float = 1.0) -> str | None:  # noqa: ARG001
+        if live_queue:
+            return live_queue.pop(0)
+        return None
+
+    async def _no_db_events(_run_id: str, after_seq: int) -> list[dict[str, Any]]:  # noqa: ARG001
+        return []
+
+    # After the queue drains, report the run terminal so the loop exits.
+    def _fake_get_run(_run_id: str) -> dict[str, Any]:
+        return {"id": run_id, "status": "completed" if not live_queue else "running"}
+
+    monkeypatch.setattr(agentic_api, "subscribe_live_events", _fake_subscribe)
+    monkeypatch.setattr(agentic_api, "read_live_event", _fake_read)
+    monkeypatch.setattr(agentic_api, "_list_events_after", _no_db_events)
+    monkeypatch.setattr(agentic_api, "_get_run_or_404", _fake_get_run)
+
+    frames = []
+    async for frame in agentic_api._stream_live_events(run_id, after_seq=0):
+        frames.append(frame)
+
+    draft_frames = [f for f in frames if "assistant.draft" in f]
+    assert len(draft_frames) == 1
+    assert draft_frames[0].startswith("event: assistant.draft\n")
+    assert "id:" not in draft_frames[0]
+    assert '"text": "Hel"' in draft_frames[0]
+
+    durable_frames = [f for f in frames if "assistant.message" in f]
+    assert len(durable_frames) == 1
+    assert durable_frames[0].startswith("id: 3\n")
+
+
+@pytest.mark.asyncio
+async def test_stream_live_events_forwards_drafts_to_reconnecting_clients(monkeypatch) -> None:
+    """A client reconnecting mid-message still gets the next draft snapshot."""
+    run_id = "run-draft-reconnect"
+
+    draft_payload = json.dumps(
+        {
+            "event_type": "assistant.draft",
+            "payload": {"message_id": "m-1", "text": "Full text so far, resent whole"},
+        }
+    )
+
+    live_queue = [draft_payload]
+
+    class _FakePubSub:
+        pass
+
+    @asynccontextmanager
+    async def _fake_subscribe(_run_id: str):
+        yield _FakePubSub()
+
+    async def _fake_read(_pubsub: Any, timeout_seconds: float = 1.0) -> str | None:  # noqa: ARG001
+        if live_queue:
+            return live_queue.pop(0)
+        return None
+
+    async def _no_db_events(_run_id: str, after_seq: int) -> list[dict[str, Any]]:  # noqa: ARG001
+        return []
+
+    def _fake_get_run(_run_id: str) -> dict[str, Any]:
+        return {"id": run_id, "status": "completed" if not live_queue else "running"}
+
+    monkeypatch.setattr(agentic_api, "subscribe_live_events", _fake_subscribe)
+    monkeypatch.setattr(agentic_api, "read_live_event", _fake_read)
+    monkeypatch.setattr(agentic_api, "_list_events_after", _no_db_events)
+    monkeypatch.setattr(agentic_api, "_get_run_or_404", _fake_get_run)
+
+    frames = []
+    async for frame in agentic_api._stream_live_events(run_id, after_seq=42):
+        frames.append(frame)
+
+    draft_frames = [f for f in frames if "assistant.draft" in f]
+    assert len(draft_frames) == 1
+    assert '"text": "Full text so far, resent whole"' in draft_frames[0]

--- a/echo/server/tests/test_agentic_worker.py
+++ b/echo/server/tests/test_agentic_worker.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from tests.agentic.fakes import InMemoryDirectus
@@ -6,7 +8,11 @@ from dembrane.agentic_worker import (
     TOOL_LIMIT_SAFETY_MESSAGE,
     AGENT_CANCELLED_ERROR_CODE,
     RUN_TOOL_LIMIT_SAFETY_MESSAGE,
+    DRAFT_PUBLISH_INTERVAL_SECONDS,
+    DRAFT_PUBLISH_LONG_INTERVAL_SECONDS,
+    DRAFT_PUBLISH_MEDIUM_INTERVAL_SECONDS,
     process_agentic_run,
+    _draft_publish_interval,
     _sanitize_host_visible_assistant_content,
 )
 from dembrane.service.agentic import AgenticRunService
@@ -14,6 +20,14 @@ from dembrane.service.agentic import AgenticRunService
 
 def _build_service() -> AgenticRunService:
     return AgenticRunService(directus_client=InMemoryDirectus())
+
+
+def test_draft_publish_interval_backs_off_as_text_grows() -> None:
+    assert _draft_publish_interval(0) == DRAFT_PUBLISH_INTERVAL_SECONDS
+    assert _draft_publish_interval(1_999) == DRAFT_PUBLISH_INTERVAL_SECONDS
+    assert _draft_publish_interval(2_000) == DRAFT_PUBLISH_MEDIUM_INTERVAL_SECONDS
+    assert _draft_publish_interval(7_999) == DRAFT_PUBLISH_MEDIUM_INTERVAL_SECONDS
+    assert _draft_publish_interval(8_000) == DRAFT_PUBLISH_LONG_INTERVAL_SECONDS
 
 
 def test_sanitize_host_visible_content_strips_stray_token_and_successfully() -> None:
@@ -272,7 +286,7 @@ async def test_process_agentic_run_handles_cancel_request(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_process_agentic_run_suppresses_planning_prose_keeps_final_synthesis(
+async def test_process_agentic_run_persists_planning_prose_and_final_synthesis(
     monkeypatch,
 ) -> None:
     service = _build_service()
@@ -360,14 +374,20 @@ async def test_process_agentic_run_suppresses_planning_prose_keeps_final_synthes
 
     assert stored_run["status"] == "completed"
     assert stored_run["latest_output"] == "Final synthesis message."
-    # Pre-tool planning prose is no longer surfaced as its own bubble; only the
-    # final synthesis reaches the host. The aggregated tool activity carries the
-    # "what's happening" story instead.
-    assert len(assistant_events) == 1
-    assert assistant_events[0]["payload"]["content"] == "Final synthesis message."
+    # Pre-tool prose streams as a draft, so its durable copy must exist too:
+    # everything shown is persisted (no flicker).
+    assert len(assistant_events) == 2
+    assert assistant_events[0]["payload"]["content"] == planning_content
+    assert assistant_events[1]["payload"]["content"] == "Final synthesis message."
     assert fake_chat_service.created_messages == [
         {
             "id": "msg-1",
+            "project_chat_id": "chat-1",
+            "message_from": "assistant",
+            "text": planning_content,
+        },
+        {
+            "id": "msg-2",
             "project_chat_id": "chat-1",
             "message_from": "assistant",
             "text": "Final synthesis message.",
@@ -557,6 +577,7 @@ async def test_process_agentic_run_uses_progress_tool_output_as_user_visible_upd
         _ = (project_id, user_message, bearer_token, thread_id, message_history)
         yield {
             "type": "on_chat_model_end",
+            "run_id": "model-run-progress",
             "data": {
                 "output": {
                     "kwargs": {
@@ -633,6 +654,8 @@ async def test_process_agentic_run_uses_progress_tool_output_as_user_visible_upd
         "Final answer only.",
     ]
     assert not any(text.startswith("I'll first gather evidence") for text in assistant_texts)
+    # Carries the model turn's message_id so a streamed draft resolves into it.
+    assert assistant_events[0]["payload"]["message_id"] == "model-run-progress"
     assert fake_chat_service.created_messages == [
         {
             "id": "msg-1",
@@ -751,7 +774,7 @@ async def test_process_agentic_run_uses_progress_tool_output_from_toolmessage_sh
 
 
 @pytest.mark.asyncio
-async def test_process_agentic_run_suppresses_midpoint_planning_prose(monkeypatch) -> None:
+async def test_process_agentic_run_persists_midpoint_planning_prose(monkeypatch) -> None:
     service = _build_service()
     run = service.create_run(
         project_id="project-1",
@@ -854,19 +877,14 @@ async def test_process_agentic_run_suppresses_midpoint_planning_prose(monkeypatc
     assistant_events = [event for event in events if event["event_type"] == "assistant.message"]
     assistant_texts = [event["payload"]["content"] for event in assistant_events]
 
-    # Model prose that rides alongside a tool call (pre-tool "planning" or a
-    # mid-run "quick update" that is NOT an explicit sendProgressUpdate) is
-    # suppressed: it fragmented the aggregated activity strip. Only the final
-    # tool-free synthesis surfaces as a host-visible message.
-    assert assistant_texts == ["Final answer only."]
-    assert fake_chat_service.created_messages == [
-        {
-            "id": "msg-1",
-            "project_chat_id": "chat-1",
-            "message_from": "assistant",
-            "text": "Final answer only.",
-        },
+    # Mid-run prose is persisted (it streamed as a draft); only
+    # sendProgressUpdate narration stays suppressed.
+    assert assistant_texts == [
+        "I will start by scanning project summaries.",
+        "Quick update: I have enough signal to focus on two transcripts.",
+        "Final answer only.",
     ]
+    assert [message["text"] for message in fake_chat_service.created_messages] == assistant_texts
 
 
 @pytest.mark.asyncio
@@ -1220,14 +1238,12 @@ async def test_process_agentic_run_tool_limit_does_not_repeat_last_update(monkey
     assistant_events = [event for event in events if event["event_type"] == "assistant.message"]
     assistant_texts = [event["payload"]["content"] for event in assistant_events]
 
-    # The turn ends with the single limit message. The model's pre-tool prose
-    # ("Current synthesis draft.") rode alongside a tool call, so it is
-    # suppressed rather than surfaced or repeated.
-    assert len(assistant_texts) == 1
-    assert assistant_texts[0] != "Current synthesis draft."
-    assert 'request: "hello"' in assistant_texts[0]
-    assert "fresh pass" in assistant_texts[0]
-    assert assistant_texts.count("Current synthesis draft.") == 0
+    # Pre-tool prose persists once, then the single limit message; no repeats.
+    assert len(assistant_texts) == 2
+    assert assistant_texts[0] == "Current synthesis draft."
+    assert 'request: "hello"' in assistant_texts[1]
+    assert "fresh pass" in assistant_texts[1]
+    assert assistant_texts.count("Current synthesis draft.") == 1
 
 
 @pytest.mark.asyncio
@@ -1887,3 +1903,393 @@ async def test_process_agentic_run_sanitizes_host_visible_assistant_artifacts(mo
 
     assert assistant_texts == ["Let's start here!"]
     assert persisted_texts == ["Let's start here!"]
+
+
+@pytest.mark.asyncio
+async def test_process_agentic_run_streams_drafts_without_persisting_chunks(
+    monkeypatch,
+) -> None:
+    service = _build_service()
+    run = service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+    )
+    fake_chat_service = _FakeChatService()
+    published_events: list[str] = []
+
+    model_run_id = "model-run-1"
+
+    def _chunk(text: str) -> dict:
+        return {
+            "event": "on_chat_model_stream",
+            "run_id": model_run_id,
+            "data": {"chunk": {"kwargs": {"content": text}}},
+        }
+
+    async def _fake_stream(
+        *,
+        project_id: str,
+        user_message: str,
+        bearer_token: str,
+        thread_id: str,
+        message_history: list[dict[str, str]] | None = None,
+        **_context: object,
+    ):
+        _ = (project_id, user_message, bearer_token, message_history)
+        assert thread_id == run["id"]
+        yield _chunk("Here is what ")
+        yield _chunk("the transcripts show.")
+        yield _chunk("")  # final empty chunk (chunk_position: last)
+        yield {
+            "event": "on_chat_model_end",
+            "run_id": model_run_id,
+            "data": {
+                "output": {
+                    "kwargs": {
+                        "content": "Here is what the transcripts show.",
+                        "additional_kwargs": {},
+                    }
+                }
+            },
+        }
+
+    async def _fake_publish(run_id: str, event_json: str) -> None:
+        assert run_id == run["id"]
+        published_events.append(event_json)
+
+    async def _never_cancel(run_id: str, turn_seq: int) -> bool:  # noqa: ARG001
+        return False
+
+    async def _clear_cancel(run_id: str, turn_seq: int) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("dembrane.agentic_worker.stream_agent_events", _fake_stream)
+    monkeypatch.setattr("dembrane.agentic_worker.chat_service", fake_chat_service)
+    monkeypatch.setattr("dembrane.agentic_worker.publish_live_event", _fake_publish)
+    monkeypatch.setattr("dembrane.agentic_worker.is_cancel_requested", _never_cancel)
+    monkeypatch.setattr("dembrane.agentic_worker.clear_cancel", _clear_cancel)
+
+    await process_agentic_run(
+        run_id=run["id"],
+        project_id="project-1",
+        user_message="hello",
+        bearer_token="token-1",
+        turn_seq=1,
+        owner_token="owner-1",
+        run_service=service,
+    )
+
+    events = service.list_events(run["id"])
+    # Chunk events are never persisted (no Directus rows, no seq consumed).
+    assert all(event["event_type"] != "on_chat_model_stream" for event in events)
+    assert all(event["event_type"] != "assistant.draft" for event in events)
+
+    drafts = [
+        json.loads(raw)
+        for raw in published_events
+        if json.loads(raw).get("event_type") == "assistant.draft"
+    ]
+    # Snapshots, not increments: each draft carries the full text so far.
+    assert [draft["payload"]["text"] for draft in drafts] == [
+        "Here is what",
+        "Here is what the transcripts show.",
+    ]
+    assert all(draft["payload"]["message_id"] == model_run_id for draft in drafts)
+
+    # The durable message carries the same message_id so the frontend can
+    # swap the draft bubble atomically.
+    assistant_events = [e for e in events if e["event_type"] == "assistant.message"]
+    assert len(assistant_events) == 1
+    assert assistant_events[0]["payload"]["content"] == "Here is what the transcripts show."
+    assert assistant_events[0]["payload"]["message_id"] == model_run_id
+
+
+@pytest.mark.asyncio
+async def test_process_agentic_run_throttles_draft_snapshots(monkeypatch) -> None:
+    """A chunk burst yields two snapshots: first chunk and final full-text flush."""
+    service = _build_service()
+    run = service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+    )
+    published_events: list[str] = []
+    model_run_id = "model-run-throttle"
+    words = [f"word{i} " for i in range(10)]
+
+    async def _fake_stream(
+        *,
+        project_id: str,
+        user_message: str,
+        bearer_token: str,
+        thread_id: str,
+        message_history: list[dict[str, str]] | None = None,
+        **_context: object,
+    ):
+        _ = (project_id, user_message, bearer_token, thread_id, message_history)
+        for word in words:
+            yield {
+                "event": "on_chat_model_stream",
+                "run_id": model_run_id,
+                "data": {"chunk": {"kwargs": {"content": word}}},
+            }
+        yield {
+            "event": "on_chat_model_end",
+            "run_id": model_run_id,
+            "data": {
+                "output": {
+                    "kwargs": {"content": "".join(words), "additional_kwargs": {}}
+                }
+            },
+        }
+
+    async def _fake_publish(run_id: str, event_json: str) -> None:  # noqa: ARG001
+        published_events.append(event_json)
+
+    async def _never_cancel(run_id: str, turn_seq: int) -> bool:  # noqa: ARG001
+        return False
+
+    async def _clear_cancel(run_id: str, turn_seq: int) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("dembrane.agentic_worker.DRAFT_PUBLISH_INTERVAL_SECONDS", 3600.0)
+    monkeypatch.setattr("dembrane.agentic_worker.stream_agent_events", _fake_stream)
+    monkeypatch.setattr("dembrane.agentic_worker.chat_service", _FakeChatService())
+    monkeypatch.setattr("dembrane.agentic_worker.publish_live_event", _fake_publish)
+    monkeypatch.setattr("dembrane.agentic_worker.is_cancel_requested", _never_cancel)
+    monkeypatch.setattr("dembrane.agentic_worker.clear_cancel", _clear_cancel)
+
+    await process_agentic_run(
+        run_id=run["id"],
+        project_id="project-1",
+        user_message="hello",
+        bearer_token="token-1",
+        turn_seq=1,
+        owner_token="owner-1",
+        run_service=service,
+    )
+
+    drafts = [
+        json.loads(raw)
+        for raw in published_events
+        if json.loads(raw).get("event_type") == "assistant.draft"
+    ]
+    assert [draft["payload"]["text"] for draft in drafts] == [
+        "word0",
+        "".join(words).strip(),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_agentic_run_progress_turn_draft_resolves_into_tool_output(
+    monkeypatch,
+) -> None:
+    """Narration streams as a draft but the durable message is the tool output,
+    carrying the model turn's message_id so the draft resolves into it."""
+    service = _build_service()
+    run = service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+    )
+    fake_chat_service = _FakeChatService()
+    published_events: list[str] = []
+    model_run_id = "model-run-progress-divergence"
+    narration = "The halftime interviews look promising so far."
+
+    async def _fake_stream(
+        *,
+        project_id: str,
+        user_message: str,
+        bearer_token: str,
+        thread_id: str,
+        message_history: list[dict[str, str]] | None = None,
+        **_context: object,
+    ):
+        _ = (project_id, user_message, bearer_token, thread_id, message_history)
+        yield {
+            "event": "on_chat_model_stream",
+            "run_id": model_run_id,
+            "data": {"chunk": {"kwargs": {"content": narration}}},
+        }
+        yield {
+            "event": "on_chat_model_end",
+            "run_id": model_run_id,
+            "data": {
+                "output": {
+                    "kwargs": {
+                        "content": narration,
+                        "additional_kwargs": {
+                            "function_call": {
+                                "name": "sendProgressUpdate",
+                                "arguments": "{}",
+                            }
+                        },
+                    }
+                }
+            },
+        }
+        yield {"type": "on_tool_start", "name": "sendProgressUpdate"}
+        yield {
+            "type": "on_tool_end",
+            "name": "sendProgressUpdate",
+            "data": {
+                "output": {
+                    "kind": "progress_update",
+                    "update": "Halftime themes located.",
+                    "next_steps": "I will verify two quotes.",
+                    "visible_to_user": True,
+                }
+            },
+        }
+
+    async def _fake_publish(run_id: str, event_json: str) -> None:  # noqa: ARG001
+        published_events.append(event_json)
+
+    async def _never_cancel(run_id: str, turn_seq: int) -> bool:  # noqa: ARG001
+        return False
+
+    async def _clear_cancel(run_id: str, turn_seq: int) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("dembrane.agentic_worker.stream_agent_events", _fake_stream)
+    monkeypatch.setattr("dembrane.agentic_worker.chat_service", fake_chat_service)
+    monkeypatch.setattr("dembrane.agentic_worker.publish_live_event", _fake_publish)
+    monkeypatch.setattr("dembrane.agentic_worker.is_cancel_requested", _never_cancel)
+    monkeypatch.setattr("dembrane.agentic_worker.clear_cancel", _clear_cancel)
+
+    await process_agentic_run(
+        run_id=run["id"],
+        project_id="project-1",
+        user_message="hello",
+        bearer_token="token-1",
+        turn_seq=1,
+        owner_token="owner-1",
+        run_service=service,
+    )
+
+    events = service.list_events(run["id"])
+    assistant_events = [event for event in events if event["event_type"] == "assistant.message"]
+    drafts = [
+        json.loads(raw)
+        for raw in published_events
+        if json.loads(raw).get("event_type") == "assistant.draft"
+    ]
+
+    # The narration streamed as a draft under the model turn's id...
+    assert drafts
+    assert all(draft["payload"]["message_id"] == model_run_id for draft in drafts)
+    assert drafts[-1]["payload"]["text"] == narration
+    # ...but the durable message is the tool output with the same id, so the
+    # frontend swaps the draft for it. The narration itself is never persisted.
+    assert len(assistant_events) == 1
+    assert assistant_events[0]["payload"]["content"] == (
+        "Halftime themes located.\n\nI will verify two quotes."
+    )
+    assert assistant_events[0]["payload"]["message_id"] == model_run_id
+    assert all(narration != event["payload"]["content"] for event in assistant_events)
+
+
+@pytest.mark.asyncio
+async def test_process_agentic_run_never_streams_placeholder_prefixes(monkeypatch) -> None:
+    """Placeholder prefixes ("(calling") are held back; a real answer starting
+    with the same letters publishes once it diverges."""
+    service = _build_service()
+    run = service.create_run(
+        project_id="project-1",
+        project_chat_id="chat-1",
+        directus_user_id="user-1",
+    )
+    published_events: list[str] = []
+
+    def _chunk(run_id: str, text: str) -> dict:
+        return {
+            "event": "on_chat_model_stream",
+            "run_id": run_id,
+            "data": {"chunk": {"kwargs": {"content": text}}},
+        }
+
+    async def _fake_stream(
+        *,
+        project_id: str,
+        user_message: str,
+        bearer_token: str,
+        thread_id: str,
+        message_history: list[dict[str, str]] | None = None,
+        **_context: object,
+    ):
+        _ = (project_id, user_message, bearer_token, thread_id, message_history)
+        # Turn 1: the model mimics the placeholder while calling a tool.
+        yield _chunk("model-run-mimic", "(calling")
+        yield _chunk("model-run-mimic", " tools)")
+        yield {
+            "event": "on_chat_model_end",
+            "run_id": "model-run-mimic",
+            "data": {
+                "output": {
+                    "kwargs": {
+                        "content": "(calling tools)",
+                        "additional_kwargs": {
+                            "function_call": {"name": "grepDocs", "arguments": "{}"}
+                        },
+                    }
+                }
+            },
+        }
+        yield {"type": "on_tool_start", "name": "grepDocs"}
+        yield {"type": "on_tool_end", "name": "grepDocs", "data": {"output": {}}}
+        # Turn 2: a real answer that shares the placeholder's first letters.
+        yield _chunk("model-run-answer", "(calling")
+        yield _chunk("model-run-answer", " all participants early is key.)")
+        yield {
+            "event": "on_chat_model_end",
+            "run_id": "model-run-answer",
+            "data": {
+                "output": {
+                    "kwargs": {
+                        "content": "(calling all participants early is key.)",
+                        "additional_kwargs": {},
+                    }
+                }
+            },
+        }
+
+    async def _fake_publish(run_id: str, event_json: str) -> None:  # noqa: ARG001
+        published_events.append(event_json)
+
+    async def _never_cancel(run_id: str, turn_seq: int) -> bool:  # noqa: ARG001
+        return False
+
+    async def _clear_cancel(run_id: str, turn_seq: int) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("dembrane.agentic_worker.stream_agent_events", _fake_stream)
+    monkeypatch.setattr("dembrane.agentic_worker.chat_service", _FakeChatService())
+    monkeypatch.setattr("dembrane.agentic_worker.publish_live_event", _fake_publish)
+    monkeypatch.setattr("dembrane.agentic_worker.is_cancel_requested", _never_cancel)
+    monkeypatch.setattr("dembrane.agentic_worker.clear_cancel", _clear_cancel)
+
+    await process_agentic_run(
+        run_id=run["id"],
+        project_id="project-1",
+        user_message="hello",
+        bearer_token="token-1",
+        turn_seq=1,
+        owner_token="owner-1",
+        run_service=service,
+    )
+
+    drafts = [
+        json.loads(raw)
+        for raw in published_events
+        if json.loads(raw).get("event_type") == "assistant.draft"
+    ]
+    # No draft from the mimic turn, not even a prefix of the placeholder.
+    assert all(draft["payload"]["message_id"] != "model-run-mimic" for draft in drafts)
+    assert all(not draft["payload"]["text"].startswith("(calling t") for draft in drafts)
+    assert all(draft["payload"]["text"] != "(calling" for draft in drafts)
+    # The real answer still streams once it diverges from the placeholder.
+    answer_drafts = [d for d in drafts if d["payload"]["message_id"] == "model-run-answer"]
+    assert answer_drafts
+    assert answer_drafts[-1]["payload"]["text"] == "(calling all participants early is key.)"


### PR DESCRIPTION
Assistant answers in agentic chat now stream word by word, like the other chat modes. The worker turns on_chat_model_stream chunks into ephemeral assistant.draft snapshots: full text so far, Redis pub/sub only, throttled with size-aware backoff. The SSE endpoint forwards drafts without touching the durable seq cursor, and the panel renders one draft bubble that the durable assistant.message replaces in place via a shared message_id. Reconnects self-heal because every snapshot is complete; every failure path degrades to today's whole-message behavior.

Behavior changes:
- Pre-tool "planning" prose is now persisted: anything shown while streaming must keep a durable copy, or it flickers away. Exception: sendProgressUpdate narration stays suppressed (the tool output repeats it) and the progress message inherits the turn's message_id.
- Chunk events are no longer written to Directus. They were one row per token chunk, the largest event type in the table, and unread.
- The "Send Progress Update" step row is hidden from the tool group; the update itself still posts as a chat message.
- Drafts that are prefixes of the "(calling tools)" placeholder are held back so half-typed placeholders never flash on screen.