### PR TITLE
ECHO-869 fix(frontend): recover tabs stranded on a stale deploy

### DIFF
--- a/echo/frontend/src/App.tsx
+++ b/echo/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { lazy, Suspense, useEffect } from "react";
 import { RouterProvider } from "react-router/dom";
 import { I18nProvider } from "./components/layout/I18nProvider";
 import { ENABLE_AGENTATION, USE_PARTICIPANT_ROUTER } from "./config";
+import { watchForNewVersion } from "./lib/appVersion";
 import { detectAndEmitPilotBlock } from "./lib/pilotBlock";
 
 // Gated at runtime by ENABLE_AGENTATION (config.ts), not at build time, so no
@@ -65,6 +66,8 @@ const router = USE_PARTICIPANT_ROUTER ? participantRouter : mainRouter;
 export const App = () => {
 	// Pageviews (including SPA history changes) are captured by PostHog via
 	// the `defaults` option in posthog.init (src/main.tsx).
+
+	useEffect(() => watchForNewVersion(router), []);
 
 	useEffect(() => {
 		const preloadRoutes = () => {

--- a/echo/frontend/src/lib/appVersion.test.ts
+++ b/echo/frontend/src/lib/appVersion.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const CURRENT_BUILD = "build-current";
+
+vi.mock("posthog-js", () => ({ default: { capture: vi.fn() } }));
+
+const reload = vi.fn();
+
+/** Fresh module per test: the guards and throttle are module state. */
+const loadModule = async () => {
+	vi.resetModules();
+	return import("./appVersion");
+};
+
+const mockVersionEndpoint = (buildId: string) => {
+	const fetchMock = vi.fn().mockResolvedValue({
+		json: async () => ({ buildId }),
+		ok: true,
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+};
+
+const mockUnreadableVersionEndpoint = () => {
+	const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+};
+
+/** Stand-in for the react-router data router's subscribe API. */
+const fakeRouter = (pathname: string) => {
+	const subscribers: Array<
+		(state: { location: { pathname: string } }) => void
+	> = [];
+	return {
+		navigate: (to: string) => {
+			for (const fn of subscribers) fn({ location: { pathname: to } });
+		},
+		state: { location: { pathname } },
+		subscribe: (fn: (state: { location: { pathname: string } }) => void) => {
+			subscribers.push(fn);
+			return () => {};
+		},
+	};
+};
+
+beforeEach(() => {
+	sessionStorage.clear();
+	reload.mockClear();
+	// Re-stubbed per test: `define` supplies the real sha, unstubAllGlobals restores it.
+	vi.stubGlobal("__APP_BUILD_ID__", CURRENT_BUILD);
+	vi.stubEnv("DEV", false as never);
+	Object.defineProperty(window, "location", {
+		configurable: true,
+		value: { ...window.location, reload },
+	});
+	Object.defineProperty(navigator, "onLine", {
+		configurable: true,
+		value: true,
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+// --- reactive path ---
+
+it("reloads when a chunk fails and a newer deploy is serving", async () => {
+	mockVersionEndpoint("build-newer");
+	const { recoverFromChunkFailure } = await loadModule();
+
+	await recoverFromChunkFailure();
+	expect(reload).toHaveBeenCalledTimes(1);
+});
+
+it("leaves a healthy tab alone when the chunk failure was not a new deploy", async () => {
+	// A dropped background prefetch looks exactly like a deleted chunk.
+	mockVersionEndpoint(CURRENT_BUILD);
+	const { recoverFromChunkFailure } = await loadModule();
+
+	await recoverFromChunkFailure();
+	expect(reload).not.toHaveBeenCalled();
+});
+
+it("does not consume the guard when it declines to reload", async () => {
+	mockVersionEndpoint(CURRENT_BUILD);
+	const { recoverFromChunkFailure } = await loadModule();
+
+	await recoverFromChunkFailure();
+
+	mockVersionEndpoint("build-newer");
+	await recoverFromChunkFailure();
+	expect(reload).toHaveBeenCalledTimes(1);
+});
+
+it("takes one guarded reload when the manifest cannot be read", async () => {
+	mockUnreadableVersionEndpoint();
+	const { recoverFromChunkFailure } = await loadModule();
+
+	await recoverFromChunkFailure();
+	expect(reload).toHaveBeenCalledTimes(1);
+
+	await recoverFromChunkFailure();
+	expect(reload).toHaveBeenCalledTimes(1);
+});
+
+it("dedupes concurrent failures from the idle prefetch burst", async () => {
+	const fetchMock = mockVersionEndpoint(CURRENT_BUILD);
+	const { recoverFromChunkFailure } = await loadModule();
+
+	await Promise.all([
+		recoverFromChunkFailure(),
+		recoverFromChunkFailure(),
+		recoverFromChunkFailure(),
+	]);
+	expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+// --- guard ---
+
+it("reloads at most once per target build", async () => {
+	const { reloadForNewVersion } = await loadModule();
+
+	expect(reloadForNewVersion("new_version_detected", "build-b")).toBe(true);
+	expect(reloadForNewVersion("new_version_detected", "build-b")).toBe(false);
+	expect(reload).toHaveBeenCalledTimes(1);
+});
+
+it("stays armed for the next deploy after an earlier reload", async () => {
+	const { reloadForNewVersion } = await loadModule();
+
+	expect(reloadForNewVersion("new_version_detected", "build-b")).toBe(true);
+	expect(reloadForNewVersion("new_version_detected", "build-c")).toBe(true);
+	expect(reload).toHaveBeenCalledTimes(2);
+});
+
+it("caps total reloads per session against a manifest serving rotating ids", async () => {
+	const { reloadForNewVersion } = await loadModule();
+
+	for (const target of ["b", "c", "d", "e", "f"]) {
+		reloadForNewVersion("new_version_detected", target);
+	}
+	expect(reload).toHaveBeenCalledTimes(3);
+});
+
+it("refuses to reload when sessionStorage is unavailable", async () => {
+	vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+		throw new Error("blocked");
+	});
+	const { reloadForNewVersion } = await loadModule();
+
+	expect(reloadForNewVersion("new_version_detected", "build-b")).toBe(false);
+	expect(reload).not.toHaveBeenCalled();
+});
+
+it("declines to reload while offline", async () => {
+	Object.defineProperty(navigator, "onLine", {
+		configurable: true,
+		value: false,
+	});
+	const { reloadForNewVersion } = await loadModule();
+
+	expect(reloadForNewVersion("chunk_load_failed", "build-b")).toBe(false);
+	expect(reload).not.toHaveBeenCalled();
+});
+
+// --- proactive path ---
+
+it("reloads on navigation once the server serves a newer build", async () => {
+	mockVersionEndpoint("build-newer");
+	const { watchForNewVersion } = await loadModule();
+
+	watchForNewVersion(fakeRouter("/en-US/login"));
+	await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+});
+
+it("leaves the tab alone when the server serves the running build", async () => {
+	mockVersionEndpoint(CURRENT_BUILD);
+	const { watchForNewVersion } = await loadModule();
+
+	watchForNewVersion(fakeRouter("/en-US/login"));
+	await Promise.resolve();
+	expect(reload).not.toHaveBeenCalled();
+});
+
+it("does not refetch the manifest on every navigation", async () => {
+	const fetchMock = mockVersionEndpoint(CURRENT_BUILD);
+	const { watchForNewVersion } = await loadModule();
+	const router = fakeRouter("/en-US/login");
+
+	watchForNewVersion(router);
+	router.navigate("/en-US/projects");
+	router.navigate("/en-US/settings");
+
+	await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+});
+
+// --- dev ---
+
+it("is inert in dev, where no manifest is emitted", async () => {
+	vi.stubEnv("DEV", true as never);
+	const fetchMock = mockVersionEndpoint("build-newer");
+	const { watchForNewVersion, recoverFromChunkFailure } = await loadModule();
+
+	watchForNewVersion(fakeRouter("/en-US/login"));
+	await recoverFromChunkFailure();
+
+	expect(fetchMock).not.toHaveBeenCalled();
+	expect(reload).not.toHaveBeenCalled();
+});

--- a/echo/frontend/src/lib/appVersion.ts
+++ b/echo/frontend/src/lib/appVersion.ts
@@ -1,0 +1,147 @@
+// Stale-deploy recovery: a tab holding an old index.html requests hashed chunks
+// the newest deploy no longer serves. Both halves confirm a newer build first.
+
+import posthog from "posthog-js";
+
+// `typeof` guard so a missing `define` disables the mechanism instead of throwing.
+export const BUILD_ID: string =
+	typeof __APP_BUILD_ID__ === "string" ? __APP_BUILD_ID__ : "unknown";
+
+const VERSION_URL = "/version.json";
+const MIN_CHECK_INTERVAL_MS = 60_000;
+const MAX_RELOADS_PER_SESSION = 3;
+
+const COUNT_KEY = "dembrane:version-reloads";
+const targetKey = (target: string) => `dembrane:version-reload:${target}`;
+
+export type ReloadReason = "new_version_detected" | "chunk_load_failed";
+
+/** Dev emits no manifest, so there is nothing to compare against. */
+const isEnabled = (): boolean => !import.meta.env.DEV && BUILD_ID !== "unknown";
+
+/** sessionStorage, or null where it throws (private mode, blocked frames). */
+const openGuardStore = (): Storage | null => {
+	try {
+		const probe = "dembrane:version-probe";
+		sessionStorage.setItem(probe, "1");
+		sessionStorage.removeItem(probe);
+		return sessionStorage;
+	} catch {
+		return null;
+	}
+};
+
+/** Returns whether the reload was taken, so callers can fall back on false. */
+export const reloadForNewVersion = (
+	reason: ReloadReason,
+	targetBuildId: string | null,
+): boolean => {
+	// A dead chunk and a dead network look alike; reloading offline is worse.
+	if (typeof navigator !== "undefined" && navigator.onLine === false) {
+		return false;
+	}
+
+	const store = openGuardStore();
+	// No persistence means no way to bound the reloads.
+	if (!store) return false;
+
+	// Keyed on the target, not the running build, so one reload doesn't disarm
+	// the tab for the next deploy.
+	const key = targetKey(targetBuildId ?? "unknown");
+	if (store.getItem(key)) return false;
+
+	// Backstop for a manifest reporting a stream of different targets.
+	const count = Number.parseInt(store.getItem(COUNT_KEY) ?? "0", 10) || 0;
+	if (count >= MAX_RELOADS_PER_SESSION) return false;
+
+	store.setItem(key, "1");
+	store.setItem(COUNT_KEY, String(count + 1));
+
+	posthog.capture(
+		"app_version_reloaded",
+		{ build_id: BUILD_ID, reason, target_build_id: targetBuildId },
+		// The reload races the batch queue.
+		{ send_instantly: true, transport: "sendBeacon" },
+	);
+	window.location.reload();
+	return true;
+};
+
+/** Build id the server is currently serving, or null if it can't be read. */
+const fetchDeployedBuildId = async (): Promise<string | null> => {
+	try {
+		const response = await fetch(VERSION_URL, { cache: "no-store" });
+		if (!response.ok) return null;
+		const body = (await response.json()) as { buildId?: unknown };
+		return typeof body.buildId === "string" ? body.buildId : null;
+	} catch {
+		return null;
+	}
+};
+
+let recovering = false;
+
+/** Reactive path: a dynamic import failed. */
+export const recoverFromChunkFailure = async (): Promise<void> => {
+	// Deduped: the idle prefetch can fail on several chunks at once.
+	if (!isEnabled() || recovering) return;
+	recovering = true;
+
+	try {
+		const deployed = await fetchDeployedBuildId();
+
+		// Unreadable manifest, but the route is dead either way.
+		if (deployed === null) {
+			reloadForNewVersion("chunk_load_failed", null);
+			return;
+		}
+
+		// Chunk is missing from the deploy we are already on, so reloading cannot
+		// help. Let it fall through to the ErrorBoundary.
+		if (deployed === BUILD_ID) return;
+
+		reloadForNewVersion("chunk_load_failed", deployed);
+	} finally {
+		recovering = false;
+	}
+};
+
+let lastCheckedAt = 0;
+
+const checkForNewVersion = async (): Promise<void> => {
+	if (!isEnabled()) return;
+
+	const now = Date.now();
+	if (now - lastCheckedAt < MIN_CHECK_INTERVAL_MS) return;
+	lastCheckedAt = now;
+
+	const deployed = await fetchDeployedBuildId();
+	if (deployed === null || deployed === BUILD_ID) return;
+
+	reloadForNewVersion("new_version_detected", deployed);
+};
+
+interface SubscribableRouter {
+	subscribe: (
+		fn: (state: { location: { pathname: string } }) => void,
+	) => () => void;
+	state: { location: { pathname: string } };
+}
+
+/**
+ * Proactive path. Route changes only: a navigation already discards screen
+ * state, whereas a timer or tab focus could yank a half-filled form.
+ */
+export const watchForNewVersion = (
+	router: SubscribableRouter,
+): (() => void) => {
+	void checkForNewVersion();
+
+	let lastPathname = router.state.location.pathname;
+
+	return router.subscribe((state) => {
+		if (state.location.pathname === lastPathname) return;
+		lastPathname = state.location.pathname;
+		void checkForNewVersion();
+	});
+};

--- a/echo/frontend/src/main.tsx
+++ b/echo/frontend/src/main.tsx
@@ -12,19 +12,10 @@ import {
 	POSTHOG_UI_HOST,
 	USE_PARTICIPANT_ROUTER,
 } from "./config";
+import { recoverFromChunkFailure } from "./lib/appVersion";
 
 posthog.init(POSTHOG_TOKEN, {
 	api_host: POSTHOG_HOST,
-	// api_host is our reverse proxy; ui_host must stay the real PostHog host so
-	// the toolbar and in-app links resolve (required when api_host is proxied).
-	ui_host: POSTHOG_UI_HOST,
-	// The portal serves anonymous participants on a privacy-sensitive flow, so
-	// never record their sessions. We track the journey with explicit events
-	// instead. The dashboard (hosts) is unaffected.
-	disable_session_recording: USE_PARTICIPANT_ROUTER,
-	// Share the cookie across .dembrane.com so a visitor's distinct id carries
-	// over from the marketing site, stitching both into one person profile.
-	cross_subdomain_cookie: true,
 	// Error tracking: autocapture unhandled errors and promise rejections.
 	// React render errors are reported separately via ErrorBoundary.
 	capture_exceptions: {
@@ -32,7 +23,14 @@ posthog.init(POSTHOG_TOKEN, {
 		capture_unhandled_errors: true,
 		capture_unhandled_rejections: true,
 	},
+	// Share the cookie across .dembrane.com so a visitor's distinct id carries
+	// over from the marketing site, stitching both into one person profile.
+	cross_subdomain_cookie: true,
 	defaults: "2026-01-30",
+	// The portal serves anonymous participants on a privacy-sensitive flow, so
+	// never record their sessions. We track the journey with explicit events
+	// instead. The dashboard (hosts) is unaffected.
+	disable_session_recording: USE_PARTICIPANT_ROUTER,
 	loaded: (ph) => {
 		// testing + local never send analytics (see POSTHOG_CAPTURE in config.ts).
 		// The opt-out persists per-domain, so explicitly opt back in when the
@@ -46,6 +44,15 @@ posthog.init(POSTHOG_TOKEN, {
 			posthog.opt_in_capturing({ captureEventName: null });
 		}
 	},
+	// api_host is our reverse proxy; ui_host must stay the real PostHog host so
+	// the toolbar and in-app links resolve (required when api_host is proxied).
+	ui_host: POSTHOG_UI_HOST,
+});
+
+// Not calling preventDefault: cancelling makes Vite resolve the import to
+// `undefined`, so LazyRoute throws a misleading error instead of the real one.
+window.addEventListener("vite:preloadError", () => {
+	void recoverFromChunkFailure();
 });
 
 const root = document.getElementById("root");

--- a/echo/frontend/src/vite-env.d.ts
+++ b/echo/frontend/src/vite-env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
+/** Injected by vite.config.ts `define`. */
+declare const __APP_BUILD_ID__: string;
+
 declare module "*.woff2?inline" {
 	const src: string;
 	export default src;

--- a/echo/frontend/vercel.json
+++ b/echo/frontend/vercel.json
@@ -24,12 +24,21 @@
 				}
 			],
 			"source": "/(.*)"
+		},
+		{
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "no-store"
+				}
+			],
+			"source": "/version.json"
 		}
 	],
 	"rewrites": [
 		{
 			"destination": "/",
-			"source": "/(.*)"
+			"source": "/((?!assets/).*)"
 		}
 	]
 }

--- a/echo/frontend/vite.config.ts
+++ b/echo/frontend/vite.config.ts
@@ -1,7 +1,8 @@
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { lingui } from "@lingui/vite-plugin";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 
 // Babel plugin: inject __source into the props object of _jsx/_jsxs calls so
 // Agentation can resolve element-to-source paths in production-mode builds.
@@ -85,9 +86,40 @@ const injectJsxSource = (babel: any) => {
 	};
 };
 
+// Identifies the build; the client compares it against /version.json.
+const resolveBuildId = (): string => {
+	// VERCEL_GIT_COMMIT_SHA covers a Vercel-native build, whose container does
+	// not expose .git, so the git fallback below would miss.
+	const sha = process.env.GITHUB_SHA || process.env.VERCEL_GIT_COMMIT_SHA;
+	if (sha) return sha.slice(0, 12);
+	try {
+		return execSync("git rev-parse --short=12 HEAD", {
+			stdio: ["ignore", "pipe", "ignore"],
+		})
+			.toString()
+			.trim();
+	} catch {
+		return `t${Date.now().toString(36)}`;
+	}
+};
+
+// Emitted through rollup rather than public/ so it always matches the assets.
+const emitVersionManifest = (buildId: string): PluginOption => ({
+	apply: "build",
+	generateBundle() {
+		this.emitFile({
+			fileName: "version.json",
+			source: JSON.stringify({ buildId }),
+			type: "asset",
+		});
+	},
+	name: "dembrane-version-manifest",
+});
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
 	const isDev = mode === "development";
+	const buildId = resolveBuildId();
 	const devApiProxyTarget =
 		process.env.VITE_DEV_API_PROXY || "http://localhost:8000/";
 	const devDirectusProxyTarget =
@@ -127,6 +159,9 @@ export default defineConfig(({ mode }) => {
 				},
 			},
 		},
+		define: {
+			__APP_BUILD_ID__: JSON.stringify(buildId),
+		},
 		plugins: [
 			react({
 				babel: {
@@ -135,6 +170,7 @@ export default defineConfig(({ mode }) => {
 				},
 			}),
 			lingui(),
+			emitVersionManifest(buildId),
 		],
 		resolve: {
 			alias: {


### PR DESCRIPTION
Code-split routes mean a long-open tab holding an old index.html requests hashed chunks the newest Vercel deploy no longer serves, and the route dies. PostHog issue 019eef48 covers ~40 hosts, still firing, across login and every other lazy route.

Stamp a build id into the bundle and into /version.json, then reload the tab onto the current deploy: proactively at route changes, and reactively on vite:preloadError. Both paths confirm a newer build exists first, so a dropped background prefetch or a chunk genuinely missing from the current build does not reload a healthy tab.

Reloads are guarded: skipped while offline, keyed on the target build so one reload does not disarm the tab for the next deploy, capped at 3 per session, and refused outright when sessionStorage is unavailable and no bound could be recorded.

Skew Protection was considered and rejected: it pins the client to an old deployment while the API ships separately on k8s, trading a loud chunk error for quiet frontend/backend skew. It also needs config Vite does not get for free and breaks under vercel deploy --prebuilt.

Also stop the SPA catch-all rewrite from returning index.html as 200 text/html for missing /assets, so dead chunks 404 honestly.