### PR TITLE
Document the device and browser floor for portal recording

### DIFF
--- a/docs/_authoring/FACTS.md
+++ b/docs/_authoring/FACTS.md
@@ -325,6 +325,38 @@ subscription, portal tags. Live preview. QR + invite link.
 - *report* - participant-facing summary/artifacts. *unsubscribe*.
 No account required. Public/participant API in §10.4.
 
+### 8.3 Device & browser support (portal recording) - verified against code, NOT against devices
+
+*Hard floor: iOS 16 (Safari 16) / Chrome 103.* `checkS3Connectivity` (`frontend/src/lib/api.ts`)
+calls `AbortSignal.timeout`, which Safari shipped in 16 and Chrome in 103. It runs as a
+mandatory pre-flight on every participant conversation (`useS3ConnectivityCheck.ts`). Below the
+floor the call throws, the check reports `failed`, and `ParticipantConversationAudio.tsx`
+disables the Record button (`disabled={s3Status !== "passed"}`), short-circuits
+`handleStartRecording`, and opens a modal with `withCloseButton={false}`,
+`closeOnClickOutside={false}`, `closeOnEscape={false}`. The participant cannot dismiss it and
+cannot record. iOS 16 = *iPhone 8 and newer* (iOS 16 dropped 6s, 7 and SE 1st gen).
+
+*Capture itself* needs `getUserMedia` over HTTPS (iOS Safari 11) and `MediaRecorder` (iOS
+Safari 14, Chrome 47), with the mime chain `audio/webm` → `audio/wav` → `video/mp4`
+(`useChunkedAudioRecorder.ts`). Both sit below the floor above, so the floor governs.
+
+*Wake lock: iOS Safari 18.4* (Chrome Android 84; desktop Safari 16.4 - do not confuse the two).
+`useWakeLock.ts` feature-detects and degrades silently, so on any iPhone older than XS, or any
+iPhone not updated to 18.4+, the screen sleeps and the recording is interrupted. The recorder
+carries iOS interruption detection (suspicious-chunk tracking, `useChunkedAudioRecorder.ts`)
+for exactly this case. iOS 18.4 = *iPhone XS and newer*.
+
+*The build target is an inherited default, not a decision.* `frontend/vite.config.ts` sets no
+`build.target`, so Vite 6's `ESBUILD_MODULES_TARGET` applies (es2020, safari14, chrome87,
+firefox78, edge88). That syntax floor is below the API floor, so it never binds.
+
+*In-app browsers (Instagram, LinkedIn, Slack webviews): untested and undetected.* No webview
+detection exists anywhere in `frontend/src`. Whether the microphone works is unknown, and
+nothing warns the participant if it doesn't.
+
+*No device matrix exists.* None of the above is confirmed on hardware. It is read from the
+code plus MDN compatibility data, so treat the floors as necessary conditions, not tested ones.
+
 ---
 
 ## 9. dembrane Go (iOS) - native SwiftUI app (`dembrane-go/`)

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -31,6 +31,25 @@ with the same pause, resume and stop controls - useful when you're the one in th
 most robust option when connectivity is shaky: it records to the device first and uploads
 when it can, so a dead spot never costs you the conversation.
 
+## What you need to record
+
+Recording runs in an ordinary web browser, with nothing to install. What it does need:
+
+- *An iPhone 8 or newer, on iOS 16 or later.* Older iPhones cannot record at all - the portal
+  shows a message about reaching storage that can't be dismissed.
+- *An Android phone with an up-to-date Chrome* (Chrome 103, mid-2022, or newer). Chrome updates
+  itself, so almost any phone still getting updates qualifies.
+- *A real browser, not an in-app one.* A link tapped inside Instagram, LinkedIn or Slack may
+  block the microphone, and dembrane can't warn anyone when it does. Ask people to open it in
+  Safari or Chrome.
+- *The screen kept awake.* dembrane asks the phone to stay awake, but only iOS 18.4 and later
+  (iPhone XS and newer) and Chrome on Android honour that request. On anything older the screen
+  sleeps and recording stops, so tell participants to keep the screen on.
+
+> [!NOTE]
+> These are the requirements as the code reads them. dembrane publishes no tested device list,
+> so if a specific handset matters for your session, try it beforehand.
+
 ## The mic check
 
 Before recording, the portal offers a *mic check* so a participant can confirm the right

--- a/docs/users/host/collecting-conversations.md
+++ b/docs/users/host/collecting-conversations.md
@@ -64,9 +64,15 @@ shows the same thing in brief under *Live & recent*. For a detailed walkthrough 
 
 A quick checklist that saves a lot of lost recordings:
 
+- Use a phone from roughly *2018 onwards* - an iPhone 8 or newer on iOS 16, or an Android with
+  an up-to-date Chrome. Older phones can't record at all, and get stuck on an error they
+  can't close.
+- *Open the link in Safari or Chrome*, not inside another app. A link tapped in Instagram,
+  LinkedIn or Slack can block the microphone silently.
 - Be on good *wifi or 5G*.
 - When prompted, *allow microphone access*.
-- *Keep the screen on* - a black screen means no recording.
+- *Keep the screen on* - a black screen means no recording. On most iPhones dembrane cannot
+  keep it awake for them, so this one is on the participant.
 - A well-*charged phone* is less likely to sleep.
 - Turn on *Do Not Disturb* - better privacy, fewer interruptions.
 

--- a/docs/users/participant/recording-your-conversation.md
+++ b/docs/users/participant/recording-your-conversation.md
@@ -14,9 +14,14 @@ controls work, how to type instead of speak, and what to try if something goes w
 A few things set you up well:
 
 - *Good signal.* Be on solid wifi or 5G.
+- *A phone from the last few years.* An iPhone 8 or newer (on iOS 16 or later), or an Android
+  with an up-to-date Chrome. Older phones can't record.
+- *Open the link in your normal browser.* If you tapped it inside another app like Instagram or
+  LinkedIn, the microphone may be blocked. Copy the link into Safari or Chrome instead.
 - *Allow the microphone* when your browser asks.
-- *Keep the screen on.* A black screen means no recording. A well-charged phone is less likely
-  to fall asleep.
+- *Keep the screen on.* A black screen means no recording. On most iPhones dembrane can't keep
+  the screen awake for you, so tap it now and then. A well-charged phone is less likely to fall
+  asleep.
 - *Turn on Do Not Disturb* for more privacy and fewer interruptions.
 
 ## Recording well
@@ -48,6 +53,14 @@ words are treated exactly the same way.
 ## If something isn't working
 
 Most hiccups are quick to fix.
+
+### If the Record button won't turn on
+
+- *If you see a message about reaching storage that you can't close*, your phone or browser is
+  too old. Recording needs an iPhone 8 or newer on iOS 16, or an up-to-date Chrome on Android.
+  Try a different phone, or ask the person who invited you whether you can type instead.
+- *Otherwise the connection check is probably still running.* Give it a moment, or use the
+  reconnect button if one is offered.
 
 ### If the microphone isn't working
 


### PR DESCRIPTION
Docs for the device floor: iOS 16 / iPhone 8, Chrome 103, and wake lock only from iOS 18.4.