### PR TITLE
fix(transcribe,merge): stop retry churn on bad Gemini output and unreadable chunks

### DIFF
--- a/echo/AGENTS.md
+++ b/echo/AGENTS.md
@@ -173,6 +173,8 @@ Which group powers which feature is non-obvious, so don't downgrade silently.
 ### Transcription
 
 - Transcription runs as a single synchronous Gemini pass on `MULTI_MODAL_PRO` (Vertex `europe-west1`, EU). The `Dembrane-26-07` provider sends chunk audio directly to Gemini, which transcribes, normalizes hotwords, optionally redacts PII, and returns a recording-feedback note in one call
+- Transcription passes a per-call router fallback `MULTI_MODAL_PRO` to `MULTI_MODAL_FAST`; never set it on the shared router, chat and reports must not degrade. Answering models are logged and stored in `diarization.data.models`
+- Fallback timing: with one Pro deployment (production today) LiteLLM skips cooldowns, so 429s retry in-group first. Once a `_1` deployment exists, a 429 burst can route straight to Flash for the 60s cooldown. It also fires on non-429 failures, costing one Flash call per corrupt chunk
 - Gemini is natively multilingual (en, nl, de, fr, es, it, uk and more); there is no per-language model selection
 - When PII redaction or anonymization is requested, a dedicated second Gemini pass redacts the transcribed text (a single transcribe-and-redact pass under-redacts because verbatim transcription dominates). Anonymized conversations then run `regex_redact_pii` (`pii_regex.py`) as a deterministic post-pass and store no raw response
 - The redaction pass keeps the correction prompt's keyterms allow-list permanently empty on purpose: hotwords are passed as canonical_terms for normalization only, never as keyterms, so nothing is exempted and all PII (including names that are hotwords) is redacted. Do not wire hotwords into keyterms

--- a/echo/server/dembrane/api/conversation.py
+++ b/echo/server/dembrane/api/conversation.py
@@ -16,6 +16,7 @@ from dembrane.utils import generate_uuid, get_utc_timestamp
 from dembrane.service import project_service, conversation_service
 from dembrane.directus import directus
 from dembrane.audio_utils import (
+    NoMergeableChunksError,
     sanitize_filename_component,
     merge_multiple_audio_files_and_save_to_s3,
 )
@@ -30,6 +31,7 @@ from dembrane.async_helpers import safe_gather, run_in_thread_pool
 from dembrane.stream_status import stream_with_status
 from dembrane.api.exceptions import (
     NoContentFoundException,
+    NoMergeableChunksException,
     ConversationNotFoundException,
 )
 from dembrane.directus_async import async_directus
