### PR TITLE
ECHO-930 chore(server): remove recording_started_at deploy fallback

### DIFF
--- a/echo/server/dembrane/api/v2/bff/conversations.py
+++ b/echo/server/dembrane/api/v2/bff/conversations.py
@@ -38,7 +38,6 @@ from fastapi import Query, Request, APIRouter, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
 
-from dembrane.directus import is_unknown_field_error
 from dembrane.settings import get_settings
 from dembrane.free_tier import resolve_project_gate, workspace_over_cap_active
 from dembrane.redis_async import get_redis_client
@@ -92,29 +91,6 @@ _CONVERSATION_DEFAULT_FIELDS = [
     "is_over_cap",
     "move_history",
 ]
-
-_RECORDING_STARTED_AT = "recording_started_at"
-
-
-async def _get_conversations(query_dict: dict) -> Any:
-    """List conversations, degrading if recording_started_at isn't deployed yet.
-
-    API pods can roll before the Directus snapshot applies; without this the
-    whole list would come back as a query error.
-    """
-    result = await async_directus.get_items("conversation", {"query": query_dict})
-    fields = query_dict.get("fields") or []
-    if _RECORDING_STARTED_AT not in fields:
-        return result
-    detail = result.get("error") if isinstance(result, dict) else None
-    if detail is None or not is_unknown_field_error(detail, _RECORDING_STARTED_AT):
-        return result
-    logger.warning(
-        "conversation list: %s missing in Directus, retrying without it", _RECORDING_STARTED_AT
-    )
-    retry = {**query_dict, "fields": [f for f in fields if f != _RECORDING_STARTED_AT]}
-    return await async_directus.get_items("conversation", {"query": retry})
-
 
 # Shared by the list/count/select-all endpoints so they stay consistent.
 # No `id`: Directus rejects _icontains on uuid fields and errors the query.
@@ -290,7 +266,13 @@ async def list_conversations(
             conv_filter, search_text.strip(), _CONVERSATION_SEARCH_FIELDS
         )
 
-    convs = await _get_conversations(query_dict) or []
+    convs = (
+        await async_directus.get_items(
+            "conversation",
+            {"query": query_dict},
+        )
+        or []
+    )
     if not isinstance(convs, list):
         return []
 

--- a/echo/server/dembrane/directus.py
+++ b/echo/server/dembrane/directus.py
@@ -56,28 +56,6 @@ class DirectusBadRequest(DirectusGenericException):
     """Exception raised for bad requests to Directus API (e.g., assertion errors)."""
 
 
-_UNKNOWN_FIELD_SIGNATURES = (
-    "invalid query",
-    "invalid_query",
-    "doesn't exist",
-    "does not exist",
-    "failedvalidation",
-)
-
-
-def is_unknown_field_error(detail: Any, field: str) -> bool:
-    """True when a Directus error says `field` is not in the collection.
-
-    Lets callers tolerate a column that exists in code but not yet in the
-    deployed Directus schema, without swallowing real 403/500 failures.
-    """
-    text = str(detail)
-    if field not in text:
-        return False
-    lowered = text.lower()
-    return any(signature in lowered for signature in _UNKNOWN_FIELD_SIGNATURES)
-
-
 def is_recoverable_error(response: requests.Response) -> bool:
     """
     Check if the response status code indicates a recoverable error.

--- a/echo/server/dembrane/service/conversation.py
+++ b/echo/server/dembrane/service/conversation.py
@@ -12,7 +12,6 @@ from dembrane.directus import (
     DirectusBadRequest,
     DirectusGenericException,
     directus,
-    is_unknown_field_error,
     directus_client_context,
 )
 
@@ -92,15 +91,9 @@ def stamp_recording_started_at(
         try:
             active_client.patch("/items/conversation", json=payload)
         except DirectusBadRequest as exc:
-            if is_unknown_field_error(exc, "recording_started_at"):
-                # column not deployed in this environment yet
-                logger.debug(
-                    "recording_started_at not writable for %s", conversation_id, exc_info=True
-                )
-            else:
-                logger.warning(
-                    "failed to stamp recording_started_at for %s: %s", conversation_id, exc
-                )
+            logger.warning(
+                "failed to stamp recording_started_at for %s: %s", conversation_id, exc
+            )
 
 
 def sanitize_url_for_logging(url: str) -> str:
@@ -147,11 +140,6 @@ class ConversationService:
         Fill-if-empty only: never overwrites a value the server-clocked liveness
         path already wrote.
         """
-        if "recording_started_at" not in conversation:
-            # column not deployed in this environment yet
-            logger.debug("recording_started_at absent on %s, skipping", conversation.get("id"))
-            return
-
         if conversation.get("source") == "DASHBOARD_UPLOAD":
             # upload time is not a recording start
             return

--- a/echo/server/tests/service/test_conversation_service.py
+++ b/echo/server/tests/service/test_conversation_service.py
@@ -741,7 +741,7 @@ def test_stamp_filter_excludes_dashboard_uploads():
 
 
 def test_stamp_logs_warning_on_unexpected_directus_error(caplog):
-    """A 403/500 must be visible, not swallowed as 'column not deployed'."""
+    """A Directus error is logged as a warning, not raised or swallowed."""
     context, mock_client = _mock_directus()
     try:
         mock_client.patch.side_effect = DirectusBadRequest("403 Forbidden")
@@ -750,37 +750,6 @@ def test_stamp_logs_warning_on_unexpected_directus_error(caplog):
                 "conv-1", datetime(2024, 1, 15, 14, 30, 25, tzinfo=timezone.utc)
             )
         assert any("403 Forbidden" in record.getMessage() for record in caplog.records)
-    finally:
-        context.stop()
-
-
-def test_stamp_stays_quiet_when_column_not_deployed(caplog):
-    """The pre-migration unknown-field error is expected, so no warning."""
-    context, mock_client = _mock_directus()
-    try:
-        mock_client.patch.side_effect = DirectusBadRequest(
-            'Invalid query. Field "recording_started_at" does not exist in collection "conversation".'
-        )
-        with caplog.at_level(logging.WARNING, logger="dembrane.service.conversation"):
-            stamp_recording_started_at(
-                "conv-1", datetime(2024, 1, 15, 14, 30, 25, tzinfo=timezone.utc)
-            )
-        assert caplog.records == []
-    finally:
-        context.stop()
-
-
-def test_stamp_recording_started_at_skips_when_column_missing():
-    """Migration not applied: the key is absent and no PATCH is attempted."""
-    conversation = {"id": "conv-1", "created_at": "2024-01-01T00:00:00Z"}
-
-    context, mock_client = _mock_directus()
-    try:
-        conversation_service._stamp_recording_started_at(
-            conversation, datetime(2024, 1, 15, 14, 30, 25)
-        )
-
-        mock_client.patch.assert_not_called()
     finally:
         context.stop()
 


### PR DESCRIPTION
The column ships with the Directus snapshot before the next release, so the pre-deployment tolerance is dead code:

- drop is_unknown_field_error and its error-signature matching
- BFF conversation list no longer retries without the field
- stamp_recording_started_at logs a warning on any DirectusBadRequest instead of special-casing an unknown column
- create_chunk no longer skips stamping when the key is absent
- delete the two tests covering the pre-migration paths