### PR TITLE
ECHO-933 fix: serialize app_user.settings writes with per-user Redis lock

### DIFF
--- a/echo/server/dembrane/api/v2/me.py
+++ b/echo/server/dembrane/api/v2/me.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
 from pydantic import Field, BaseModel
+from redis.exceptions import LockError
 
 from dembrane.app_user import (
     resolve_app_user,
@@ -14,6 +15,7 @@ from dembrane.app_user import (
     get_directus_user_profile,
 )
 from dembrane.policies import ROLE_HIERARCHY as _ROLE_LEVEL
+from dembrane.redis_async import get_redis_client
 from dembrane.seat_capacity import assert_can_add_seat
 from dembrane.api.rate_limit import create_user_rate_limiter
 from dembrane.api.v2.invites import compute_invite_hash
@@ -245,6 +247,9 @@ async def update_me(
     auth: DependencyDirectusSession,
 ) -> dict:
     """Update the current user's profile (display_name and settings)."""
+    if body.display_name is None and body.settings is None:
+        raise HTTPException(status_code=400, detail="Nothing to update")
+
     app_user = await get_app_user_or_raise(auth.user_id)
 
     payload: dict[str, Any] = {}
@@ -254,17 +259,42 @@ async def update_me(
         cleaned = body.display_name.replace("\r", " ").replace("\n", " ").strip()
         payload["display_name"] = cleaned
 
+    lock = None
     if body.settings is not None:
-        existing_settings = app_user.get("settings") or {}
-        if not isinstance(existing_settings, dict):
-            existing_settings = {}
-        merged_settings = {**existing_settings, **body.settings}
-        payload["settings"] = merged_settings
+        # Per-user lock: concurrent read-merge-writes clobber each other's keys.
+        # Fails closed if Redis is down; an unlocked fallback would revive the race.
+        redis = await get_redis_client()
+        lock = redis.lock(
+            f"dembrane:app_user_settings_lock:{app_user['id']}",
+            timeout=30,
+            blocking_timeout=3,
+        )
+        if not await lock.acquire():
+            raise HTTPException(
+                status_code=503,
+                detail="Settings are being updated, try again",
+                headers={"Retry-After": "2"},
+            )
 
-    if not payload:
-        raise HTTPException(status_code=400, detail="Nothing to update")
-
-    await async_directus.update_item("app_user", app_user["id"], payload)
+    try:
+        if body.settings is not None:
+            # Re-read inside the lock; the pre-lock read may be stale.
+            fresh_user = await get_app_user_or_raise(auth.user_id)
+            existing_settings = fresh_user.get("settings") or {}
+            if not isinstance(existing_settings, dict):
+                existing_settings = {}
+            payload["settings"] = {**existing_settings, **body.settings}
+        await async_directus.update_item("app_user", app_user["id"], payload)
+    finally:
+        if lock is not None:
+            try:
+                await lock.release()
+            except LockError:
+                # Lock expired mid-hold; the write already committed.
+                logger.warning(
+                    "settings lock for app_user %s expired before release",
+                    app_user["id"],
+                )
     return {"status": "success"}
 
 

--- a/echo/server/tests/test_user_settings_flags.py
+++ b/echo/server/tests/test_user_settings_flags.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI
+from redis.exceptions import LockError, LockNotOwnedError
 
 from dembrane.api.v2.me import router
 from dembrane.api.dependency_auth import DirectusSession, require_directus_session
@@ -48,7 +50,7 @@ async def test_get_me_returns_settings(
         "display_name": "Test User",
         "settings": {"enable_collapsible_sidebar": True},
     }
-    mock_directus.get_items.return_value = []  # No memberships, etc.
+    mock_directus.get_items = AsyncMock(return_value=[])  # No memberships, etc.
 
     app = _build_app()
     async with AsyncClient(
@@ -67,6 +69,7 @@ async def test_get_me_returns_settings(
 async def test_patch_me_updates_and_merges_settings(
     mock_get_raise: AsyncMock,
     mock_directus: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """PATCH /v2/me updates and merges settings dict in app_user."""
     # Existing settings in app_user
@@ -76,6 +79,7 @@ async def test_patch_me_updates_and_merges_settings(
     }
 
     mock_directus.update_item = AsyncMock(return_value={"data": {}})
+    _install_fake_redis(monkeypatch)
 
     app = _build_app()
     async with AsyncClient(
@@ -102,3 +106,183 @@ async def test_patch_me_updates_and_merges_settings(
             }
         },
     )
+
+
+class _FakeLock:
+    """Mimics redis.asyncio Lock: explicit acquire/release plus context manager."""
+
+    def __init__(self, lock: "asyncio.Lock"):
+        self._lock = lock
+
+    async def acquire(self) -> bool:
+        await self._lock.acquire()
+        return True
+
+    async def release(self) -> None:
+        self._lock.release()
+
+    async def __aenter__(self) -> "_FakeLock":
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        await self.release()
+        return False
+
+
+class _FakeRedisLocks:
+    """Models a correct distributed lock service: mutual exclusion per key."""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def lock(self, name: str, **_kwargs) -> _FakeLock:
+        return _FakeLock(self._locks.setdefault(name, asyncio.Lock()))
+
+
+def _install_fake_redis(monkeypatch: pytest.MonkeyPatch) -> _FakeRedisLocks:
+    fake_redis = _FakeRedisLocks()
+
+    async def fake_get_redis() -> _FakeRedisLocks:
+        return fake_redis
+
+    monkeypatch.setattr("dembrane.api.v2.me.get_redis_client", fake_get_redis)
+    return fake_redis
+
+
+@pytest.mark.asyncio
+@patch("dembrane.api.v2.me.async_directus")
+@patch("dembrane.api.v2.me.get_app_user_or_raise")
+async def test_patch_me_concurrent_settings_writes_do_not_clobber(
+    mock_get_raise: AsyncMock,
+    mock_directus: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two concurrent PATCHes with different settings keys must both survive.
+
+    Reproduces the read-merge-write lost-update race: each request reads the
+    settings blob, merges its own key in Python, and writes the whole blob
+    back. Without per-user serialization, the last write erases the other
+    request's key.
+    """
+    store: dict = {"id": _APP_USER_ID, "settings": {}}
+
+    async def fake_get(_user_id: str) -> dict:
+        # Snapshot read, like Directus returning the current row
+        return {"id": store["id"], "settings": dict(store["settings"])}
+
+    async def fake_update(_collection: str, _item_id: str, payload: dict) -> dict:
+        # Yield before committing, like real Directus write latency, so the
+        # second request's read happens before this write lands
+        await asyncio.sleep(0.05)
+        store["settings"] = dict(payload["settings"])
+        return {"data": {}}
+
+    mock_get_raise.side_effect = fake_get
+    mock_directus.update_item = AsyncMock(side_effect=fake_update)
+
+    _install_fake_redis(monkeypatch)
+
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp_a, resp_b = await asyncio.gather(
+            ac.patch("/v2/me", json={"settings": {"release_video_seen": "2026-08"}}),
+            ac.patch("/v2/me", json={"settings": {"race_test_flag": True}}),
+        )
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    assert store["settings"] == {
+        "release_video_seen": "2026-08",
+        "race_test_flag": True,
+    }
+
+
+class _FlakyReleaseLock(_FakeLock):
+    """Lock whose key 'expired' mid-hold: release always fails."""
+
+    async def release(self) -> None:
+        await super().release()
+        raise LockNotOwnedError("Cannot release a lock that's no longer owned")
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        await self.release()
+        return False
+
+
+class _UnavailableLock(_FakeLock):
+    """Lock that can never be acquired (someone else holds it)."""
+
+    async def acquire(self) -> bool:
+        return False
+
+    async def __aenter__(self) -> "_FakeLock":
+        raise LockError("Unable to acquire lock within the time specified")
+
+
+@pytest.mark.asyncio
+@patch("dembrane.api.v2.me.async_directus")
+@patch("dembrane.api.v2.me.get_app_user_or_raise")
+async def test_patch_me_succeeds_when_lock_release_fails(
+    mock_get_raise: AsyncMock,
+    mock_directus: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A lock that expires before release (clock jump, slow request) must not
+    fail the request: the settings write already committed."""
+    mock_get_raise.return_value = {"id": _APP_USER_ID, "settings": {}}
+    mock_directus.update_item = AsyncMock(return_value={"data": {}})
+
+    fake_redis = _install_fake_redis(monkeypatch)
+    monkeypatch.setattr(
+        fake_redis,
+        "lock",
+        lambda name, **_kw: _FlakyReleaseLock(
+            fake_redis._locks.setdefault(name, asyncio.Lock())
+        ),
+    )
+
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.patch("/v2/me", json={"settings": {"flag": True}})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+    mock_directus.update_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("dembrane.api.v2.me.async_directus")
+@patch("dembrane.api.v2.me.get_app_user_or_raise")
+async def test_patch_me_returns_503_when_lock_unavailable(
+    mock_get_raise: AsyncMock,
+    mock_directus: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the per-user lock cannot be acquired in time, fail loudly with 503
+    instead of silently racing or returning a generic 500."""
+    mock_get_raise.return_value = {"id": _APP_USER_ID, "settings": {}}
+    mock_directus.update_item = AsyncMock(return_value={"data": {}})
+
+    fake_redis = _install_fake_redis(monkeypatch)
+    monkeypatch.setattr(
+        fake_redis,
+        "lock",
+        lambda name, **_kw: _UnavailableLock(
+            fake_redis._locks.setdefault(name, asyncio.Lock())
+        ),
+    )
+
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.patch("/v2/me", json={"settings": {"flag": True}})
+
+    assert response.status_code == 503
+    assert response.headers.get("Retry-After") == "2"
+    mock_directus.update_item.assert_not_called()


### PR DESCRIPTION
PATCH /v2/me merged settings via read-merge-write, so concurrent requests (two tabs, double-fired mutations) read the same stale blob and the last write erased the other's keys. Reproduced live: a release video dismissal was lost to a concurrent settings write.

Wrap the settings merge in a per-user Redis lock (existing redis_async client), re-reading the blob inside the lock before merging. Fails closed: 503 with Retry-After if the lock is busy past 3s, and a warning (not a 500) if the lock expires before release, since the write has already committed by then. Lock TTL is 30s as a crash-recovery bound; real holds are ~100ms.

Tests: concurrency test that fails without the lock, plus lock-busy (503) and release-failure (200) edge cases. Also repairs the broken get_items mock in the existing GET /v2/me test.