### PR TITLE
ECHO-949 fix(auth): validate org-scoped ?next against the new account's access

### DIFF
--- a/echo/frontend/src/components/auth/utils/nextPath.test.ts
+++ b/echo/frontend/src/components/auth/utils/nextPath.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { resolveNextPath } from "./nextPath";
+
+const ORG_A = "3dab35ac-47ff-47c6-b48f-0e366b0f8555";
+const ORG_B = "9c1f2e10-1111-4222-8333-444455556666";
+const WS_A = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const WS_B = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+
+const workspaces = [
+	{ id: WS_A, org_id: ORG_A },
+	{ id: WS_B, org_id: ORG_A },
+];
+
+describe("resolveNextPath", () => {
+	it("rejects unsafe paths", () => {
+		expect(resolveNextPath("https://evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("//evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("/\\evil.com", workspaces)).toBeNull();
+		expect(resolveNextPath("relative/path", workspaces)).toBeNull();
+		expect(resolveNextPath(null, workspaces)).toBeNull();
+		expect(resolveNextPath(undefined, workspaces)).toBeNull();
+		expect(resolveNextPath("", workspaces)).toBeNull();
+	});
+
+	it("rejects auth paths to avoid redirect loops", () => {
+		expect(resolveNextPath("/login", workspaces)).toBeNull();
+		expect(resolveNextPath("/en-US/login?verified=1", workspaces)).toBeNull();
+		expect(resolveNextPath("/register", workspaces)).toBeNull();
+	});
+
+	it("allows an org path the user has a workspace in", () => {
+		expect(resolveNextPath(`/o/${ORG_A}/overview`, workspaces)).toBe(
+			`/o/${ORG_A}/overview`,
+		);
+	});
+
+	it("allows a locale-prefixed org path the user has access to", () => {
+		expect(resolveNextPath(`/en-US/o/${ORG_A}/overview`, workspaces)).toBe(
+			`/en-US/o/${ORG_A}/overview`,
+		);
+	});
+
+	it("rejects an org path the user has no access to", () => {
+		expect(resolveNextPath(`/o/${ORG_B}/overview`, workspaces)).toBeNull();
+		expect(
+			resolveNextPath(`/en-US/o/${ORG_B}/overview`, workspaces),
+		).toBeNull();
+	});
+
+	it("allows the bare /o landing without any access check", () => {
+		expect(resolveNextPath("/o", workspaces)).toBe("/o");
+		expect(resolveNextPath("/en-US/o", workspaces)).toBe("/en-US/o");
+	});
+
+	it("allows a workspace path the user is a member of", () => {
+		expect(resolveNextPath(`/w/${WS_A}/home`, workspaces)).toBe(
+			`/w/${WS_A}/home`,
+		);
+	});
+
+	it("rejects a workspace path the user is not a member of", () => {
+		const foreignWs = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f";
+		expect(resolveNextPath(`/w/${foreignWs}/home`, workspaces)).toBeNull();
+	});
+
+	it("allows unscoped app paths", () => {
+		expect(resolveNextPath("/profile", workspaces)).toBe("/profile");
+	});
+
+	it("ignores query and hash when extracting scope ids", () => {
+		expect(
+			resolveNextPath(`/o/${ORG_B}/overview?tab=members`, workspaces),
+		).toBeNull();
+		expect(
+			resolveNextPath(`/o/${ORG_A}/overview?tab=members#x`, workspaces),
+		).toBe(`/o/${ORG_A}/overview?tab=members#x`);
+	});
+
+	it("rejects org/workspace paths when the workspace list is empty", () => {
+		expect(resolveNextPath(`/o/${ORG_A}/overview`, [])).toBeNull();
+		expect(resolveNextPath(`/w/${WS_A}/home`, [])).toBeNull();
+	});
+});

--- a/echo/frontend/src/components/auth/utils/nextPath.ts
+++ b/echo/frontend/src/components/auth/utils/nextPath.ts
@@ -1,0 +1,62 @@
+// Validates ?next= deep-links: a stale next can point at an org/workspace
+// the freshly logged-in account can't access.
+import { isAuthPath } from "./authPaths";
+
+// Same-origin path guard against open-redirect via ?next=//evil.com.
+export const isSafeNextPath = (
+	next: string | null | undefined,
+): next is string => {
+	if (!next) return false;
+	if (!next.startsWith("/")) return false;
+	if (next.startsWith("//") || next.startsWith("/\\")) return false;
+	return true;
+};
+
+const UUID_RE =
+	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// Locale-prefix-tolerant path segments, query/hash stripped.
+const pathSegments = (path: string): string[] => {
+	const segments = path.split(/[?#]/)[0].split("/").filter(Boolean);
+	if (segments[0] && /^[a-z]{2}(-[A-Z]{2})?$/.test(segments[0])) {
+		segments.shift();
+	}
+	return segments;
+};
+
+const scopedId = (path: string, prefix: "w" | "o"): string | null => {
+	const segments = pathSegments(path);
+	if (segments[0] !== prefix || !segments[1]) return null;
+	return UUID_RE.test(segments[1]) ? segments[1] : null;
+};
+
+// Returns the workspace UUID from /w/:id/... else null.
+export const extractWorkspaceIdFromPath = (path: string): string | null =>
+	scopedId(path, "w");
+
+// Returns the organisation UUID from /o/:id/... else null.
+export const extractOrgIdFromPath = (path: string): string | null =>
+	scopedId(path, "o");
+
+interface AccessibleWorkspace {
+	id: string;
+	org_id?: string;
+}
+
+// Returns `next` when it is a safe path the account may deep-link into
+// (/w/:id needs membership, /o/:id needs a workspace in that org), else null.
+export const resolveNextPath = (
+	next: string | null | undefined,
+	workspaces: AccessibleWorkspace[],
+): string | null => {
+	if (!isSafeNextPath(next)) return null;
+	if (isAuthPath(next)) return null;
+
+	const wsId = extractWorkspaceIdFromPath(next);
+	if (wsId && !workspaces.some((w) => w.id === wsId)) return null;
+
+	const orgId = extractOrgIdFromPath(next);
+	if (orgId && !workspaces.some((w) => w.org_id === orgId)) return null;
+
+	return next;
+};

--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr "Create account"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr "Create an account"
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5628,11 +5628,11 @@ msgstr "Log out and use the invited email"
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6856,7 +6856,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6895,7 +6895,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "or"
 
@@ -7131,8 +7131,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Password"
 
@@ -7382,7 +7382,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr "Please log in to continue."
 
@@ -9343,7 +9343,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9827,7 +9827,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11197,7 +11197,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11428,7 +11428,7 @@ msgstr "Webhooks are not enabled for this environment."
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11437,7 +11437,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welcome back, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welcome to dembrane"
 
@@ -11458,7 +11458,7 @@ msgstr "Welcome to Overview Mode! I have summaries of all your conversations loa
 msgid "Welcome, {displayName}"
 msgstr "Welcome, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11881,7 +11881,7 @@ msgstr "You left the workspace"
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12071,7 +12071,7 @@ msgstr "Your draft won't be saved."
 msgid "Your email is already verified"
 msgstr "Your email is already verified"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr "Your email is verified. Log in to continue."
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -1675,7 +1675,7 @@ msgstr "Audit-Protokolle als CSV exportiert"
 msgid "Audit logs exported to JSON"
 msgstr "Audit-Protokolle als JSON exportiert"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Bearbeiten Sie den Berichts-Inhalt mit dem Rich-Text-Editor unten. Sie k
 msgid "Edit Webhook"
 msgstr "Webhook bearbeiten"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Dateiname eingeben (ohne Erweiterung)"
 msgid "Enter new password"
 msgstr "Neues Passwort eingeben"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Geben Sie den 6-stelligen Code aus Ihrer Authentifizierungs-App ein."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
 
@@ -4940,7 +4940,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Ungültiger Code. Bitte fordern Sie einen neuen an."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Ungültige Anmeldedaten."
 
@@ -5629,11 +5629,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Anmelden"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Anmelden | dembrane"
 
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Öffnen Sie Ihre Authentifizierungs-App und geben Sie den aktuellen 6-stelligen Code ein."
 
@@ -6896,7 +6896,7 @@ msgid "Options"
 msgstr "Optionen"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "oder"
 
@@ -7132,8 +7132,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Passwort"
 
@@ -7383,7 +7383,7 @@ msgstr "Bitte aktivieren Sie die Teilnahme, um das Teilen zu ermöglichen"
 msgid "Please enter a valid email."
 msgstr "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9344,7 +9344,7 @@ msgstr "Etwas blockiert Ihre Verbindung. Ihr Audio wird nicht gespeichert, solan
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9828,7 +9828,7 @@ msgstr "Danke-Seite Inhalt"
 msgid "Thank you!"
 msgstr "Vielen Dank!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Der Code hat nicht funktioniert. Versuchen Sie es erneut mit einem neuen Code aus Ihrer Authentifizierungs-App."
 
@@ -11196,7 +11196,7 @@ msgstr "Verifizieren"
 msgid "participant.echo.verify"
 msgstr "Verifizieren"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Code verifizieren"
 
@@ -11427,7 +11427,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11436,7 +11436,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11457,7 +11457,7 @@ msgstr "Willkommen im Übersichtmodus! Ich hab Zusammenfassungen von all deinen 
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Willkommen!"
 
@@ -11880,7 +11880,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "Sie können auch wählen, ein weiteres Gespräch aufzunehmen."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Sie müssen sich mit demselben Anbieter anmelden, mit dem Sie sich registriert haben. Wenn Sie auf Probleme stoßen, wenden Sie sich bitte an den Support."
 
@@ -12070,7 +12070,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr "Create account"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr "Create an account"
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr "Forecast"
 msgid "Forgetting a saved memory"
 msgstr "Forgetting a saved memory"
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4939,7 +4939,7 @@ msgstr "interview"
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5628,11 +5628,11 @@ msgstr "Log out and use the invited email"
 msgid "Logging this with the dembrane team"
 msgstr "Logging this with the dembrane team"
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6856,7 +6856,7 @@ msgstr "Open workspace"
 msgid "Open workspace actions"
 msgstr "Open workspace actions"
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6895,7 +6895,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "or"
 
@@ -7131,8 +7131,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr "Partner workspace, billed separately from the organisation."
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Password"
 
@@ -7382,7 +7382,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr "Please log in to continue."
 
@@ -9343,7 +9343,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9827,7 +9827,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11197,7 +11197,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11428,7 +11428,7 @@ msgstr "Webhooks are not enabled for this environment."
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11437,7 +11437,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welcome back, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welcome to dembrane"
 
@@ -11458,7 +11458,7 @@ msgstr "Welcome to Overview Mode! I have summaries of all your conversations loa
 msgid "Welcome, {displayName}"
 msgstr "Welcome, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11881,7 +11881,7 @@ msgstr "You left the workspace"
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12071,7 +12071,7 @@ msgstr "Your draft won't be saved."
 msgid "Your email is already verified"
 msgstr "Your email is already verified"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr "Your email is verified. Log in to continue."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -1675,7 +1675,7 @@ msgstr "Registros de auditoría exportados a CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Registros de auditoría exportados a JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Edita el contenido del informe usando el editor de texto enriquecido a c
 msgid "Edit Webhook"
 msgstr "Editar Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Ingresa el nombre del archivo (sin extensión)"
 msgid "Enter new password"
 msgstr "Introduzca la nueva contraseña"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Ingresa el código de 6 dígitos de tu aplicación de autenticación."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "¿Olvidaste tu contraseña?"
 
@@ -4940,7 +4940,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Código inválido. Por favor solicita uno nuevo."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Credenciales inválidas."
 
@@ -5629,11 +5629,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Iniciar sesión | dembrane"
 
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Abre tu aplicación de autenticación e ingresa el código actual de seis dígitos."
 
@@ -6896,7 +6896,7 @@ msgid "Options"
 msgstr "Opciones"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "o"
 
@@ -7132,8 +7132,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Contraseña"
 
@@ -7383,7 +7383,7 @@ msgstr "Por favor, habilite la participación para habilitar el uso compartido"
 msgid "Please enter a valid email."
 msgstr "Por favor, ingrese un correo electrónico válido."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9344,7 +9344,7 @@ msgstr "Algo está bloqueando tu conexión. Tu audio no se guardará a menos que
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9828,7 +9828,7 @@ msgstr "Contenido de la Página de Gracias"
 msgid "Thank you!"
 msgstr "¡Gracias!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Ese código no funcionó. Inténtalo de nuevo con un código nuevo de tu aplicación de autenticación."
 
@@ -11198,7 +11198,7 @@ msgstr "Verificar"
 msgid "participant.echo.verify"
 msgstr "Verificar"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Verificar código"
 
@@ -11429,7 +11429,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Bienvenido de nuevo"
 
@@ -11438,7 +11438,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11459,7 +11459,7 @@ msgstr "Bienvenido al modo Resumen. Tengo cargados los resúmenes de todas tus c
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "¡Bienvenido!"
 
@@ -11882,7 +11882,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "También puedes elegir registrar otra conversación."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Debes iniciar sesión con el mismo proveedor con el que te registraste. Si encuentras algún problema, por favor contáctanos."
 
@@ -12072,7 +12072,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -1675,7 +1675,7 @@ msgstr "Journaux d'audit exportés en CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Journaux d'audit exportés en JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2943,7 +2943,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr ""
 
@@ -3684,8 +3684,8 @@ msgstr "Modifier le contenu du rapport en utilisant l'éditeur de texte enrichi 
 msgid "Edit Webhook"
 msgstr "Modifier le webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3820,7 +3820,7 @@ msgstr "Entrez le nom du fichier (sans extension)"
 msgid "Enter new password"
 msgstr "Saisir le nouveau mot de passe"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Entrez le code à 6 chiffres de votre application d'authentification."
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
 
@@ -4940,7 +4940,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Code invalide. Veuillez en demander un nouveau."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Identifiants invalides."
 
@@ -5629,11 +5629,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Connexion"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Connexion | dembrane"
 
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Ouvrez votre application d'authentification et entrez le code actuel à six chiffres."
 
@@ -6896,7 +6896,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "ou"
 
@@ -7132,8 +7132,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -7383,7 +7383,7 @@ msgstr "Veuillez activer la participation pour activer le partage"
 msgid "Please enter a valid email."
 msgstr "Veuillez entrer une adresse e-mail valide."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9344,7 +9344,7 @@ msgstr "Quelque chose bloque votre connexion. Votre audio ne sera pas sauvegard�
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9828,7 +9828,7 @@ msgstr "Contenu de la page Merci"
 msgid "Thank you!"
 msgstr "Merci !"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Ce code n'a pas fonctionné. Réessayez avec un nouveau code de votre application d'authentification."
 
@@ -11195,7 +11195,7 @@ msgstr "Vérifier"
 msgid "participant.echo.verify"
 msgstr "Vérifier"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Vérifier le code"
 
@@ -11426,7 +11426,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Bon retour"
 
@@ -11435,7 +11435,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11456,7 +11456,7 @@ msgstr "Bienvenue en mode Vue d’ensemble ! J’ai chargé les résumés de tou
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Bienvenue !"
 
@@ -11879,7 +11879,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "Vous pouvez également choisir d'enregistrer une autre conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Vous devez vous connecter avec le même fournisseur que vous avez utilisé pour vous inscrire. Si vous rencontrez des problèmes, veuillez contacter le support."
 
@@ -12069,7 +12069,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr ""
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5628,11 +5628,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6856,7 +6856,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6895,7 +6895,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "or"
 
@@ -7131,8 +7131,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Password"
 
@@ -7382,7 +7382,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9343,7 +9343,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9827,7 +9827,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11197,7 +11197,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11428,7 +11428,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11437,7 +11437,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11458,7 +11458,7 @@ msgstr "Benvenuto nella modalità Panoramica. Ho caricato i riassunti di tutte l
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11881,7 +11881,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12071,7 +12071,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -1672,7 +1672,7 @@ msgstr "Auditlogboeken geëxporteerd naar CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Auditlogboeken geëxporteerd naar JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2940,7 +2940,7 @@ msgid "Create account"
 msgstr "Account aanmaken"
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr "Maak een account aan"
 
@@ -3681,8 +3681,8 @@ msgstr "Bewerk de rapport inhoud met de rich text editor hieronder. Je kunt teks
 msgid "Edit Webhook"
 msgstr "Webhook bewerken"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3817,7 +3817,7 @@ msgstr "Voer bestandsnaam (zonder extensie) in"
 msgid "Enter new password"
 msgstr "Voer het nieuwe wachtwoord in"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Voer de 6-cijferige code uit je authenticator-app in."
 
@@ -4423,7 +4423,7 @@ msgstr "Prognose"
 msgid "Forgetting a saved memory"
 msgstr "Een opgeslagen herinnering vergeten"
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
@@ -4937,7 +4937,7 @@ msgstr "interview"
 msgid "Invalid code. Please request a new one."
 msgstr "Ongeldige code. Vraag een nieuwe aan."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Ongeldige inloggegevens."
 
@@ -5626,11 +5626,11 @@ msgstr "Uitloggen en het uitgenodigde e-mailadres gebruiken"
 msgid "Logging this with the dembrane team"
 msgstr "Dit doorgeven aan het dembrane-team"
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Inloggen"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Inloggen | dembrane"
 
@@ -6854,7 +6854,7 @@ msgstr "Werkruimte openen"
 msgid "Open workspace actions"
 msgstr "Werkruimteacties openen"
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open je authenticator-app en voer de huidige zescijferige code in."
 
@@ -6893,7 +6893,7 @@ msgid "Options"
 msgstr "Opties"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "of"
 
@@ -7129,8 +7129,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr "Partnerwerkruimte, apart gefactureerd van de organisatie."
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -7380,7 +7380,7 @@ msgstr "Schakel deelneming in om delen mogelijk te maken"
 msgid "Please enter a valid email."
 msgstr "Voer een geldig e-mailadres in."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr "Log in om door te gaan."
 
@@ -9341,7 +9341,7 @@ msgstr "Iets blokkeert je verbinding. Je audio wordt niet opgeslagen tenzij dit 
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9825,7 +9825,7 @@ msgstr "Bedankt pagina inhoud"
 msgid "Thank you!"
 msgstr "Bedankt!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "Die code werkte niet. Probeer het opnieuw met een verse code uit je authenticator-app."
 
@@ -11193,7 +11193,7 @@ msgstr "Verifiëren"
 msgid "participant.echo.verify"
 msgstr "Verifiëren"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Code controleren"
 
@@ -11424,7 +11424,7 @@ msgstr "Webhooks zijn niet ingeschakeld voor deze omgeving."
 msgid "Welcome"
 msgstr "Welkom"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welkom terug"
 
@@ -11433,7 +11433,7 @@ msgid "Welcome back, {displayName}"
 msgstr "Welkom terug, {displayName}"
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr "Welkom bij dembrane"
 
@@ -11454,7 +11454,7 @@ msgstr "Welkom in Overview Mode! Ik heb samenvattingen van al je gesprekken klaa
 msgid "Welcome, {displayName}"
 msgstr "Welkom, {displayName}"
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Welkom!"
 
@@ -11877,7 +11877,7 @@ msgstr "Je hebt de werkruimte verlaten"
 msgid "You may also choose to record another conversation."
 msgstr "Je kunt er ook voor kiezen om een ander gesprek op te nemen."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "Je moet inloggen met dezelfde provider die u gebruikte om u aan te melden. Als u problemen ondervindt, neem dan contact op met de ondersteuning."
 
@@ -12067,7 +12067,7 @@ msgstr "Je concept wordt niet opgeslagen."
 msgid "Your email is already verified"
 msgstr "Je e-mailadres is al geverifieerd"
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr "Je e-mailadres is geverifieerd. Log in om door te gaan."
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -1674,7 +1674,7 @@ msgstr "Audit logs exported to CSV"
 msgid "Audit logs exported to JSON"
 msgstr "Audit logs exported to JSON"
 
-#: src/routes/auth/Login.tsx:298
+#: src/routes/auth/Login.tsx:277
 #: src/components/settings/TwoFactorSettingsCard.tsx:231
 #: src/components/settings/TwoFactorSettingsCard.tsx:381
 msgid "Authenticator code"
@@ -2942,7 +2942,7 @@ msgid "Create account"
 msgstr ""
 
 #: src/routes/auth/Register.tsx:126
-#: src/routes/auth/Login.tsx:407
+#: src/routes/auth/Login.tsx:386
 msgid "Create an account"
 msgstr ""
 
@@ -3683,8 +3683,8 @@ msgstr "Edit the report content using the rich text editor below. You can format
 msgid "Edit Webhook"
 msgstr "Edit Webhook"
 
-#: src/routes/auth/Login.tsx:339
-#: src/routes/auth/Login.tsx:343
+#: src/routes/auth/Login.tsx:318
+#: src/routes/auth/Login.tsx:322
 #: src/components/settings/AccountSettingsCard.tsx:186
 #: src/components/common/RedactedText.tsx:38
 msgid "Email"
@@ -3819,7 +3819,7 @@ msgstr "Enter filename (without extension)"
 msgid "Enter new password"
 msgstr "Enter new password"
 
-#: src/routes/auth/Login.tsx:124
+#: src/routes/auth/Login.tsx:104
 msgid "Enter the 6-digit code from your authenticator app."
 msgstr "Enter the 6-digit code from your authenticator app."
 
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Forgetting a saved memory"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:375
+#: src/routes/auth/Login.tsx:354
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Invalid code. Please request a new one."
 msgstr "Invalid code. Please request a new one."
 
-#: src/routes/auth/Login.tsx:250
+#: src/routes/auth/Login.tsx:229
 msgid "Invalid credentials."
 msgstr "Invalid credentials."
 
@@ -5628,11 +5628,11 @@ msgstr ""
 msgid "Logging this with the dembrane team"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:391
+#: src/routes/auth/Login.tsx:370
 msgid "Login"
 msgstr "Login"
 
-#: src/routes/auth/Login.tsx:78
+#: src/routes/auth/Login.tsx:58
 msgid "Login | dembrane"
 msgstr "Login | dembrane"
 
@@ -6856,7 +6856,7 @@ msgstr ""
 msgid "Open workspace actions"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:330
+#: src/routes/auth/Login.tsx:309
 msgid "Open your authenticator app and enter the current six-digit code."
 msgstr "Open your authenticator app and enter the current six-digit code."
 
@@ -6895,7 +6895,7 @@ msgid "Options"
 msgstr "Options"
 
 #: src/routes/auth/Register.tsx:292
-#: src/routes/auth/Login.tsx:398
+#: src/routes/auth/Login.tsx:377
 msgid "or"
 msgstr "or"
 
@@ -7131,8 +7131,8 @@ msgid "Partner workspace, billed separately from the organisation."
 msgstr ""
 
 #: src/routes/auth/Register.tsx:222
-#: src/routes/auth/Login.tsx:353
-#: src/routes/auth/Login.tsx:357
+#: src/routes/auth/Login.tsx:332
+#: src/routes/auth/Login.tsx:336
 msgid "Password"
 msgstr "Password"
 
@@ -7382,7 +7382,7 @@ msgstr "Please enable participation to enable sharing"
 msgid "Please enter a valid email."
 msgstr "Please enter a valid email."
 
-#: src/routes/auth/Login.tsx:286
+#: src/routes/auth/Login.tsx:265
 msgid "Please log in to continue."
 msgstr ""
 
@@ -9343,7 +9343,7 @@ msgstr "Something is blocking your connection. Your audio will not be saved unle
 #: src/routes/project/report/ProjectReportRoute.tsx:933
 #: src/routes/project/report/ProjectReportRoute.tsx:1404
 #: src/routes/onboarding/OnboardingRoute.tsx:189
-#: src/routes/auth/Login.tsx:241
+#: src/routes/auth/Login.tsx:220
 #: src/components/project/ProjectAccessGuard.tsx:87
 #: src/components/participant/ParticipantInitiateForm.tsx:209
 #: src/components/error/ErrorPage.tsx:55
@@ -9827,7 +9827,7 @@ msgstr "Thank You Page Content"
 msgid "Thank you!"
 msgstr "Thank you!"
 
-#: src/routes/auth/Login.tsx:224
+#: src/routes/auth/Login.tsx:203
 msgid "That code didn't work. Try again with a fresh code from your authenticator app."
 msgstr "That code didn't work. Try again with a fresh code from your authenticator app."
 
@@ -11197,7 +11197,7 @@ msgstr "Verify"
 msgid "participant.echo.verify"
 msgstr "Verify"
 
-#: src/routes/auth/Login.tsx:389
+#: src/routes/auth/Login.tsx:368
 msgid "Verify code"
 msgstr "Verify code"
 
@@ -11428,7 +11428,7 @@ msgstr ""
 msgid "Welcome"
 msgstr "Welcome"
 
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome back"
 msgstr "Welcome back"
 
@@ -11437,7 +11437,7 @@ msgid "Welcome back, {displayName}"
 msgstr ""
 
 #: src/routes/onboarding/OnboardingRoute.tsx:585
-#: src/routes/auth/Login.tsx:142
+#: src/routes/auth/Login.tsx:122
 msgid "Welcome to dembrane"
 msgstr ""
 
@@ -11458,7 +11458,7 @@ msgstr "Ласкаво просимо в режим Огляду! Я заван�
 msgid "Welcome, {displayName}"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:274
+#: src/routes/auth/Login.tsx:253
 msgid "Welcome!"
 msgstr "Welcome!"
 
@@ -11881,7 +11881,7 @@ msgstr ""
 msgid "You may also choose to record another conversation."
 msgstr "You may also choose to record another conversation."
 
-#: src/routes/auth/Login.tsx:255
+#: src/routes/auth/Login.tsx:234
 msgid "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 msgstr "You must login with the same provider you used to sign up. If you face any issues, please contact support."
 
@@ -12071,7 +12071,7 @@ msgstr ""
 msgid "Your email is already verified"
 msgstr ""
 
-#: src/routes/auth/Login.tsx:279
+#: src/routes/auth/Login.tsx:258
 msgid "Your email is verified. Log in to continue."
 msgstr ""
 

--- a/echo/frontend/src/routes/auth/Login.tsx
+++ b/echo/frontend/src/routes/auth/Login.tsx
@@ -19,32 +19,12 @@ import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSearchParams } from "react-router";
 import { useLoginMutation } from "@/components/auth/hooks";
+import { resolveNextPath } from "@/components/auth/utils/nextPath";
 import { I18nLink } from "@/components/common/i18nLink";
 import { useTransitionCurtain } from "@/components/layout/TransitionCurtainProvider";
 import { API_BASE_URL } from "@/config";
 import { useI18nNavigate } from "@/hooks/useI18nNavigate";
 import { testId } from "@/lib/testUtils";
-
-// Same-origin path guard against open-redirect via ?next=//evil.com.
-const isSafeNextPath = (next: string | null | undefined): next is string => {
-	if (!next) return false;
-	if (!next.startsWith("/")) return false;
-	if (next.startsWith("//") || next.startsWith("/\\")) return false;
-	return true;
-};
-
-const UUID_RE =
-	/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
-// Returns the workspace UUID from /w/:id/... (locale-prefix tolerant), else null.
-const extractWorkspaceIdFromPath = (path: string): string | null => {
-	const segments = path.split(/[?#]/)[0].split("/").filter(Boolean);
-	if (segments[0] && /^[a-z]{2}(-[A-Z]{2})?$/.test(segments[0])) {
-		segments.shift();
-	}
-	if (segments[0] !== "w" || !segments[1]) return null;
-	return UUID_RE.test(segments[1]) ? segments[1] : null;
-};
 
 // const LoginWithProvider = ({
 // 	provider,
@@ -150,7 +130,7 @@ export const LoginRoute = () => {
 			// were removed — /o is the canonical landing.
 			let needsOnboarding = false;
 			let onboardingIncomplete = false;
-			let wsList: { id: string }[] = [];
+			let wsList: { id: string; org_id?: string }[] = [];
 			try {
 				await new Promise((r) => setTimeout(r, 300));
 				const meResponse = await fetch(`${API_BASE_URL}/v2/me`, {
@@ -190,13 +170,12 @@ export const LoginRoute = () => {
 				return;
 			}
 
-			// Deep-link priority — but block cross-user leaks via workspace access check.
-			const nextWsId = isSafeNextPath(next)
-				? extractWorkspaceIdFromPath(next)
-				: null;
-			const nextHasAccess = !nextWsId || wsList.some((w) => w.id === nextWsId);
-			if (isSafeNextPath(next) && next !== "/login" && nextHasAccess) {
-				navigate(next);
+			// Deep-link priority — but block cross-user leaks: a stale ?next from
+			// the previous session can point at a workspace or organisation this
+			// account can't see ("Organisation not found"). Fails closed to /o.
+			const resolvedNext = resolveNextPath(next, wsList);
+			if (resolvedNext) {
+				navigate(resolvedNext);
 				return;
 			}
 


### PR DESCRIPTION
Logging out from an org page and back in as a different account landed on "Organisation not found". Logout preserves the current path as ?next, and Login only checked /w/:id membership: an /o/:orgId target has no workspace segment, so the access check passed vacuously and we navigated the new account into the previous account's org.

Restores nextPath.ts and its tests verbatim from eabde789 (reverted in b6b88d9f) and calls resolveNextPath from Login.tsx, which already holds the /v2/workspaces list at the decision point. Org access derives from w.org_id; an unresolvable next falls through to /o.

AuthLayout is deliberately untouched. Putting the check there is what forced the revert: it needed a fresh /v2/workspaces fetch inside the redirect effect, which replaced the instant redirect and was cancelled on every re-render by the unstable navigate dep. No new network calls or queries here.