@@ -415,6 +417,9 @@ async def get_conversation_content(
 
         return return_url_or_redirect(merged_path, signed=signed, return_url=return_url)
 
+    except NoMergeableChunksError as e:
+        logger.error(f"Error merging audio files: {str(e)}")
+        raise NoMergeableChunksException(str(e)) from e
     except Exception as e:
         logger.error(f"Error merging audio files: {str(e)}")
         raise HTTPException(status_code=400, detail=f"Failed to merge audio files: {str(e)}") from e

--- a/echo/server/dembrane/api/exceptions.py
+++ b/echo/server/dembrane/api/exceptions.py
@@ -27,6 +27,14 @@ ConversationNotOpenForParticipationException = HTTPException(
     detail="This conversation is not open for participation at this time",
 )
 
+
 class NoContentFoundException(HTTPException):
     def __init__(self) -> None:
         super().__init__(status_code=404, detail="No content found")
+
+
+class NoMergeableChunksException(HTTPException):
+    """Every audio chunk failed to probe; distinct so the merge task can stop retrying."""
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(status_code=400, detail=f"Failed to merge audio files: {detail}")

--- a/echo/server/dembrane/audio_utils.py
+++ b/echo/server/dembrane/audio_utils.py
@@ -83,6 +83,23 @@ class FFmpegError(Exception):
     pass
 
 
+class NoMergeableChunksError(ValueError):
+    """Every input chunk failed to probe, so a retry cannot produce a merge."""
+
+    # ffprobe stderr is unbounded and this text ends up in logs, the processing
+    # status row and a 400 body.
+    MAX_ERROR_CHARS = 200
+
+    def __init__(self, file_names: List[str], errors: List[str]) -> None:
+        self.file_names = file_names
+        self.errors = errors
+        detail = "; ".join(
+            f"{name}: {err[: self.MAX_ERROR_CHARS]}"
+            for name, err in zip(file_names, errors, strict=False)
+        )
+        super().__init__(f"No processed data streams ({len(file_names)} chunk(s) failed): {detail}")
+
+
 class FileTooLargeError(Exception):
     """Custom exception for files that are too large to process"""
 
@@ -93,6 +110,10 @@ class FileTooSmallError(Exception):
     """Custom exception for files that are too small to process"""
 
     pass
+
+
+# Raised for chunk bytes that will not change on retry.
+_TERMINAL_CHUNK_ERRORS = (ValueError, FFmpegError, FileTooLargeError, FileTooSmallError)
 
 
 settings = get_settings()
@@ -342,6 +363,9 @@ def merge_multiple_audio_files_and_save_to_s3(
 
     # Process each file - probe format and convert if needed
     processed_data_streams = []
+    failed_names: List[str] = []
+    failed_errors: List[str] = []
+    transient_failure = False
     for i_name in input_file_names:
         # Probe file to determine format
         try:
@@ -368,9 +392,26 @@ def merge_multiple_audio_files_and_save_to_s3(
 
         except Exception as e:
             logger.error(f"Error probing file {i_name}: {str(e)} - Moving on to next file")
+            failed_names.append(i_name)
+            failed_errors.append(str(e))
+            # Bad bytes surface as probe/convert errors; anything else is transport
+            # (S3, network) and a retry can still succeed.
+            if not isinstance(e, _TERMINAL_CHUNK_ERRORS):
+                transient_failure = True
+
+    if failed_names and processed_data_streams:
+        logger.warning(
+            f"Skipped {len(failed_names)} of {len(input_file_names)} chunk(s) during merge: "
+            + "; ".join(
+                f"{n}: {e[: NoMergeableChunksError.MAX_ERROR_CHARS]}"
+                for n, e in zip(failed_names, failed_errors, strict=False)
+            )
+        )
 
     if not processed_data_streams:
-        raise ValueError("No processed data streams")
+        if transient_failure:
+            raise ValueError(f"No processed data streams: {'; '.join(failed_errors)}")
+        raise NoMergeableChunksError(failed_names, failed_errors)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         chunk_paths = []
@@ -564,12 +605,12 @@ def probe_from_bytes(file_bytes: bytes, input_format: str) -> dict:
                 if process.returncode != 0:
                     error = stderr_output or "Unknown error"
                     logger.error(f"ffprobe error: {error}")
-                    raise Exception(f"ffprobe error: {error}")
+                    raise FFmpegError(f"ffprobe error: {error}")
 
             output = process.stdout.decode()
             if not output:
                 logger.error("ffprobe returned empty output")
-                raise Exception("ffprobe returned empty output")
+                raise FFmpegError("ffprobe returned empty output")
 
             # Check the output for valid structure
             probe_data = json.loads(output)

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -211,7 +211,15 @@ broker.add_middleware(SkipRetryOnUnrecoverableError())
 
 
 # Transcription Task
-@dramatiq.actor(queue_name="network", priority=0)
+# Every retry re-sends the full audio to Gemini, so the default of 20 is far too many.
+# Five attempts with 30s..10min backoff still span roughly fifteen minutes of outage.
+@dramatiq.actor(
+    queue_name="network",
+    priority=0,
+    max_retries=5,
+    min_backoff=30_000,
+    max_backoff=600_000,
+)
 def task_transcribe_chunk(
     conversation_chunk_id: str,
     conversation_id: str,
@@ -587,28 +595,37 @@ def task_merge_conversation_chunks(conversation_id: str) -> None:
             return
 
         # local import to avoid circular imports
-        from dembrane.api.exceptions import NoContentFoundException
+        from dembrane.api.exceptions import (
+            NoContentFoundException,
+            NoMergeableChunksException,
+        )
         from dembrane.api.conversation import get_conversation_content
 
-        with ProcessingStatusContext(
-            conversation_id=conversation_id,
-            event_prefix="task_merge_conversation_chunks",
-        ):
-            try:
-                # Run async function in new event loop (CPU worker context)
-                run_async_in_new_loop(
-                    lambda: get_conversation_content(
-                        conversation_id,
-                        auth=DependencyDirectusSession(user_id="none", is_admin=True),
-                        force_merge=True,
-                        return_url=True,
+        try:
+            with ProcessingStatusContext(
+                conversation_id=conversation_id,
+                event_prefix="task_merge_conversation_chunks",
+            ):
+                try:
+                    # Run async function in new event loop (CPU worker context)
+                    run_async_in_new_loop(
+                        lambda: get_conversation_content(
+                            conversation_id,
+                            auth=DependencyDirectusSession(user_id="none", is_admin=True),
+                            force_merge=True,
+                            return_url=True,
+                        )
                     )
-                )
-            except NoContentFoundException:
-                logger.info(
-                    f"No valid content found for conversation {conversation_id}; skipping merge task."
-                )
-                return
+                except NoContentFoundException:
+                    logger.info(
+                        f"No valid content found for conversation {conversation_id}; skipping merge task."
+                    )
+                    return
+        except NoMergeableChunksException as e:
+            # Every chunk is unreadable; a retry re-probes the same bytes. Caught outside
+            # the status context so the timeline records a failure, not a completion.
+            logger.warning(f"Conversation {conversation_id} has no mergeable audio: {e.detail}")
+            return
 
         return
     except Exception as e:

--- a/echo/server/dembrane/transcribe.py
+++ b/echo/server/dembrane/transcribe.py
@@ -7,6 +7,7 @@ But it is probably not needed.
 # transcribe.py
 import io
 import os
+import re
 import json
 import logging
 import mimetypes
@@ -15,9 +16,10 @@ from typing import Any, List, Literal, Optional
 
 import litellm
 import requests
+from litellm.exceptions import BadRequestError
 
 from dembrane.s3 import get_signed_url, get_stream_from_s3
-from dembrane.llms import MODELS, router_completion
+from dembrane.llms import MODELS, MODEL_REGISTRY, router_completion
 from dembrane.prompts import render_prompt
 from dembrane.service import file_service, conversation_service
 from dembrane.directus import directus
@@ -38,6 +40,100 @@ LITELLM_TRANSCRIPTION_API_VERSION = transcription_cfg.litellm_api_version
 
 class TranscriptionError(Exception):
     pass
+
+
+class TranscriptParseError(TranscriptionError):
+    """The model returned transcript JSON that could not be parsed or repaired."""
+
+    def __init__(self, message: str, finish_reason: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.finish_reason = finish_reason
+
+    @property
+    def is_truncated(self) -> bool:
+        """The output limit cut the response; the same prompt truncates the same way."""
+        return str(self.finish_reason or "").lower() in {"length", "max_tokens"}
+
+
+# Gemini sometimes emits a literal backslash-u that is not a \uXXXX escape. The
+# lookbehind and the even-backslash group keep already-escaped backslashes intact.
+_BAD_UNICODE_ESCAPE = re.compile(r"(?<!\\)((?:\\\\)*)\\u(?![0-9a-fA-F]{4})")
+
+_TRANSCRIPT_KEYS = ("corrected_transcript", "note")
+
+
+def _transcript_fallbacks() -> List[dict[str, List[str]]]:
+    """Rate-limited transcription may degrade to the fast group.
+
+    Passed per call, not set on the shared router, so chat and reports keep their own
+    policy. Group names come from the registry so a rename cannot silently drop this.
+    Note: a per-call list replaces the router's fallbacks for that call, so reuse this
+    only for calls that start on multi_modal_pro.
+    """
+    primary = MODEL_REGISTRY[MODELS.MULTI_MODAL_PRO]["settings_attr"]
+    fallback = MODEL_REGISTRY[MODELS.MULTI_MODAL_FAST]["settings_attr"]
+    return [{primary: [fallback]}]
+
+
+def _parse_transcript_response(response: Any) -> dict[str, Any]:
+    """Parse the JSON transcript payload, repairing stray escapes when possible."""
+    choice = response.choices[0]
+    content = choice.message.content or ""
+    finish_reason = getattr(choice, "finish_reason", None)
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as first_error:
+        repaired = _BAD_UNICODE_ESCAPE.sub(r"\1\\\\u", content)
+        try:
+            parsed = json.loads(repaired) if repaired != content else None
+        except json.JSONDecodeError:
+            parsed = None
+        if parsed is None:
+            raise TranscriptParseError(
+                f"Unparseable transcript JSON (finish_reason={finish_reason}, "
+                f"{len(content)} chars): {first_error}",
+                finish_reason=finish_reason,
+            ) from first_error
+    if not isinstance(parsed, dict) or not all(
+        isinstance(parsed.get(k), str) for k in _TRANSCRIPT_KEYS
+    ):
+        raise TranscriptParseError(
+            f"Transcript JSON missing {_TRANSCRIPT_KEYS} (finish_reason={finish_reason})",
+            finish_reason=finish_reason,
+        )
+    return parsed
+
+
+def _complete_transcript_json(
+    messages: List[dict[str, Any]], response_schema: dict[str, Any], logger: logging.Logger
+) -> tuple[dict[str, Any], Optional[str]]:
+    """One Gemini call returning the transcript schema, retried once on a bad payload.
+
+    Retrying here, rather than letting Dramatiq retry the whole chunk, means a parse
+    failure in the correction pass does not re-run the transcription pass within one
+    delivery. Returns the parsed payload and the model that answered.
+    """
+    last_error: Optional[TranscriptParseError] = None
+    for attempt in range(2):
+        response = router_completion(
+            MODELS.MULTI_MODAL_PRO,
+            messages=messages,
+            response_format={"type": "json_object", "response_schema": response_schema},
+            fallbacks=_transcript_fallbacks(),
+        )
+        # Visible record of which deployment answered, so a fallback is never silent.
+        model = getattr(response, "model", None)
+        logger.info("Transcript call answered by model=%s", model)
+        try:
+            return _parse_transcript_response(response), model
+        except TranscriptParseError as e:
+            last_error = e
+            logger.warning("Transcript JSON parse failed on attempt %d: %s", attempt + 1, e)
+            if e.is_truncated:
+                break  # same audio, same limit: a second upload buys nothing
+    if last_error is None:
+        raise TranscriptParseError("transcript completion never ran")
+    raise last_error
 
 
 def transcribe_audio_litellm(
@@ -110,7 +206,7 @@ def _transcribe_audio_gemini(
     use_pii_redaction: bool,
     custom_guidance_prompt: Optional[str] = None,
     prompt_override: Optional[str] = None,
-) -> tuple[str, str]:
+) -> tuple[str, str, Optional[str]]:
     """Single Gemini pass: transcribe audio directly, normalize hotwords, optional PII redaction.
 
     prompt_override replaces the entire rendered transcription prompt. The JSON output
@@ -140,21 +236,18 @@ def _transcribe_audio_gemini(
 
     assert GCP_SA_JSON, "GCP_SA_JSON is not set"
 
-    # Use router for load balancing and failover across Gemini EU regions
-    response = router_completion(
-        MODELS.MULTI_MODAL_PRO,
-        messages=[
+    json_response, model = _complete_transcript_json(
+        [
             {"role": "system", "content": [{"type": "text", "text": prompt}]},
             {"role": "user", "content": [_get_audio_file_object(audio_file_uri)]},
         ],
-        response_format={"type": "json_object", "response_schema": response_schema},
+        response_schema,
+        logger,
     )
-
-    json_response = json.loads(response.choices[0].message.content)
     transcript = json_response["corrected_transcript"]
     note = json_response["note"]
     logger.debug(f"gemini transcript: {len(transcript)} chars; note: {note}")
-    return transcript, note
+    return transcript, note, model
 
 
 def _transcript_correction_workflow(
@@ -163,7 +256,7 @@ def _transcript_correction_workflow(
     hotwords: Optional[List[str]],
     use_pii_redaction: bool,
     custom_guidance_prompt: Optional[str] = None,
-) -> tuple[str, str]:
+) -> tuple[str, str, Optional[str]]:
     """Correction and PII-redaction pass over a candidate transcript plus its audio.
 
     This is the same pass that ran under the AssemblyAI pipeline. It reliably redacts
@@ -193,10 +286,8 @@ def _transcript_correction_workflow(
 
     assert GCP_SA_JSON, "GCP_SA_JSON is not set"
 
-    # Use router for load balancing and failover across Gemini EU regions
-    response = router_completion(
-        MODELS.MULTI_MODAL_PRO,
-        messages=[
+    json_response, model = _complete_transcript_json(
+        [
             {"role": "system", "content": [{"type": "text", "text": transcript_correction_prompt}]},
             {
                 "role": "user",
@@ -206,14 +297,13 @@ def _transcript_correction_workflow(
                 ],
             },
         ],
-        response_format={"type": "json_object", "response_schema": response_schema},
+        response_schema,
+        logger,
     )
-
-    json_response = json.loads(response.choices[0].message.content)
     corrected_transcript = json_response["corrected_transcript"]
     note = json_response["note"]
     logger.debug(f"corrected_transcript: {len(corrected_transcript)} chars; note: {note}")
-    return corrected_transcript, note
+    return corrected_transcript, note, model
 
 
 def transcribe_audio_dembrane_26_07(
@@ -246,9 +336,11 @@ def transcribe_audio_dembrane_26_07(
     pii_on = use_pii_redaction or anonymize_transcripts
 
     # Pass 1: transcription only, no redaction.
-    transcript, note = _transcribe_audio_gemini(
+    transcript, note, model = _transcribe_audio_gemini(
         audio_file_uri, language, hotwords, False, custom_guidance_prompt, prompt_override
     )
+    # Which deployments answered, so a fallback-degraded chunk is identifiable later.
+    models = [model]
 
     # Regex runs before correction, matching the old pipeline order.
     if anonymize_transcripts:
@@ -259,14 +351,15 @@ def transcribe_audio_dembrane_26_07(
     # Never pass keyterms: an empty allow-list is load-bearing so all PII (including
     # hotword names) is redacted, not exempted.
     if pii_on:
-        transcript, note = _transcript_correction_workflow(
+        transcript, note, model = _transcript_correction_workflow(
             audio_file_uri, transcript, hotwords, True, custom_guidance_prompt
         )
+        models.append(model)
 
     if transcript == "":
         transcript = "[Nothing to transcribe]"
 
-    return transcript, {"note": note, "raw": {}, "error": None}
+    return transcript, {"note": note, "raw": {}, "error": None, "models": models}
 
 
 # Helper functions extracted to simplify `transcribe_conversation_chunk`
@@ -339,27 +432,55 @@ RECOVERABLE_ERRORS = [
 ]
 
 
+def _is_vertex_invalid_argument(error: Exception) -> bool:
+    """Vertex rejected the request body itself, which for us means the audio is bad.
+
+    BadRequestError is also the Router's own error for a missing group or no healthy
+    deployment, and the base of context-window and content-policy errors, so the
+    provider and status text both have to match. Known gap: Vertex uses the same code
+    for a bad response_schema or project misconfiguration and gives no audio-specific
+    text, so a prompt regression would mark chunks failed. Watch the `bad_request`
+    analytics reason for a spike.
+    """
+    if not isinstance(error, BadRequestError):
+        return False
+    provider = str(getattr(error, "llm_provider", "") or "").lower()
+    return provider.startswith("vertex") and "invalid_argument" in str(error).lower()
+
+
 def _is_recoverable_error(error: Exception) -> bool:
     """Check if an error is recoverable (chunk should be marked as failed, not retried)."""
+    if _is_vertex_invalid_argument(error):
+        return True
+    # Two truncated attempts in a row: redelivery would only repeat the cost.
+    if isinstance(error, TranscriptParseError) and error.is_truncated:
+        return True
     error_str = str(error).lower()
     return any(pattern in error_str for pattern in RECOVERABLE_ERRORS)
+
+
+def _failure_reason(error: Exception) -> str:
+    """Short analytics label for a transcription failure."""
+    if _is_vertex_invalid_argument(error):
+        return "bad_request"
+    if isinstance(error, TranscriptParseError) and error.is_truncated:
+        return "truncated_output"
+    error_str = str(error).lower()
+    return next((pattern for pattern in RECOVERABLE_ERRORS if pattern in error_str), "other")
 
 
 def _report_transcription_failure(
     conversation_chunk_id: str, error: Exception, conversation_id: Optional[str] = None
 ) -> None:
     """Fire-and-forget analytics for a chunk that failed transcription, keyed by conversation_id."""
-    error_str = str(error).lower()
-    recoverable = _is_recoverable_error(error)
-    reason = next((pattern for pattern in RECOVERABLE_ERRORS if pattern in error_str), "other")
     capture_event_sync(
         conversation_id or conversation_chunk_id,
         "server_chunk_transcription_failed",
         {
             "chunk_id": conversation_chunk_id,
             "conversation_id": conversation_id,
-            "recoverable": recoverable,
-            "error_reason": reason,
+            "recoverable": _is_recoverable_error(error),
+            "error_reason": _failure_reason(error),
         },
     )
 

--- a/echo/server/tests/llm_fakes.py
+++ b/echo/server/tests/llm_fakes.py
@@ -1,0 +1,20 @@
+"""Minimal stand-ins for a LiteLLM completion response, shared across tests."""
+
+from __future__ import annotations
+
+
+class FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class FakeChoice:
+    def __init__(self, content: str, finish_reason: str = "stop") -> None:
+        self.message = FakeMessage(content)
+        self.finish_reason = finish_reason
+
+
+class FakeCompletion:
+    def __init__(self, content: str, finish_reason: str = "stop", model: str = "fake") -> None:
+        self.choices = [FakeChoice(content, finish_reason)]
+        self.model = model

--- a/echo/server/tests/test_merge_no_mergeable_chunks.py
+++ b/echo/server/tests/test_merge_no_mergeable_chunks.py
@@ -1,0 +1,193 @@
+"""
+When every chunk of a conversation fails to probe (production case: one truncated mp3
+upload), the merge cannot succeed on retry. The failure must name the chunks and the
+merge task must stop instead of retrying through Dramatiq. Transport failures are
+different: those must keep retrying.
+"""
+
+from __future__ import annotations
+
+import io
+import asyncio
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import dembrane.tasks as tasks
+import dembrane.audio_utils as audio_utils
+import dembrane.api.conversation as conversation_api
+from dembrane.service import conversation_service
+from dembrane.api.exceptions import NoMergeableChunksException
+
+FFPROBE_STDERR = b"[mp3 @ 0x7f] Failed to find two consecutive MPEG audio frames."
+
+
+def _failing_ffprobe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every ffprobe invocation fail the way it does on a truncated upload."""
+
+    def _run(*_a, **_k):
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=FFPROBE_STDERR)
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+
+def test_probe_from_bytes_raises_ffmpeg_error_on_corrupt_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _failing_ffprobe(monkeypatch)
+    with pytest.raises(audio_utils.FFmpegError, match="MPEG audio frames"):
+        audio_utils.probe_from_bytes(b"not really mp3 bytes", "mp3")
+
+
+def test_corrupt_upload_through_real_probe_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End to end through probe_from_s3 -> probe_from_bytes, no exception type stubbed."""
+    _failing_ffprobe(monkeypatch)
+    monkeypatch.setattr(audio_utils, "get_stream_from_s3", lambda _n: io.BytesIO(b"garbage"))
+
+    with pytest.raises(audio_utils.NoMergeableChunksError) as excinfo:
+        audio_utils.merge_multiple_audio_files_and_save_to_s3(
+            ["https://s3/chunks/Nieuwe opname 227.mp3"], "out.mp3", "mp3"
+        )
+    assert "MPEG audio frames" in str(excinfo.value)
+
+
+def test_all_probes_failing_raises_no_mergeable_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _probe(name: str, _fmt: str) -> dict:
+        raise audio_utils.FFmpegError(
+            "ffprobe error: Failed to find two consecutive MPEG audio frames"
+        )
+
+    monkeypatch.setattr(audio_utils, "probe_from_s3", _probe)
+
+    with pytest.raises(audio_utils.NoMergeableChunksError) as excinfo:
+        audio_utils.merge_multiple_audio_files_and_save_to_s3(
+            ["https://s3/chunks/a.mp3", "https://s3/chunks/b.mp3"], "out.mp3", "mp3"
+        )
+
+    message = str(excinfo.value)
+    assert "a.mp3" in message and "b.mp3" in message
+    assert "MPEG audio frames" in message
+
+
+@pytest.mark.parametrize(
+    "error_type", [audio_utils.FileTooLargeError, audio_utils.FileTooSmallError]
+)
+def test_size_rejections_during_conversion_are_terminal(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[Exception]
+) -> None:
+    """Conversion runs inside the probe loop for non-mp3 chunks and rejects on size.
+    The bytes will not change on retry, so this is as terminal as a failed probe."""
+    monkeypatch.setattr(
+        audio_utils, "probe_from_s3", lambda _n, _f: {"format": {"format_name": "webm"}}
+    )
+
+    def _convert(*_a, **_k):
+        raise error_type("size out of range")
+
+    monkeypatch.setattr(audio_utils, "convert_and_save_to_s3", _convert)
+
+    with pytest.raises(audio_utils.NoMergeableChunksError):
+        audio_utils.merge_multiple_audio_files_and_save_to_s3(
+            ["https://s3/chunks/a.webm"], "out.mp3", "mp3"
+        )
+
+
+def test_partial_skips_are_logged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One bad chunk among good ones is skipped silently today; the merge should say so."""
+    _failing_ffprobe(monkeypatch)
+    monkeypatch.setattr(audio_utils, "get_stream_from_s3", lambda _n: io.BytesIO(b"garbage"))
+
+    good = {"format": {"format_name": "mp3"}}
+    real_probe = audio_utils.probe_from_s3
+    monkeypatch.setattr(
+        audio_utils,
+        "probe_from_s3",
+        lambda name, fmt: good if name.endswith("good.mp3") else real_probe(name, fmt),
+    )
+    # Stop before ffmpeg runs; we only care about the skip report.
+    monkeypatch.setattr(
+        audio_utils.tempfile,
+        "TemporaryDirectory",
+        lambda: (_ for _ in ()).throw(RuntimeError("stop")),
+    )
+
+    with (
+        caplog.at_level("WARNING", logger="audio_utils"),
+        pytest.raises(RuntimeError, match="stop"),
+    ):
+        audio_utils.merge_multiple_audio_files_and_save_to_s3(
+            ["https://s3/chunks/good.mp3", "https://s3/chunks/bad.mp3"], "out.mp3", "mp3"
+        )
+
+    skipped = [r for r in caplog.records if "Skipped 1 of 2" in r.getMessage()]
+    assert skipped and "bad.mp3" in skipped[0].getMessage()
+
+
+def test_transport_failure_is_not_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An S3 outage empties the stream list too, but a retry can fix that."""
+
+    def _probe(name: str, _fmt: str) -> dict:
+        raise ConnectionError("Could not connect to the endpoint URL")
+
+    monkeypatch.setattr(audio_utils, "probe_from_s3", _probe)
+
+    with pytest.raises(Exception) as excinfo:
+        audio_utils.merge_multiple_audio_files_and_save_to_s3(
+            ["https://s3/chunks/a.mp3"], "out.mp3", "mp3"
+        )
+    assert not isinstance(excinfo.value, audio_utils.NoMergeableChunksError)
+
+
+def test_no_mergeable_chunks_message_is_bounded() -> None:
+    """ffprobe stderr can be huge and this text is logged, stored as a processing status
+    message, and returned as a 400 body. Cap it per chunk."""
+    exc = audio_utils.NoMergeableChunksError(["a.mp3", "b.mp3"], ["x" * 5000, "y" * 5000])
+    text = str(exc)
+    assert len(text) < 700
+    assert "a.mp3" in text and "b.mp3" in text
+    assert "x" * 200 in text and "x" * 201 not in text
+
+
+def test_http_wrapper_keeps_400_for_the_download_route() -> None:
+    exc = NoMergeableChunksException("No processed data streams (1 chunk(s) failed): a.mp3")
+    assert exc.status_code == 400
+    assert "a.mp3" in exc.detail
+
+
+def test_merge_task_stops_without_retry_when_nothing_is_mergeable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes: list[str] = []
+
+    class _Status:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, *_a):
+            outcomes.append("failed" if exc_type else "completed")
+            return False
+
+    monkeypatch.setattr(tasks, "ProcessingStatusContext", _Status)
+    monkeypatch.setattr(
+        conversation_service,
+        "get_chunk_counts",
+        lambda _cid: {"total": 1, "ok": 0, "error": 1, "processed": 1, "pending": 0},
+    )
+    monkeypatch.setattr(conversation_service, "get_by_id_or_raise", lambda _cid: {"id": "c1"})
+
+    async def _content(*_a, **_k):
+        raise NoMergeableChunksException("No processed data streams (1 chunk(s) failed): x.mp3")
+
+    monkeypatch.setattr(conversation_api, "get_conversation_content", _content)
+    monkeypatch.setattr(tasks, "run_async_in_new_loop", lambda factory: asyncio.run(factory()))
+
+    # Must return, not raise: a raise here is what makes Dramatiq retry.
+    assert tasks.task_merge_conversation_chunks.fn("c1") is None
+    # The processing timeline must not claim a merge completed.
+    assert outcomes == ["failed"]

--- a/echo/server/tests/test_transcribe_dembrane_26_07.py
+++ b/echo/server/tests/test_transcribe_dembrane_26_07.py
@@ -6,21 +6,7 @@ from typing import Any
 import pytest
 
 import dembrane.transcribe as transcribe
-
-
-class _FakeMessage:
-    def __init__(self, content: str) -> None:
-        self.content = content
-
-
-class _FakeChoice:
-    def __init__(self, content: str) -> None:
-        self.message = _FakeMessage(content)
-
-
-class _FakeCompletion:
-    def __init__(self, content: str) -> None:
-        self.choices = [_FakeChoice(content)]
+from tests.llm_fakes import FakeCompletion as _FakeCompletion
 
 
 def _stub_common(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,7 +23,7 @@ def _router_dispatch(transcribe_json: dict[str, Any], correction_json: dict[str,
     user message) with transcribe_json and the correction/redaction call (candidate
     transcript text plus audio) with correction_json."""
 
-    def _fake(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _fake(model: Any, messages: Any, response_format: Any, **kwargs: Any) -> _FakeCompletion:
         user_msg = next(m for m in messages if m["role"] == "user")
         has_candidate_text = any(part.get("type") == "text" for part in user_msg["content"])
         return _FakeCompletion(
@@ -51,7 +37,9 @@ def test_transcribe_26_07_audio_only_no_candidate(monkeypatch: pytest.MonkeyPatc
     _stub_common(monkeypatch)
     captured: dict[str, Any] = {}
 
-    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _fake_router(
+        model: Any, messages: Any, response_format: Any, **kwargs: Any
+    ) -> _FakeCompletion:
         captured["model"] = model
         captured["messages"] = messages
         return _FakeCompletion(
@@ -77,7 +65,9 @@ def test_transcribe_26_07_no_pii_is_single_call(monkeypatch: pytest.MonkeyPatch)
     _stub_common(monkeypatch)
     calls = {"n": 0}
 
-    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _fake_router(
+        model: Any, messages: Any, response_format: Any, **kwargs: Any
+    ) -> _FakeCompletion:
         calls["n"] += 1
         return _FakeCompletion(json.dumps({"corrected_transcript": "hello", "note": ""}))
 
@@ -109,7 +99,9 @@ def test_transcribe_26_07_prompt_override_replaces_transcription_prompt(
     _stub_common(monkeypatch)
     captured: dict[str, Any] = {}
 
-    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _fake_router(
+        model: Any, messages: Any, response_format: Any, **kwargs: Any
+    ) -> _FakeCompletion:
         captured["messages"] = messages
         return _FakeCompletion(json.dumps({"corrected_transcript": "HELLO", "note": ""}))
 
@@ -132,7 +124,9 @@ def test_transcribe_26_07_prompt_override_leaves_redaction_prompt_alone(
     _stub_common(monkeypatch)
     system_prompts: list[str] = []
 
-    def _fake_router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _fake_router(
+        model: Any, messages: Any, response_format: Any, **kwargs: Any
+    ) -> _FakeCompletion:
         system_msg = next(m for m in messages if m["role"] == "system")
         system_prompts.append(system_msg["content"][0]["text"])
         return _FakeCompletion(json.dumps({"corrected_transcript": "x", "note": ""}))
@@ -159,7 +153,7 @@ def test_transcribe_26_07_pii_runs_correction_pass_over_audio_and_transcript(
     _stub_common(monkeypatch)
     correction_msgs: dict[str, Any] = {}
 
-    def _router(model: Any, messages: Any, response_format: Any) -> _FakeCompletion:
+    def _router(model: Any, messages: Any, response_format: Any, **kwargs: Any) -> _FakeCompletion:
         user_msg = next(m for m in messages if m["role"] == "user")
         has_candidate_text = any(part.get("type") == "text" for part in user_msg["content"])
         if has_candidate_text:

--- a/echo/server/tests/test_transcribe_json_parse.py
+++ b/echo/server/tests/test_transcribe_json_parse.py
@@ -1,0 +1,274 @@
+"""
+Gemini occasionally returns transcript JSON that json.loads rejects. Two shapes seen
+in production: a stray backslash-u inside a long transcript (repairable) and a
+response cut off mid-string (must be regenerated). A parse failure in the correction
+pass must not re-run the transcription pass.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from litellm.exceptions import BadRequestError
+
+import dembrane.tasks as tasks
+import dembrane.transcribe as transcribe
+from tests.llm_fakes import FakeCompletion
+
+VALID = json.dumps({"corrected_transcript": "hello world", "note": "ok"})
+TRUNCATED = '{\n  "corrected_transcript": "hello wor'
+BAD_ESCAPE = '{"corrected_transcript": "pad \\u00e9 fine, then C:\\users bad", "note": "n"}'
+# A correctly escaped backslash followed by a stray escape elsewhere.
+BAD_ESCAPE_AFTER_ESCAPED_BACKSLASH = (
+    '{"corrected_transcript": "C:\\\\users ok, then \\uZZ bad", "note": "n"}'
+)
+
+
+def _stub_common(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(transcribe, "GCP_SA_JSON", {"type": "service_account"})
+    monkeypatch.setattr(
+        transcribe,
+        "_get_audio_file_object",
+        lambda _uri: {"type": "file", "file": {"file_data": "x"}},
+    )
+
+
+def test_parse_repairs_invalid_unicode_escape() -> None:
+    parsed = transcribe._parse_transcript_response(FakeCompletion(BAD_ESCAPE))
+    assert parsed["corrected_transcript"] == "pad \u00e9 fine, then C:\\users bad"
+    assert parsed["note"] == "n"
+
+
+def test_parse_repair_leaves_escaped_backslashes_alone() -> None:
+    parsed = transcribe._parse_transcript_response(
+        FakeCompletion(BAD_ESCAPE_AFTER_ESCAPED_BACKSLASH)
+    )
+    assert parsed["corrected_transcript"] == "C:\\users ok, then \\uZZ bad"
+
+
+def test_parse_raises_on_truncated_output() -> None:
+    with pytest.raises(transcribe.TranscriptParseError):
+        transcribe._parse_transcript_response(FakeCompletion(TRUNCATED, "length"))
+
+
+def test_parse_raises_on_missing_keys() -> None:
+    with pytest.raises(transcribe.TranscriptParseError):
+        transcribe._parse_transcript_response(FakeCompletion(json.dumps({"note": "only"})))
+
+
+def test_transcription_pass_retries_model_once_on_parse_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_common(monkeypatch)
+    responses = [FakeCompletion(TRUNCATED, "stop"), FakeCompletion(VALID)]
+    calls: list[Any] = []
+
+    def _fake_router(model: Any, **kwargs: Any) -> FakeCompletion:
+        calls.append(model)
+        return responses.pop(0)
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    transcript, note, _model = transcribe._transcribe_audio_gemini("s3://x", "en", None, False)
+
+    assert transcript == "hello world"
+    assert note == "ok"
+    assert len(calls) == 2
+
+
+def test_transcription_pass_gives_up_after_one_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_common(monkeypatch)
+    calls: list[Any] = []
+
+    def _fake_router(model: Any, **kwargs: Any) -> FakeCompletion:
+        calls.append(model)
+        return FakeCompletion(TRUNCATED, "stop")
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    with pytest.raises(transcribe.TranscriptParseError):
+        transcribe._transcribe_audio_gemini("s3://x", "en", None, False)
+    assert len(calls) == 2
+
+
+def test_correction_parse_error_does_not_rerun_transcription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_common(monkeypatch)
+    counts = {"transcribe": 0, "correct": 0}
+
+    def _fake_router(model: Any, **kwargs: Any) -> FakeCompletion:
+        user_msg = next(m for m in kwargs["messages"] if m["role"] == "user")
+        is_correction = any(part.get("type") == "text" for part in user_msg["content"])
+        if not is_correction:
+            counts["transcribe"] += 1
+            return FakeCompletion(VALID)
+        counts["correct"] += 1
+        if counts["correct"] == 1:
+            return FakeCompletion(TRUNCATED, "stop")
+        return FakeCompletion(json.dumps({"corrected_transcript": "redacted", "note": "r"}))
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    transcript, meta = transcribe.transcribe_audio_dembrane_26_07(
+        "s3://x", language="en", use_pii_redaction=True
+    )
+
+    assert transcript == "redacted"
+    assert meta["note"] == "r"
+    assert counts == {"transcribe": 1, "correct": 2}
+
+
+def test_transcription_call_declares_fast_fallback_for_this_call_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rate-limited transcription may degrade to the fast group. This is scoped to the
+    transcription call, not the shared router, so chat keeps its own policy."""
+    _stub_common(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def _fake_router(model: Any, **kwargs: Any) -> FakeCompletion:
+        captured.update(kwargs)
+        return FakeCompletion(VALID)
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    transcribe._transcribe_audio_gemini("s3://x", "en", None, False)
+
+    assert captured["fallbacks"] == [{"multi_modal_pro": ["multi_modal_fast"]}]
+
+
+def test_fallback_group_names_come_from_the_model_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rename in llms.MODEL_REGISTRY must not silently disable the fallback."""
+    monkeypatch.setitem(
+        transcribe.MODEL_REGISTRY,
+        transcribe.MODELS.MULTI_MODAL_FAST,
+        {"settings_attr": "renamed_fast"},
+    )
+    assert transcribe._transcript_fallbacks() == [{"multi_modal_pro": ["renamed_fast"]}]
+
+
+def _stub_chunk_pipeline(monkeypatch: pytest.MonkeyPatch, saved: list[str], events: list) -> None:
+    monkeypatch.setattr(
+        transcribe, "_fetch_chunk", lambda _cid: {"conversation_id": "c1", "path": "p.mp3"}
+    )
+    monkeypatch.setattr(
+        transcribe, "_fetch_conversation", lambda _cid: {"project_id": {"language": "en"}}
+    )
+    monkeypatch.setattr(transcribe, "_get_transcript_provider", lambda: "Dembrane-26-07")
+    monkeypatch.setattr(transcribe, "_build_hotwords", lambda _c: None)
+    monkeypatch.setattr(transcribe, "get_signed_url", lambda _p, **_k: "https://u")
+    monkeypatch.setattr(transcribe, "_save_chunk_error", lambda _cid, msg: saved.append(msg))
+    monkeypatch.setattr(
+        transcribe, "capture_event_sync", lambda _id, name, props: events.append((name, props))
+    )
+
+
+def test_vertex_invalid_argument_marks_chunk_failed_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Vertex 400 INVALID_ARGUMENT means the audio itself is bad. Retrying re-sends
+    the same bytes, so the chunk is marked failed and the task returns normally."""
+    saved: list[str] = []
+    events: list = []
+    _stub_chunk_pipeline(monkeypatch, saved, events)
+
+    def _raise(*_a: Any, **_k: Any) -> None:
+        raise BadRequestError(
+            "Vertex_aiException BadRequestError - 400 INVALID_ARGUMENT",
+            model="gemini",
+            llm_provider="vertex_ai",
+        )
+
+    monkeypatch.setattr(transcribe, "transcribe_audio_dembrane_26_07", _raise)
+
+    assert transcribe.transcribe_conversation_chunk("chunk-1") == "chunk-1"
+    assert saved and "INVALID_ARGUMENT" in saved[0]
+    name, props = events[0]
+    assert name == "server_chunk_transcription_failed"
+    assert props["recoverable"] is True
+    assert props["error_reason"] == "bad_request"
+
+
+def test_router_bad_request_is_still_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LiteLLM's Router raises BadRequestError for its own problems (no healthy
+    deployment, unknown model group). Those are config or capacity issues, not bad
+    audio, and must keep going through the retry path."""
+    saved: list[str] = []
+    _stub_chunk_pipeline(monkeypatch, saved, [])
+
+    def _raise(*_a: Any, **_k: Any) -> None:
+        raise BadRequestError(
+            "No healthy deployment available, passed model=multi_modal_pro",
+            model="multi_modal_pro",
+            llm_provider=None,
+        )
+
+    monkeypatch.setattr(transcribe, "transcribe_audio_dembrane_26_07", _raise)
+
+    with pytest.raises(transcribe.TranscriptionError):
+        transcribe.transcribe_conversation_chunk("chunk-1")
+
+
+def test_transcribe_actor_retries_are_bounded_but_span_a_real_incident() -> None:
+    """Default Dramatiq retries (20) re-send the full audio each time. Five attempts
+    with 30s to 10min backoff cover roughly fifteen minutes, long enough for a Vertex
+    blip, without the cost of the default."""
+    options = tasks.task_transcribe_chunk.options
+    assert options["max_retries"] == 5
+    assert options["min_backoff"] == 30_000
+    assert options["max_backoff"] == 600_000
+
+
+def test_meta_records_which_models_answered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A degraded (fallback) transcription must be identifiable from the stored chunk."""
+    _stub_common(monkeypatch)
+    models = iter(["vertex_ai/gemini-pro-x", "vertex_ai/gemini-flash-y"])
+
+    def _fake_router(model: Any, **kwargs: Any) -> FakeCompletion:
+        return FakeCompletion(VALID, model=next(models))
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    _, meta = transcribe.transcribe_audio_dembrane_26_07(
+        "s3://x", language="en", use_pii_redaction=True
+    )
+
+    assert meta["models"] == ["vertex_ai/gemini-pro-x", "vertex_ai/gemini-flash-y"]
+
+
+def test_length_truncation_is_terminal_without_a_second_upload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response cut off by the output limit repeats on the same audio, so neither the
+    in-process retry nor a redelivery is worth another upload."""
+    _stub_common(monkeypatch)
+    calls: list[Any] = []
+
+    def _fake_router(*_a: Any, **_k: Any) -> FakeCompletion:
+        calls.append(1)
+        return FakeCompletion(TRUNCATED, "length")
+
+    monkeypatch.setattr(transcribe, "router_completion", _fake_router)
+
+    with pytest.raises(transcribe.TranscriptParseError) as excinfo:
+        transcribe._transcribe_audio_gemini("s3://x", "en", None, False)
+
+    assert len(calls) == 1
+    assert transcribe._is_recoverable_error(excinfo.value) is True
+    assert transcribe._failure_reason(excinfo.value) == "truncated_output"
+
+
+def test_non_length_parse_failure_is_still_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbled output with a normal stop reason succeeded on redelivery in production."""
+    _stub_common(monkeypatch)
+    monkeypatch.setattr(
+        transcribe, "router_completion", lambda *_a, **_k: FakeCompletion(TRUNCATED, "stop")
+    )
+
+    with pytest.raises(transcribe.TranscriptParseError) as excinfo:
+        transcribe._transcribe_audio_gemini("s3://x", "en", None, False)
+
+    assert transcribe._is_recoverable_error(excinfo.value) is False


### PR DESCRIPTION
Transcription
- Repair stray \u escapes in Gemini transcript JSON and validate the payload shape before use
- Retry a bad payload once in-process so a correction-pass failure no longer re-runs the transcription pass; skip the retry on length truncation and mark the chunk failed, since the same audio truncates the same way
- Treat Vertex 400 INVALID_ARGUMENT as bad audio: mark the chunk failed instead of redelivering. Router-originated 400s still retry
- Cap task_transcribe_chunk at 5 retries with 30s..10min backoff instead of the default 20
- Pass a per-call multi_modal_pro -> multi_modal_fast fallback on transcription only, log the answering model, and store it per chunk in diarization.data.models

Merge
- Raise NoMergeableChunksError when every chunk fails to probe, mapped to a 400 NoMergeableChunksException; the merge task stops instead of retrying and the status timeline records a failure
- ffprobe failures raise FFmpegError so they classify as terminal; transport errors still retry
- Log skipped chunks on partial failures and cap error text per chunk

Evidence: 114 non-recoverable chunk failures in 30 days (PostHog server_chunk_transcription_failed), prod tracebacks at transcribe.py json.loads for both passes, and a 13-retry merge loop on a truncated upload.

Refs ECHO-962, ECHO-923