### PR TITLE
ECHO-939 fix(conversation): generate a single title instead of a list of options

### DIFF
--- a/echo/server/dembrane/api/stateless.py
+++ b/echo/server/dembrane/api/stateless.py
@@ -97,6 +97,32 @@ def generate_summary(
         return ""
 
 
+def _clean_generated_title(content: str) -> str:
+    # The model occasionally returns a list of options or wraps the title in
+    # quotes/markdown; keep only the first candidate as plain text.
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    if not lines:
+        return ""
+
+    list_item = re.compile(r"^(?:[-*•]\s+|\d+[.):]\s+)(.+)$")
+    candidate = ""
+    for line in lines:
+        match = list_item.match(line)
+        if match:
+            candidate = match.group(1)
+            break
+    if not candidate:
+        for i, line in enumerate(lines):
+            # Skip preamble like "Here are some options:" when more lines follow
+            if line.endswith(":") and i < len(lines) - 1:
+                continue
+            candidate = line
+            break
+
+    candidate = re.sub(r"^\*\*(.+?)\*\*$", r"\1", candidate)
+    return candidate.strip().strip("\"'“”‘’").strip()
+
+
 def generate_conversation_title(
     summary: str,
     language: str | None,
@@ -147,7 +173,7 @@ def generate_conversation_title(
         if response_content is None:
             logger.warning("LLM returned None content for title")
             return ""
-        return response_content.strip()
+        return _clean_generated_title(response_content)
     except (IndexError, AttributeError, KeyError) as e:
         logger.error(f"Error getting response content for title: {e}")
         return ""

--- a/echo/server/prompt_templates/generate_conversation_title.en.jinja
+++ b/echo/server/prompt_templates/generate_conversation_title.en.jinja
@@ -27,4 +27,5 @@ Generate a 1-3 word title that captures the essence of this conversation.
 - Match the style of existing titles if provided
 - Be specific, not generic (avoid "Discussion" or "Meeting")
 - Do NOT use person names as the title
-- Output ONLY the title, nothing else
+- Output exactly ONE title on a single line, nothing else
+- Never output a list of options, alternatives, or numbered suggestions, even if the custom instructions ask for several: pick the single best title yourself

--- a/echo/server/tests/test_clean_generated_title.py
+++ b/echo/server/tests/test_clean_generated_title.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from dembrane.api.stateless import _clean_generated_title
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # plain title passes through
+        ("Housing Costs", "Housing Costs"),
+        ("  Buurtveiligheid  \n", "Buurtveiligheid"),
+        ("2025-2026 Budget", "2025-2026 Budget"),
+        # lists collapse to the first option
+        ("1. Housing Costs\n2. Rent Debate", "Housing Costs"),
+        ("- Housing Costs\n- Rent Debate", "Housing Costs"),
+        ("* Housing Costs\n* Rent Debate", "Housing Costs"),
+        # preamble before a list is skipped
+        (
+            "Here are some options:\n1. Housing Costs\n2. Rent Debate\n3. Zoning Rules",
+            "Housing Costs",
+        ),
+        ("Here are 3 titles:\n- **Wijkgroen**\n- Parkeerdruk", "Wijkgroen"),
+        # quote and markdown wrappers stripped
+        ('"Housing Costs"', "Housing Costs"),
+        ("**Housing Costs**", "Housing Costs"),
+        ("“Housing Costs”", "Housing Costs"),
+        # a colon inside a title is kept when there is nothing after it
+        ("Title: Housing Costs", "Title: Housing Costs"),
+        # degenerate inputs
+        ("", ""),
+        ("\n\n", ""),
+    ],
+)
+def test_clean_generated_title(raw: str, expected: str) -> None:
+    assert _clean_generated_title(raw) == expected


### PR DESCRIPTION
The title generator stored the LLM response verbatim, so when the model returned multiple suggestions (or a custom title prompt asked for options), the whole list was crammed into the conversation title field.

- Sanitize the LLM output in generate_conversation_title: take the first list item (skipping preamble like "Here are some options:"), strip bullets, numbering, quotes, and markdown bold
- Harden the prompt to require exactly one title on a single line, even when custom instructions ask for several
- Add unit tests for the sanitizer