### PR TITLE
fix(theme): read v2 preferences key in pre-mount theme script

### DIFF
--- a/echo/frontend/index.html
+++ b/echo/frontend/index.html
@@ -16,8 +16,10 @@
     <script>
       (function() {
         try {
-          var prefs = JSON.parse(localStorage.getItem('dembrane-app-preferences') || '{}');
-          var isDmSans = prefs.fontFamily === 'dm-sans';
+          var prefs = JSON.parse(localStorage.getItem('dembrane-app-preferences-v2') || '{}');
+          var urlTheme = new URLSearchParams(window.location.search).get('theme');
+          var fontFamily = (urlTheme === 'dm-sans' || urlTheme === 'space-grotesk') ? urlTheme : prefs.fontFamily;
+          var isDmSans = fontFamily !== 'space-grotesk';
           var bg = isDmSans ? '#F6F4F1' : '#FFFFFF';
           var text = isDmSans ? '#2D2D2C' : '#000000';
           var font = isDmSans ? "'DM Sans Variable', sans-serif" : "'Space Grotesk Variable', sans-serif";


### PR DESCRIPTION
index.html still read the old 'dembrane-app-preferences' key after the storage key moved to '-v2', so the pre-mount script always saw empty prefs and first-painted Space Grotesk/white for DM Sans users. Read the v2 key, default to DM Sans to match the app default, and honor the ?theme= URL param like useAppPreferences does.