### PR TITLE
ECHO-949 fix(auth): validate ?next deep-links against the account's access

### DIFF
--- a/echo/frontend/src/components/auth/utils/nextPath.test.ts
+++ b/echo/frontend/src/components/auth/utils/nextPath.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { resolveNextPath } from "./nextPath";
+
+const ORG_A = "3dab35ac-47ff-47c6-b48f-0e366b0f8555";
+const ORG_B = "9c1f2e10-1111-4222-8333-444455556666";
+const WS_A = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const WS_B = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+
+const workspaces = [
+	{ id: WS_A, org_id: ORG_A },
+	{ id: WS_B, org_id: ORG_A },
+];
+
+describe("resolveNextPath", () => {
+	it("rejects unsafe paths", () => {
+		expect(resolveNextPath("https://evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("//evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("/\\evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("relative/path", workspaces)).toBeNull();
+		expect(resolveNextPath(null, workspaces)).toBeNull();
+		expect(resolveNextPath(undefined, workspaces)).toBeNull();
+		expect(resolveNextPath("", workspaces)).toBeNull();
+	});
+
+	it("rejects auth paths to avoid redirect loops", () => {
+		expect(resolveNextPath("/login", workspaces)).toBeNull();
+		expect(resolveNextPath("/en-US/login?verified=1", workspaces)).toBeNull();
+		expect(resolveNextPath("/register", workspaces)).toBeNull();
+	});
+
+	it("allows an org path the user has a workspace in", () => {
+		expect(resolveNextPath(`/o/${ORG_A}/overview`, workspaces)).toBe(
+			`/o/${ORG_A}/overview`,
+		);
+	});
+
+	it("allows a locale-prefixed org path the user has access to", () => {
+		expect(resolveNextPath(`/en-US/o/${ORG_A}/overview`, workspaces)).toBe(
+			`/en-US/o/${ORG_A}/overview`,
+		);
+	});
+
+	it("rejects an org path the user has no access to", () => {
+		expect(resolveNextPath(`/o/${ORG_B}/overview`, workspaces)).toBeNull();
+		expect(
+			resolveNextPath(`/en-US/o/${ORG_B}/overview`, workspaces),
+		).toBeNull();
+	});
+
+	it("allows the bare /o landing without any access check", () => {
+		expect(resolveNextPath("/o", workspaces)).toBe("/o");
+		expect(resolveNextPath("/en-US/o", workspaces)).toBe("/en-US/o");
+	});
+
+	it("allows a workspace path the user is a member of", () => {
+		expect(resolveNextPath(`/w/${WS_A}/home`, workspaces)).toBe(
+			`/w/${WS_A}/home`,
+		);
+	});
+
+	it("rejects a workspace path the user is not a member of", () => {
+		const foreignWs = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f";
+		expect(resolveNextPath(`/w/${foreignWs}/home`, workspaces)).toBeNull();
+	});
+
+	it("allows unscoped app paths", () => {
+		expect(resolveNextPath("/profile", workspaces)).toBe("/profile");
+	});
+
+	it("ignores query and hash when extracting scope ids", () => {
+		expect(
+			resolveNextPath(`/o/${ORG_B}/overview?tab=members`, workspaces),
+		).toBeNull();
+		expect(
+			resolveNextPath(`/o/${ORG_A}/overview?tab=members#x`, workspaces),
+		).toBe(`/o/${ORG_A}/overview?tab=members#x`);
+	});
+
+	it("rejects org/workspace paths when the workspace list is empty", () => {
+		expect(resolveNextPath(`/o/${ORG_A}/overview`, [])).toBeNull();
+		expect(resolveNextPath(`/w/${WS_A}/home`, [])).toBeNull();
+	});
+});

--- a/echo/frontend/src/components/auth/utils/nextPath.ts
+++ b/echo/frontend/src/components/auth/utils/nextPath.ts
@@ -1,0 +1,62 @@
+// Validates ?next= deep-links: a stale next can point at an org/workspace
+// the freshly logged-in account can't access.
+import { isAuthPath } from "./authPaths";
+
+// Same-origin path guard against open-redirect via ?next=//evil.com.
+export const isSafeNextPath = (
+	next: string | null | undefined,
+): next is string => {
+	if (!next) return false;
+	if (!next.startsWith("/")) return false;
+	if (next.startsWith("//") || next.startsWith("/\\")) return false;
+	return true;
+};
+
+const UUID_RE =
+	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// Locale-prefix-tolerant path segments, query/hash stripped.
+const pathSegments = (path: string): string[] => {
+	const segments = path.split(/[?#]/)[0].split("/").filter(Boolean);
+	if (segments[0] && /^[a-z]{2}(-[A-Z]{2})?$/.test(segments[0])) {
+		segments.shift();
+	}
+	return segments;
+};
+
+const scopedId = (path: string, prefix: "w" | "o"): string | null => {
+	const segments = pathSegments(path);
+	if (segments[0] !== prefix || !segments[1]) return null;
+	return UUID_RE.test(segments[1]) ? segments[1] : null;
+};
+
+// Returns the workspace UUID from /w/:id/... else null.
+export const extractWorkspaceIdFromPath = (path: string): string | null =>
+	scopedId(path, "w");
+
+// Returns the organisation UUID from /o/:id/... else null.
+export const extractOrgIdFromPath = (path: string): string | null =>
+	scopedId(path, "o");
+
+interface AccessibleWorkspace {
+	id: string;
+	org_id?: string;
+}
+
+// Returns `next` when it is a safe path the account may deep-link into
+// (/w/:id needs membership, /o/:id needs a workspace in that org), else null.
+export const resolveNextPath = (
+	next: string | null | undefined,
+	workspaces: AccessibleWorkspace[],
+): string | null => {
+	if (!isSafeNextPath(next)) return null;
+	if (isAuthPath(next)) return null;
+
+	const wsId = extractWorkspaceIdFromPath(next);
+	if (wsId && !workspaces.some((w) => w.id === wsId)) return null;
+
+	const orgId = extractOrgIdFromPath(next);
+	if (orgId && !workspaces.some((w) => w.org_id === orgId)) return null;
+
+	return next;
+};

--- a/echo/frontend/src/components/layout/AuthLayout.tsx
+++ b/echo/frontend/src/components/layout/AuthLayout.tsx
@@ -2,9 +2,11 @@ import { Group, LoadingOverlay, Paper } from "@mantine/core";
 import { type PropsWithChildren, useEffect } from "react";
 import { Outlet, useLocation, useSearchParams } from "react-router";
 import { useAuthenticated } from "@/components/auth/hooks";
+import { resolveNextPath } from "@/components/auth/utils/nextPath";
 import { I18nLink } from "@/components/common/i18nLink";
 import { Logo } from "@/components/common/Logo";
 import { LanguagePicker } from "@/components/language/LanguagePicker";
+import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { Toaster } from "../common/Toaster";
 import { Footer } from "./Footer";
@@ -54,10 +56,31 @@ const AuthLayoutInner = (props: PropsWithChildren) => {
 	);
 
 	useEffect(() => {
-		if (auth.isAuthenticated && !isActive && !skipRedirect) {
-			const nextLink = query.get("next") ?? "/o";
-			navigate(nextLink);
+		if (!(auth.isAuthenticated && !isActive && !skipRedirect)) return;
+		const next = query.get("next");
+		if (!next) {
+			navigate("/o");
+			return;
 		}
+		// Validate ?next against this account's access; fails closed to /o.
+		let cancelled = false;
+		(async () => {
+			let wsList: { id: string; org_id?: string }[] = [];
+			try {
+				const res = await fetch(`${API_BASE_URL}/v2/workspaces`, {
+					credentials: "include",
+				});
+				if (res.ok) {
+					const data = await res.json();
+					wsList = data.workspaces ?? [];
+				}
+			} catch {}
+			if (cancelled) return;
+			navigate(resolveNextPath(next, wsList) ?? "/o");
+		})();
+		return () => {
+			cancelled = true;
+		};
 	}, [auth.isAuthenticated, isActive, navigate, query, skipRedirect]);
 
 	return (

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr "Create account"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr "Create an account"
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4935,7 +4935,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5624,11 +5624,11 @@ msgstr "Log out and use the invited email"
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6852,7 +6852,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6891,7 +6891,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "or"
 
@@ -7127,8 +7127,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Password"
 
@@ -7378,7 +7378,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr "Please log in to continue."
 
@@ -9339,7 +9339,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9823,7 +9823,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11193,7 +11193,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11424,7 +11424,7 @@ msgstr "Webhooks are not enabled for this environment."
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11433,7 +11433,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welcome back, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welcome to dembrane"
 
@@ -11454,7 +11454,7 @@ msgstr "Welcome to Overview Mode! I have summaries of all your conversations loa
 msgid "Welcome, {displayName}"
 msgstr "Welcome, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11877,7 +11877,7 @@ msgstr "You left the workspace"
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12067,7 +12067,7 @@ msgstr "Your draft won't be saved."
 msgid "Your email is already verified"
 msgstr "Your email is already verified"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr "Your email is verified. Log in to continue."
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -1675,7 +1675,7 @@ msgstr "Audit-Protokolle als CSV exportiert"
 msgid "Audit logs exported to JSON"
 msgstr "Audit-Protokolle als JSON exportiert"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Bearbeiten Sie den Berichts-Inhalt mit dem Rich-Text-Editor unten. Sie k
 msgid "Edit Webhook"
 msgstr "Webhook bearbeiten"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Dateiname eingeben (ohne Erweiterung)"
 msgid "Enter new password"
 msgstr "Neues Passwort eingeben"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
 
@@ -4936,7 +4936,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Ungültiger Code. Bitte fordern Sie einen neuen an."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Ungültige Anmeldedaten."
 
@@ -5625,11 +5625,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Anmelden"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Anmelden | dembrane"
 
@@ -6853,7 +6853,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Öffnen Sie Ihre Authentifizierungs-App und geben Sie den aktuellen 6-stelligen Code ein."
 
@@ -6892,7 +6892,7 @@ msgid "Options"
 msgstr "Optionen"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "oder"
 
@@ -7128,8 +7128,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Passwort"
 
@@ -7379,7 +7379,7 @@ msgstr "Bitte aktivieren Sie die Teilnahme, um das Teilen zu ermöglichen"
 msgid "Please enter a valid email."
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9340,7 +9340,7 @@ msgstr "Etwas blockiert Ihre Verbindung. Ihr Audio wird nicht gespeichert, solan
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9824,7 +9824,7 @@ msgstr "Danke-Seite Inhalt"
 msgid "Thank you!"
 msgstr "Vielen Dank!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Der Code hat nicht funktioniert. Versuchen Sie es erneut mit einem neuen Code aus Ihrer Authentifizierungs-App."
 
@@ -11192,7 +11192,7 @@ msgstr "Verifizieren"
 msgid "participant.echo.verify"
 msgstr "Verifizieren"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Code verifizieren"
 
@@ -11423,7 +11423,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11432,7 +11432,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11453,7 +11453,7 @@ msgstr "Willkommen im Übersichtmodus! Ich hab Zusammenfassungen von all deinen 
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Willkommen!"
 
@@ -11876,7 +11876,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "Sie können auch wählen, ein weiteres Gespräch aufzunehmen."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Sie müssen sich mit demselben Anbieter anmelden, mit dem Sie sich registriert haben. Wenn Sie auf Probleme stoßen, wenden Sie sich bitte an den Support."
 
@@ -12066,7 +12066,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr "Create account"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr "Create an account"
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr "Forecast"
 msgid "Forgetting a saved memory"
 msgstr "Forgetting a saved memory"
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4935,7 +4935,7 @@ msgstr "interview"
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5624,11 +5624,11 @@ msgstr "Log out and use the invited email"
 msgid "Logging this with the dembrane team"
 msgstr "Logging this with the dembrane team"
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6852,7 +6852,7 @@ msgstr "Open workspace"
 msgid "Open workspace actions"
 msgstr "Open workspace actions"
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6891,7 +6891,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "or"
 
@@ -7127,8 +7127,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr "Partner workspace, billed separately from the organisation."
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Password"
 
@@ -7378,7 +7378,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr "Please log in to continue."
 
@@ -9339,7 +9339,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9823,7 +9823,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11193,7 +11193,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11424,7 +11424,7 @@ msgstr "Webhooks are not enabled for this environment."
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11433,7 +11433,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welcome back, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welcome to dembrane"
 
@@ -11454,7 +11454,7 @@ msgstr "Welcome to Overview Mode! I have summaries of all your conversations loa
 msgid "Welcome, {displayName}"
 msgstr "Welcome, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11877,7 +11877,7 @@ msgstr "You left the workspace"
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12067,7 +12067,7 @@ msgstr "Your draft won't be saved."
 msgid "Your email is already verified"
 msgstr "Your email is already verified"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr "Your email is verified. Log in to continue."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -1675,7 +1675,7 @@ msgstr "Registros de auditoría exportados a CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Registros de auditoría exportados a JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Edita el contenido del informe usando el editor de texto enriquecido a c
 msgid "Edit Webhook"
 msgstr "Editar Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Ingresa el nombre del archivo (sin extensión)"
 msgid "Enter new password"
 msgstr "Introduzca la nueva contraseña"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Ingresa el código de 6 dígitos de tu aplicación de autenticación."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -4936,7 +4936,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Código inválido. Por favor solicita uno nuevo."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Credenciales inválidas."
 
@@ -5625,11 +5625,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Iniciar sesión | dembrane"
 
@@ -6853,7 +6853,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Abre tu aplicación de autenticación e ingresa el código actual de seis dígitos."
 
@@ -6892,7 +6892,7 @@ msgid "Options"
 msgstr "Opciones"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "o"
 
@@ -7128,8 +7128,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Contraseña"
 
@@ -7379,7 +7379,7 @@ msgstr "Por favor, habilite la participación para habilitar el uso compartido"
 msgid "Please enter a valid email."
 msgstr "Por favor, ingrese un correo electrónico válido."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9340,7 +9340,7 @@ msgstr "Algo está bloqueando tu conexión. Tu audio no se guardará a menos que
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9824,7 +9824,7 @@ msgstr "Contenido de la Página de Gracias"
 msgid "Thank you!"
 msgstr "¡Gracias!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Ese código no funcionó. Inténtalo de nuevo con un código nuevo de tu aplicación de autenticación."
 
@@ -11194,7 +11194,7 @@ msgstr "Verificar"
 msgid "participant.echo.verify"
 msgstr "Verificar"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Verificar código"
 
@@ -11425,7 +11425,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Bienvenido de nuevo"
 
@@ -11434,7 +11434,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11455,7 +11455,7 @@ msgstr "Bienvenido al modo Resumen. Tengo cargados los resúmenes de todas tus c
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "¡Bienvenido!"
 
@@ -11878,7 +11878,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "También puedes elegir registrar otra conversación."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Debes iniciar sesión con el mismo proveedor con el que te registraste. Si encuentras algún problema, por favor contáctanos."
 
@@ -12068,7 +12068,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -1675,7 +1675,7 @@ msgstr "Journaux d'audit exportés en CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Journaux d'audit exportés en JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Modifier le contenu du rapport en utilisant l'éditeur de texte enrichi 
 msgid "Edit Webhook"
 msgstr "Modifier le webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Entrez le nom du fichier (sans extension)"
 msgid "Enter new password"
 msgstr "Saisir le nouveau mot de passe"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Entrez le code à 6 chiffres de votre application d'authentification."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
 
@@ -4936,7 +4936,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Code invalide. Veuillez en demander un nouveau."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Identifiants invalides."
 
@@ -5625,11 +5625,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Connexion"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Connexion | dembrane"
 
@@ -6853,7 +6853,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Ouvrez votre application d'authentification et entrez le code actuel à six chiffres."
 
@@ -6892,7 +6892,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "ou"
 
@@ -7128,8 +7128,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -7379,7 +7379,7 @@ msgstr "Veuillez activer la participation pour activer le partage"
 msgid "Please enter a valid email."
 msgstr "Veuillez entrer une adresse e-mail valide."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9340,7 +9340,7 @@ msgstr "Quelque chose bloque votre connexion. Votre audio ne sera pas sauvegard�
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9824,7 +9824,7 @@ msgstr "Contenu de la page Merci"
 msgid "Thank you!"
 msgstr "Merci !"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Ce code n'a pas fonctionné. Réessayez avec un nouveau code de votre application d'authentification."
 
@@ -11191,7 +11191,7 @@ msgstr "Vérifier"
 msgid "participant.echo.verify"
 msgstr "Vérifier"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Vérifier le code"
 
@@ -11422,7 +11422,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Bon retour"
 
@@ -11431,7 +11431,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11452,7 +11452,7 @@ msgstr "Bienvenue en mode Vue d’ensemble ! J’ai chargé les résumés de tou
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Bienvenue !"
 
@@ -11875,7 +11875,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "Vous pouvez également choisir d'enregistrer une autre conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Vous devez vous connecter avec le même fournisseur que vous avez utilisé pour vous inscrire. Si vous rencontrez des problèmes, veuillez contacter le support."
 
@@ -12065,7 +12065,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr ""
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4935,7 +4935,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5624,11 +5624,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6852,7 +6852,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6891,7 +6891,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "or"
 
@@ -7127,8 +7127,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Password"
 
@@ -7378,7 +7378,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9339,7 +9339,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9823,7 +9823,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11193,7 +11193,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11424,7 +11424,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11433,7 +11433,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11454,7 +11454,7 @@ msgstr "Benvenuto nella modalità Panoramica. Ho caricato i riassunti di tutte l
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11877,7 +11877,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12067,7 +12067,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -1672,7 +1672,7 @@ msgstr "Auditlogboeken geëxporteerd naar CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Auditlogboeken geëxporteerd naar JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2940,7 +2940,7 @@ msgid "Create account"
 msgstr "Account aanmaken"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr "Maak een account aan"
 
@@ -3681,8 +3681,8 @@ msgstr "Bewerk de rapport inhoud met de rich text editor hieronder. Je kunt teks
 msgid "Edit Webhook"
 msgstr "Webhook bewerken"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3817,7 +3817,7 @@ msgstr "Voer bestandsnaam (zonder extensie) in"
 msgid "Enter new password"
 msgstr "Voer het nieuwe wachtwoord in"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Voer de 6-cijferige code uit je authenticator-app in."
 
@@ -4423,7 +4423,7 @@ msgstr "Prognose"
 msgid "Forgetting a saved memory"
 msgstr "Een opgeslagen herinnering vergeten"
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
@@ -4933,7 +4933,7 @@ msgstr "interview"
 msgid "Invalid code. Please request a new one."
 msgstr "Ongeldige code. Vraag een nieuwe aan."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Ongeldige inloggegevens."
 
@@ -5622,11 +5622,11 @@ msgstr "Uitloggen en het uitgenodigde e-mailadres gebruiken"
 msgid "Logging this with the dembrane team"
 msgstr "Dit doorgeven aan het dembrane-team"
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Inloggen"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Inloggen | dembrane"
 
@@ -6850,7 +6850,7 @@ msgstr "Werkruimte openen"
 msgid "Open workspace actions"
 msgstr "Werkruimteacties openen"
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open je authenticator-app en voer de huidige zescijferige code in."
 
@@ -6889,7 +6889,7 @@ msgid "Options"
 msgstr "Opties"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "of"
 
@@ -7125,8 +7125,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr "Partnerwerkruimte, apart gefactureerd van de organisatie."
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -7376,7 +7376,7 @@ msgstr "Schakel deelneming in om delen mogelijk te maken"
 msgid "Please enter a valid email."
 msgstr "Voer een geldig e-mailadres in."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr "Log in om door te gaan."
 
@@ -9337,7 +9337,7 @@ msgstr "Iets blokkeert je verbinding. Je audio wordt niet opgeslagen tenzij dit 
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9821,7 +9821,7 @@ msgstr "Bedankt pagina inhoud"
 msgid "Thank you!"
 msgstr "Bedankt!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Die code werkte niet. Probeer het opnieuw met een verse code uit je authenticator-app."
 
@@ -11189,7 +11189,7 @@ msgstr "Verifiëren"
 msgid "participant.echo.verify"
 msgstr "Verifiëren"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Code controleren"
 
@@ -11420,7 +11420,7 @@ msgstr "Webhooks zijn niet ingeschakeld voor deze omgeving."
 msgid "Welcome"
 msgstr "Welkom"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welkom terug"
 
@@ -11429,7 +11429,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welkom terug, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welkom bij dembrane"
 
@@ -11450,7 +11450,7 @@ msgstr "Welkom in Overview Mode! Ik heb samenvattingen van al je gesprekken klaa
 msgid "Welcome, {displayName}"
 msgstr "Welkom, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Welkom!"
 
@@ -11873,7 +11873,7 @@ msgstr "Je hebt de werkruimte verlaten"
 msgid "You may also choose to record another conversation."
 msgstr "Je kunt er ook voor kiezen om een ander gesprek op te nemen."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Je moet inloggen met dezelfde provider die u gebruikte om u aan te melden. Als u problemen ondervindt, neem dan contact op met de ondersteuning."
 
@@ -12063,7 +12063,7 @@ msgstr "Je concept wordt niet opgeslagen."
 msgid "Your email is already verified"
 msgstr "Je e-mailadres is al geverifieerd"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr "Je e-mailadres is geverifieerd. Log in om door te gaan."
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:276
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:385
 msgid "Create an account"
 msgstr ""
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:317
+#: src/routes/auth/Login.tsx:321
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:353
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4935,7 +4935,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:228
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5624,11 +5624,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:369
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6852,7 +6852,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:308
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6891,7 +6891,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:376
 msgid "or"
 msgstr "or"
 
@@ -7127,8 +7127,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:331
+#: src/routes/auth/Login.tsx:335
 msgid "Password"
 msgstr "Password"
 
@@ -7378,7 +7378,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:264
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9339,7 +9339,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:219
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9823,7 +9823,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:202
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11193,7 +11193,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:367
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11424,7 +11424,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11433,7 +11433,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11454,7 +11454,7 @@ msgstr "Ласкаво просимо в режим Огляду! Я заван�
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:252
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11877,7 +11877,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:233
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12067,7 +12067,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:257
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/routes/auth/Login.tsx
+++ b/echo/frontend/src/routes/auth/Login.tsx
@@ -19,32 +19,12 @@ import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSearchParams } from "react-router";
 import { useLoginMutation } from "@/components/auth/hooks";
+import { resolveNextPath } from "@/components/auth/utils/nextPath";
 import { I18nLink } from "@/components/common/i18nLink";
 import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { testId } from "@/lib/testUtils";
-
-// Same-origin path guard against open-redirect via ?next=//evil.com.
-const isSafeNextPath = (next: string | null | undefined): next is string => {
-	if (!next) return false;
-	if (!next.startsWith("/")) return false;
-	if (next.startsWith("//") || next.startsWith("/\\")) return false;
-	return true;
-};
-
-const UUID_RE =
-	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
-// Returns the workspace UUID from /w/:id/... (locale-prefix tolerant), else null.
-const extractWorkspaceIdFromPath = (path: string): string | null => {
-	const segments = path.split(/[?#]/)[0].split("/").filter(Boolean);
-	if (segments[0] && /^[a-z]{2}(-[A-Z]{2})?$/.test(segments[0])) {
-		segments.shift();
-	}
-	if (segments[0] !== "w" || !segments[1]) return null;
-	return UUID_RE.test(segments[1]) ? segments[1] : null;
-};
 
 // const LoginWithProvider = ({
 // 	provider,
@@ -150,7 +130,7 @@ export const LoginRoute = () => {
 			// were removed — /o is the canonical landing.
 			let needsOnboarding = false;
 			let onboardingIncomplete = false;
-			let wsList: { id: string }[] = [];
+			let wsList: { id: string; org_id?: string }[] = [];
 			try {
 				await new Promise((r) => setTimeout(r, 300));
 				const meResponse = await fetch(`${API_BASE_URL}/v2/me`, {
@@ -190,13 +170,11 @@ export const LoginRoute = () => {
 				return;
 			}
 
-			// Deep-link priority — but block cross-user leaks via workspace access check.
-			const nextWsId = isSafeNextPath(next)
-				? extractWorkspaceIdFromPath(next)
-				: null;
-			const nextHasAccess = !nextWsId || wsList.some((w) => w.id === nextWsId);
-			if (isSafeNextPath(next) && next !== "/login" && nextHasAccess) {
-				navigate(next);
+			// Deep-link priority; a stale ?next from a previous account fails
+			// the access check and falls through to /o.
+			const nextTarget = resolveNextPath(next, wsList);
+			if (nextTarget) {
+				navigate(nextTarget);
 				return;
 			}
 


### PR DESCRIPTION
Logout stores the current URL as /login?next=..., but after logging in as a different account the org path was followed unchecked, landing on "Organisation not found". The existing check only covered /w/:id paths.

Extract validation into resolveNextPath(): same-origin path, never an auth page, /w/:id requires workspace membership, /o/:id requires a workspace in that org. Anything else falls back to /o. Applied in both Login.tsx and AuthLayout.tsx (which previously honored ?next with no validation at all).