### PR TITLE
ECHO-949 fix(auth): stop AuthLayout following a stale scoped ?next

### DIFF
--- a/echo/frontend/src/components/layout/AuthLayout.tsx
+++ b/echo/frontend/src/components/layout/AuthLayout.tsx
@@ -2,6 +2,7 @@ import { Group, LoadingOverlay, Paper } from "@mantine/core";
 import { type PropsWithChildren, useEffect } from "react";
 import { Outlet, useLocation, useSearchParams } from "react-router";
 import { useAuthenticated } from "@/components/auth/hooks";
+import { resolveNextPath } from "@/components/auth/utils/nextPath";
 import { I18nLink } from "@/components/common/i18nLink";
 import { Logo } from "@/components/common/Logo";
 import { LanguagePicker } from "@/components/language/LanguagePicker";
@@ -55,7 +56,7 @@ const AuthLayoutInner = (props: PropsWithChildren) => {
 
 	useEffect(() => {
 		if (auth.isAuthenticated && !isActive && !skipRedirect) {
-			const nextLink = query.get("next") ?? "/o";
+			const nextLink = resolveNextPath(query.get("next"), []) ?? "/o";
 			navigate(nextLink);
 		}
 	}, [auth.isAuthenticated, isActive, navigate, query, skipRedirect]);


### PR DESCRIPTION
Follow-up to 62b3b05e, which only closed the slow path. AuthLayout still redirected on ?next unvalidated, and it wins the race whenever Login's /v2/me + /v2/workspaces calls outlast the 2.6s curtain: its effect re-runs on every render via the unstable navigate dep, so it fires the moment isActive drops. Logging in as a different account rendered the previous account's org ("Organisation not found") before Login corrected it to /o.

AuthLayout has no workspace list, and fetching one there is what forced the b6b88d9f revert, so it calls resolveNextPath with an empty list: every /o/:id and /w/:id target is rejected, unscoped targets (invites, /profile, bare /o) still redirect instantly. Synchronous, no new requests.