### PR TITLE
Popcorn: presenting shows the room's view, and the tab row keeps its spacing

### DIFF
--- a/echo/frontend/src/locales/cs-CZ.po
+++ b/echo/frontend/src/locales/cs-CZ.po
@@ -76,7 +76,7 @@ msgstr "\"ECHO\" available soon"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explore\" available soon"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -312,7 +312,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -655,12 +655,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. When a conversation or report event happens, we automatically send the data to your URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -677,7 +677,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr "3 months ago"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -693,12 +693,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr "Any tag"
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgstr "Are you sure you want to remove your custom logo? The default dembrane l
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgid "Basic Settings"
 msgstr "Basic Settings"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2059,7 +2059,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2278,7 +2278,7 @@ msgstr "Change workspace role?"
 msgid "Change your own role?"
 msgstr "Change your own role?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2294,7 +2294,7 @@ msgstr "Changes will be saved automatically"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2747,8 +2747,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Cooling down. Available in {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2773,8 +2773,8 @@ msgstr "Copied!"
 msgid "copy"
 msgstr "copy"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3880,11 +3880,11 @@ msgstr "Email verification | dembrane"
 msgid "email@work.com"
 msgstr "email@work.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3957,7 +3957,7 @@ msgstr "Enabled"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4143,8 +4143,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr "Exceeds seat cap. Overage billing applies."
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4441,7 +4441,7 @@ msgstr "Failed to upload logo"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4594,7 +4594,7 @@ msgstr "For advanced users: A secret key to verify webhook authenticity. Only ne
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4658,8 +4658,6 @@ msgstr "French"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4736,7 +4734,7 @@ msgstr "Generating the summary. Please wait..."
 msgid "Generating your report..."
 msgstr "Generating your report..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4954,7 +4952,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5012,7 +5010,7 @@ msgstr "How it works:"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr "Keep editing"
 msgid "Keep it"
 msgstr "Keep it"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5532,7 +5530,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr "Keep pending"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5604,7 +5602,7 @@ msgstr "Latest"
 msgid "Latest report"
 msgstr "Latest report"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5718,7 +5716,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr "Lifetime cap"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5748,8 +5746,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5797,7 +5795,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5814,7 +5812,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6859,7 +6857,7 @@ msgstr "Not Added"
 msgid "Not available"
 msgstr "Not available"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6871,7 +6869,7 @@ msgstr "Not now"
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6995,7 +6993,7 @@ msgstr ""
 msgid "Off"
 msgstr "Off"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7124,7 +7122,7 @@ msgstr "Only workspace admins can change these settings. Ask an admin if somethi
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7175,8 +7173,8 @@ msgstr "Open for participation"
 msgid "Open host guide"
 msgstr "Open host guide"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7535,7 +7533,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7843,14 +7841,14 @@ msgstr "PNG, JPEG, or WebP. Will be cropped to a circle."
 msgid "Poor response"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7858,7 +7856,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7944,7 +7942,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Preparing your experience"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8192,11 +8190,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Provide an overview of the main topics and recurring themes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8245,7 +8243,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8282,7 +8280,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Read aloud"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8337,7 +8335,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8349,7 +8347,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8683,12 +8681,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9093,11 +9091,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9164,7 +9162,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9389,7 +9387,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9623,7 +9621,7 @@ msgstr "Session Name"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9688,8 +9686,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9721,7 +9719,7 @@ msgstr ""
 msgid "Setup"
 msgstr "Setup"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9783,7 +9781,7 @@ msgstr "Shortest First"
 msgid "Show"
 msgstr "Show"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9881,11 +9879,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Showing your most recent completed report."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9958,7 +9956,7 @@ msgstr ""
 msgid "Someone"
 msgstr "Someone"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10129,7 +10127,7 @@ msgstr "Start New Conversation"
 msgid "Start over"
 msgstr "Start over"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10154,12 +10152,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10637,7 +10635,7 @@ msgstr "The organisation this invite was for has been deleted. There's nothing t
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10662,11 +10660,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "The report may start up to 5 minutes after the chosen time."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11160,7 +11158,7 @@ msgstr "Tip: Use the play button (▶) to send a test payload to your webhook an
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Title"
@@ -11430,7 +11428,7 @@ msgstr "Try asking"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11455,7 +11453,7 @@ msgstr "Turn off"
 msgid "Turn off anonymization?"
 msgstr "Turn off anonymization?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12002,7 +12000,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr "Verifying your email address."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12994,7 +12992,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/de-DE.po
+++ b/echo/frontend/src/locales/de-DE.po
@@ -77,7 +77,7 @@ msgstr "\"ECHO\" bald verfügbar"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Erkunden\" bald verfügbar"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -656,12 +656,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. Wenn ein Gesprächs- oder Berichtereignis eintritt, senden wir die Daten automatisch an deine URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Sind Sie sicher, dass Sie Ihr benutzerdefiniertes Logo entfernen möchte
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1902,7 +1902,7 @@ msgid "Basic Settings"
 msgstr "Grundlegende Einstellungen"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2060,7 +2060,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2295,7 +2295,7 @@ msgstr "Änderungen werden automatisch gespeichert"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Das Ändern der Sprache während eines aktiven Chats kann unerwartete Ergebnisse hervorrufen. Es wird empfohlen, ein neues Gespräch zu beginnen, nachdem die Sprache geändert wurde. Sind Sie sicher, dass Sie fortfahren möchten?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2748,8 +2748,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Abkühlung läuft. Verfügbar in {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2774,8 +2774,8 @@ msgstr "Kopiert!"
 msgid "copy"
 msgstr "Kopie"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3881,11 +3881,11 @@ msgstr ""
 msgid "email@work.com"
 msgstr "email@work.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3958,7 +3958,7 @@ msgstr "Aktiviert"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4144,8 +4144,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr ""
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4442,7 +4442,7 @@ msgstr "Logo konnte nicht hochgeladen werden"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4595,7 +4595,7 @@ msgstr "Für erfahrene Benutzer: Ein Geheimnis-Schlüssel, um die Authentizität
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4659,8 +4659,6 @@ msgstr "Französisch"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4737,7 +4735,7 @@ msgstr "Zusammenfassung wird erstellt. Kurz warten ..."
 msgid "Generating your report..."
 msgstr "Dein Bericht wird erstellt..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4955,7 +4953,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5013,7 +5011,7 @@ msgstr "Wie es funktioniert:"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5517,7 +5515,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5533,7 +5531,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5605,7 +5603,7 @@ msgstr "Neueste"
 msgid "Latest report"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5719,7 +5717,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5749,8 +5747,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5798,7 +5796,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5815,7 +5813,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6860,7 +6858,7 @@ msgstr "Nicht hinzugefügt"
 msgid "Not available"
 msgstr "Nicht verfügbar"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6872,7 +6870,7 @@ msgstr ""
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6996,7 +6994,7 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7125,7 +7123,7 @@ msgstr ""
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7176,8 +7174,8 @@ msgstr ""
 msgid "Open host guide"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7536,7 +7534,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7844,14 +7842,14 @@ msgstr "PNG, JPEG oder WebP. Wird zu einem Kreis zugeschnitten."
 msgid "Poor response"
 msgstr "Schlechte Antwort"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7859,7 +7857,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7945,7 +7943,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Ihre Erfahrung wird vorbereitet"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8193,11 +8191,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Bieten Sie eine Übersicht über die Hauptthemen und wiederkehrende Themen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8246,7 +8244,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8283,7 +8281,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Vorlesen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8338,7 +8336,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8350,7 +8348,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8684,12 +8682,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Aufzeichnung"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9094,11 +9092,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9165,7 +9163,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Speichern..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9390,7 +9388,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9624,7 +9622,7 @@ msgstr "Sitzungsname"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9689,8 +9687,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9722,7 +9720,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9784,7 +9782,7 @@ msgstr "Kürzeste zuerst"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9882,11 +9880,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Ihr zuletzt fertiggestellter Bericht wird angezeigt."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9959,7 +9957,7 @@ msgstr ""
 msgid "Someone"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10130,7 +10128,7 @@ msgstr "Neues Gespräch starten"
 msgid "Start over"
 msgstr "Neu beginnen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10155,12 +10153,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10638,7 +10636,7 @@ msgstr ""
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10663,11 +10661,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "Der Bericht kann bis zu 5 Minuten nach der gewählten Zeit starten."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11161,7 +11159,7 @@ msgstr "Tipp: Verwenden Sie den Play-Button (▶), um einen Test-Payload an Ihre
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tipp: Sie können auch eine Vorlage aus jeder gesendeten Chat-Nachricht erstellen oder eine bestehende Vorlage duplizieren."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Titel"
@@ -11429,7 +11427,7 @@ msgstr "Frag mal"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11454,7 +11452,7 @@ msgstr "Ausschalten"
 msgid "Turn off anonymization?"
 msgstr "Anonymisierung ausschalten?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12001,7 +11999,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12993,7 +12991,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/en-US.po
+++ b/echo/frontend/src/locales/en-US.po
@@ -76,7 +76,7 @@ msgstr "\"ECHO\" available soon"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explore\" available soon"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr "\"made with dembrane\" stays on the screen."
 
@@ -312,7 +312,7 @@ msgstr "{0} added from your organisation"
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr "{0} conversations · {1} phrases"
 
@@ -655,12 +655,12 @@ msgstr "2 to 5."
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. When a conversation or report event happens, we automatically send the data to your URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr "24 hours"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr "24 more hours"
 
@@ -668,7 +668,7 @@ msgstr "24 more hours"
 msgid "250 to 1000."
 msgstr "250 to 1000."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr "3 days"
@@ -677,7 +677,7 @@ msgstr "3 days"
 msgid "3 months ago"
 msgstr "3 months ago"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr "3 more days"
 
@@ -693,12 +693,12 @@ msgstr "50 to 250."
 msgid "6 to 15."
 msgstr "6 to 15."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr "8 hours"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr "8 more hours"
 
@@ -1357,7 +1357,7 @@ msgstr "An additional training is mandatory for teams using dembrane in situatio
 msgid "An assembly."
 msgstr "An assembly."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr "An early feature. It may change, and you can turn it off again in the project settings."
 
@@ -1470,7 +1470,7 @@ msgstr "Any tag"
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr "Anyone with the link can watch. No login, and no transcripts."
 
@@ -1625,7 +1625,7 @@ msgstr "Are you sure you want to remove your custom logo? The default dembrane l
 msgid "Arranged with dembrane"
 msgstr "Arranged with dembrane"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr "As now"
 
@@ -1901,7 +1901,7 @@ msgid "Basic Settings"
 msgstr "Basic Settings"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2059,7 +2059,7 @@ msgstr "Can you tell us more?"
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2278,7 +2278,7 @@ msgstr "Change workspace role?"
 msgid "Change your own role?"
 msgstr "Change your own role?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr "Changemaker plan takes it off"
 
@@ -2294,7 +2294,7 @@ msgstr "Changes will be saved automatically"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr "Changing the voice re-reads every conversation."
 
@@ -2747,8 +2747,8 @@ msgstr "Conversations cleared"
 msgid "participant.refine.cooling.down"
 msgstr "Cooling down. Available in {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2773,8 +2773,8 @@ msgstr "Copied!"
 msgid "copy"
 msgstr "copy"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3445,7 +3445,7 @@ msgstr "dembrane B.V. {0}, all rights reserved."
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane can make mistakes. Please double-check responses."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr "dembrane default"
 
@@ -3880,11 +3880,11 @@ msgstr "Email verification | dembrane"
 msgid "email@work.com"
 msgstr "email@work.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr "Embed"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr "Embed code"
 
@@ -3957,7 +3957,7 @@ msgstr "Enabled"
 msgid "Ended"
 msgstr "Ended"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr "Ended · {read}"
 
@@ -4143,8 +4143,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr "Exceeds seat cap. Overage billing applies."
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr "Exit full screen"
+#~ msgid "Exit full screen"
+#~ msgstr "Exit full screen"
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4441,7 +4441,7 @@ msgstr "Failed to upload logo"
 msgid "Fair password"
 msgstr "Fair password"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr "Favour what became a decision, a need or a next step."
 
@@ -4594,7 +4594,7 @@ msgstr "For advanced users: A secret key to verify webhook authenticity. Only ne
 msgid "For an external organisation"
 msgstr "For an external organisation"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr "For example: keep the members' own words, skip anything about named staff."
 
@@ -4658,8 +4658,6 @@ msgstr "French"
 msgid "friction"
 msgstr "friction"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4736,7 +4734,7 @@ msgstr "Generating the summary. Please wait..."
 msgid "Generating your report..."
 msgstr "Generating your report..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr "Gentle on people"
 
@@ -4954,7 +4952,7 @@ msgstr "Hide steps"
 msgid "Hide the changes"
 msgstr "Hide the changes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr "Hide the sample"
 
@@ -5012,7 +5010,7 @@ msgstr "How it works:"
 msgid "How many recordings do you expect in your first year?"
 msgstr "How many recordings do you expect in your first year?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr "How should the phrases sound?"
 
@@ -5516,7 +5514,7 @@ msgstr "Keep editing"
 msgid "Keep it"
 msgstr "Keep it"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr "Keep it plain"
 
@@ -5532,7 +5530,7 @@ msgstr "Keep my plan"
 msgid "Keep pending"
 msgstr "Keep pending"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr "Keep reading new conversations"
 
@@ -5604,7 +5602,7 @@ msgstr "Latest"
 msgid "Latest report"
 msgstr "Latest report"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr "Lean towards decisions"
 
@@ -5718,7 +5716,7 @@ msgstr "Licenses granted"
 msgid "Lifetime cap"
 msgstr "Lifetime cap"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5748,8 +5746,8 @@ msgstr "Listing conversations"
 msgid "Listing documentation pages"
 msgstr "Listing documentation pages"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5797,7 +5795,7 @@ msgstr "Live recordings, transcription progress, and errors show up here as part
 msgid "live slides for the room"
 msgstr "live slides for the room"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr "Live slides for the room, made from this project's conversations while they are still happening."
 
@@ -5814,7 +5812,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live stream interrupted. Falling back to polling."
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr "Live until {0}"
 
@@ -6859,7 +6857,7 @@ msgstr "Not Added"
 msgid "Not available"
 msgstr "Not available"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6871,7 +6869,7 @@ msgstr "Not now"
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr "Not reading new conversations · {read}"
 
@@ -6995,7 +6993,7 @@ msgstr "off"
 msgid "Off"
 msgstr "Off"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 
@@ -7124,7 +7122,7 @@ msgstr "Only workspace admins can change these settings. Ask an admin if somethi
 msgid "Only you can see this workspace."
 msgstr "Only you can see this workspace."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 
@@ -7175,8 +7173,8 @@ msgstr "Open for participation"
 msgid "Open host guide"
 msgstr "Open host guide"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr "Open in a new tab"
 
@@ -7535,7 +7533,7 @@ msgstr "Password does not meet the requirements."
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr "Paste it into any page. It stays live."
 
@@ -7843,14 +7841,14 @@ msgstr "PNG, JPEG, or WebP. Will be cropped to a circle."
 msgid "Poor response"
 msgstr "Poor response"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr "Popcorn"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr "Popcorn could not be loaded. Try again in a moment."
 
@@ -7858,7 +7856,7 @@ msgstr "Popcorn could not be loaded. Try again in a moment."
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 
@@ -7944,7 +7942,7 @@ msgstr "Preparing this canvas"
 msgid "Preparing your experience"
 msgstr "Preparing your experience"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr "Present"
 
@@ -8192,11 +8190,11 @@ msgstr "Prorated for the rest of this billing period."
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Provide an overview of the main topics and recurring themes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr "Public link"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr "Public page"
 
@@ -8245,7 +8243,7 @@ msgstr "Questions about how dembrane works, not only about your data."
 msgid "Ran {0} steps at once"
 msgstr "Ran {0} steps at once"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 
@@ -8282,7 +8280,7 @@ msgstr "Reactivate plan"
 msgid "Read aloud"
 msgstr "Read aloud"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr "Read everything again now"
 
@@ -8337,7 +8335,7 @@ msgstr "Reading project settings"
 msgid "Reading the conversations again"
 msgstr "Reading the conversations again"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr "Reading the conversations now"
 
@@ -8349,7 +8347,7 @@ msgstr "Reading the conversations now"
 msgid "Reading the documentation"
 msgstr "Reading the documentation"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr "Reads new conversations every {every} minutes, last read {last}"
 
@@ -8683,12 +8681,12 @@ msgstr "Renewal"
 msgid "Reopen"
 msgstr "Reopen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Replay"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr "Replaying a saved run. The room's page and the public link keep showing the live session."
 
@@ -9093,11 +9091,11 @@ msgstr "Running"
 msgid "Sales invoice issued."
 msgstr "Sales invoice issued."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr "Sample popcorn session"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9164,7 +9162,7 @@ msgstr "Saved as this project's goal."
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr "Say it in your own words. Type, or press record and talk."
 
@@ -9389,7 +9387,7 @@ msgstr "see transcripts"
 msgid "See upgrade options"
 msgstr "See upgrade options"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr "See what the room will see, with a sample session, before your own day."
 
@@ -9623,7 +9621,7 @@ msgstr "Session Name"
 #~ msgid "Session settings"
 #~ msgstr "Session settings"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr "Session title"
 
@@ -9688,8 +9686,8 @@ msgstr "Setting up"
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9721,7 +9719,7 @@ msgstr "Settings updated"
 msgid "Setup"
 msgstr "Setup"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr "Share"
 
@@ -9783,7 +9781,7 @@ msgstr "Shortest First"
 msgid "Show"
 msgstr "Show"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr "Show \"made with dembrane\" on the screen"
 
@@ -9881,11 +9879,11 @@ msgstr "Showing the first {0} of {shownCount} matches. Narrow the search to see 
 msgid "Showing your most recent completed report."
 msgstr "Showing your most recent completed report."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr "Shown at the top of the screen."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr "Shown at the top of the screen. Change it any time."
 
@@ -9958,7 +9956,7 @@ msgstr "Some of the recent audio couldn't be transcribed. The recording is saved
 msgid "Someone"
 msgstr "Someone"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr "Something else"
 
@@ -10129,7 +10127,7 @@ msgstr "Start New Conversation"
 msgid "Start over"
 msgstr "Start over"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr "Start popcorn"
 
@@ -10154,12 +10152,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr "Stay live"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr "Stay live for"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr "Stays live until"
 
@@ -10637,7 +10635,7 @@ msgstr "The organisation this invite was for has been deleted. There's nothing t
 msgid "The page this answer refers to."
 msgstr "The page this answer refers to."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 
@@ -10662,11 +10660,11 @@ msgstr "The project context is read by transcription, chat answers and canvas ge
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "The report may start up to 5 minutes after the chosen time."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr "The softer of two ways the room said a thing. Nothing that names or blames a person."
 
@@ -11160,7 +11158,7 @@ msgstr "Tip: Use the play button (▶) to send a test payload to your webhook an
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Title"
@@ -11430,7 +11428,7 @@ msgstr "Try asking"
 msgid "Try it"
 msgstr "Try it"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr "Try it with a sample"
 
@@ -11455,7 +11453,7 @@ msgstr "Turn off"
 msgid "Turn off anonymization?"
 msgstr "Turn off anonymization?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr "Turn on popcorn"
 
@@ -12002,7 +12000,7 @@ msgstr "Verifying"
 msgid "Verifying your email address."
 msgstr "Verifying your email address."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr "Version"
@@ -12994,7 +12992,7 @@ msgstr "Your plan is inactive. Reactivate it to add members."
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr "Your plan is managed by dembrane. Contact your account manager to make changes."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr "Your plan lets you take the mark off."
 

--- a/echo/frontend/src/locales/es-ES.po
+++ b/echo/frontend/src/locales/es-ES.po
@@ -77,7 +77,7 @@ msgstr "\"ECHO\" disponible pronto"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explorar\" disponible pronto"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -656,12 +656,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. Cuando ocurre un evento de conversación o informe, enviamos automáticamente los datos a tu URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "¿Está seguro de que desea eliminar su logotipo personalizado? Se utili
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1902,7 +1902,7 @@ msgid "Basic Settings"
 msgstr "Configuración Básica"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2060,7 +2060,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2295,7 +2295,7 @@ msgstr "Los cambios se guardarán automáticamente"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Cambiar el idioma durante una conversación activa puede provocar resultados inesperados. Se recomienda iniciar una nueva conversación después de cambiar el idioma. ¿Estás seguro de que quieres continuar?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2748,8 +2748,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Enfriándose. Disponible en {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2774,8 +2774,8 @@ msgstr "Copiado!"
 msgid "copy"
 msgstr "copia"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3881,11 +3881,11 @@ msgstr ""
 msgid "email@work.com"
 msgstr "email@trabajo.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3958,7 +3958,7 @@ msgstr "Habilitado"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4144,8 +4144,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr ""
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4442,7 +4442,7 @@ msgstr "Error al subir el logo"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4595,7 +4595,7 @@ msgstr "Para usuarios avanzados: Una clave secreta para verificar la autenticida
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4659,8 +4659,6 @@ msgstr "Francés"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4737,7 +4735,7 @@ msgstr "Generando el resumen. Espera..."
 msgid "Generating your report..."
 msgstr "Generando tu informe..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4955,7 +4953,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5013,7 +5011,7 @@ msgstr "Cómo funciona:"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5517,7 +5515,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5533,7 +5531,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5605,7 +5603,7 @@ msgstr "Último"
 msgid "Latest report"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5719,7 +5717,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Enlace"
@@ -5749,8 +5747,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5798,7 +5796,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5815,7 +5813,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6860,7 +6858,7 @@ msgstr "No añadidas"
 msgid "Not available"
 msgstr "No disponible"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6872,7 +6870,7 @@ msgstr ""
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6996,7 +6994,7 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7125,7 +7123,7 @@ msgstr ""
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7176,8 +7174,8 @@ msgstr ""
 msgid "Open host guide"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7536,7 +7534,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7844,14 +7842,14 @@ msgstr "PNG, JPEG o WebP. Se recortará en un círculo."
 msgid "Poor response"
 msgstr "Mala respuesta"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7859,7 +7857,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7945,7 +7943,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Preparando tu experiencia"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8193,11 +8191,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Proporciona una visión general de los temas principales y los temas recurrentes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8246,7 +8244,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8283,7 +8281,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Leer en voz alta"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8338,7 +8336,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8350,7 +8348,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8684,12 +8682,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Grabación"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9094,11 +9092,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9165,7 +9163,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9390,7 +9388,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9624,7 +9622,7 @@ msgstr "Nombre de la Sesión"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9689,8 +9687,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9722,7 +9720,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9784,7 +9782,7 @@ msgstr "Más corto primero"
 msgid "Show"
 msgstr "Mostrar"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9882,11 +9880,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Mostrando su informe completado más reciente."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9959,7 +9957,7 @@ msgstr ""
 msgid "Someone"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10130,7 +10128,7 @@ msgstr "Iniciar nueva conversación"
 msgid "Start over"
 msgstr "Empezar de nuevo"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10155,12 +10153,12 @@ msgstr "Estado"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10638,7 +10636,7 @@ msgstr ""
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10663,11 +10661,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "El informe puede comenzar hasta 5 minutos después de la hora elegida."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11161,7 +11159,7 @@ msgstr "Consejo: Usa el botón de reproducción (▶) para enviar un payload de 
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Consejo: También puede crear una plantilla desde cualquier mensaje de chat que envíe, o duplicar una plantilla existente."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Título"
@@ -11431,7 +11429,7 @@ msgstr "Prueba a preguntar"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11456,7 +11454,7 @@ msgstr "Desactivar"
 msgid "Turn off anonymization?"
 msgstr "¿Desactivar la anonimización?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12003,7 +12001,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12995,7 +12993,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/fr-FR.po
+++ b/echo/frontend/src/locales/fr-FR.po
@@ -77,7 +77,7 @@ msgstr "\"ECHO\" bientôt disponible"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explorer\" bientôt disponible"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -656,12 +656,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. Lorsqu'un événement de conversation ou de rapport se produit, nous envoyons automatiquement les données à votre URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer votre logo personnalisé ? Le logo 
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1902,7 +1902,7 @@ msgid "Basic Settings"
 msgstr "Paramètres de base"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2060,7 +2060,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2295,7 +2295,7 @@ msgstr "Les modifications seront enregistrées automatiquement"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Changer de langue pendant une conversation active peut provoquer des résultats inattendus. Il est recommandé de commencer une nouvelle conversation après avoir changé la langue. Êtes-vous sûr de vouloir continuer ?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2748,8 +2748,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Période de repos. Disponible dans {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2774,8 +2774,8 @@ msgstr "Copié !"
 msgid "copy"
 msgstr "copie"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3881,11 +3881,11 @@ msgstr ""
 msgid "email@work.com"
 msgstr "email@travail.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3958,7 +3958,7 @@ msgstr "Activé"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4144,8 +4144,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr ""
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4442,7 +4442,7 @@ msgstr "Échec du téléchargement du logo"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4595,7 +4595,7 @@ msgstr "Pour les utilisateurs avancés : Une clé secrète pour vérifier l'auth
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4659,8 +4659,6 @@ msgstr "Français"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4737,7 +4735,7 @@ msgstr "Génération du résumé. Patiente un peu..."
 msgid "Generating your report..."
 msgstr "Génération de votre rapport en cours..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4955,7 +4953,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5013,7 +5011,7 @@ msgstr "Comment ça marche :"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5517,7 +5515,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5533,7 +5531,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5605,7 +5603,7 @@ msgstr "Dernier"
 msgid "Latest report"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5719,7 +5717,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Lien"
@@ -5749,8 +5747,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5798,7 +5796,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5815,7 +5813,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6860,7 +6858,7 @@ msgstr "Non ajoutées"
 msgid "Not available"
 msgstr "Non disponible"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6872,7 +6870,7 @@ msgstr ""
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6996,7 +6994,7 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7125,7 +7123,7 @@ msgstr ""
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7176,8 +7174,8 @@ msgstr ""
 msgid "Open host guide"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7536,7 +7534,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Les mots de passe ne correspondent pas"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7844,14 +7842,14 @@ msgstr "PNG, JPEG ou WebP. Sera recadré en cercle."
 msgid "Poor response"
 msgstr "Mauvaise réponse"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7859,7 +7857,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7945,7 +7943,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Préparation de votre expérience"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8193,11 +8191,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Fournissez un aperçu des sujets principaux et des thèmes récurrents"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8246,7 +8244,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8283,7 +8281,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Lire à haute voix"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8338,7 +8336,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8350,7 +8348,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8684,12 +8682,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Enregistrement"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9094,11 +9092,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9165,7 +9163,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Enregistrement..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9390,7 +9388,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9624,7 +9622,7 @@ msgstr "Nom de la Séance"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9689,8 +9687,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9722,7 +9720,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9784,7 +9782,7 @@ msgstr "Plus court en premier"
 msgid "Show"
 msgstr "Afficher"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9882,11 +9880,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Affichage de votre dernier rapport terminé."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9959,7 +9957,7 @@ msgstr ""
 msgid "Someone"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10130,7 +10128,7 @@ msgstr "Commencer une nouvelle conversation"
 msgid "Start over"
 msgstr "Recommencer"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10155,12 +10153,12 @@ msgstr "Statut"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10638,7 +10636,7 @@ msgstr ""
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10663,11 +10661,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "Le rapport peut démarrer jusqu'à 5 minutes après l'heure choisie."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11161,7 +11159,7 @@ msgstr "Conseil : Utilisez le bouton de lecture (▶) pour envoyer un payload de
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Astuce : Vous pouvez aussi créer un modèle à partir de n'importe quel message de chat que vous envoyez, ou dupliquer un modèle existant."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Titre"
@@ -11428,7 +11426,7 @@ msgstr "Tu peux demander"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11453,7 +11451,7 @@ msgstr "Désactiver"
 msgid "Turn off anonymization?"
 msgstr "Désactiver l'anonymisation ?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12000,7 +11998,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12992,7 +12990,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/it-IT.po
+++ b/echo/frontend/src/locales/it-IT.po
@@ -76,7 +76,7 @@ msgstr "\"ECHO\" available soon"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explore\" available soon"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -312,7 +312,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -655,12 +655,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. When a conversation or report event happens, we automatically send the data to your URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -677,7 +677,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -693,12 +693,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgstr "Are you sure you want to remove your custom logo? The default dembrane l
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgid "Basic Settings"
 msgstr "Basic Settings"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2059,7 +2059,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2294,7 +2294,7 @@ msgstr "Changes will be saved automatically"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2747,8 +2747,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Cooling down. Available in {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2773,8 +2773,8 @@ msgstr "Copied!"
 msgid "copy"
 msgstr "copy"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3880,11 +3880,11 @@ msgstr ""
 msgid "email@work.com"
 msgstr "email@work.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3957,7 +3957,7 @@ msgstr "Enabled"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4143,8 +4143,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr ""
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4441,7 +4441,7 @@ msgstr "Failed to upload logo"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4594,7 +4594,7 @@ msgstr "For advanced users: A secret key to verify webhook authenticity. Only ne
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4658,8 +4658,6 @@ msgstr "French"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4736,7 +4734,7 @@ msgstr "Generating the summary. Please wait..."
 msgid "Generating your report..."
 msgstr "Generating your report..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4954,7 +4952,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5012,7 +5010,7 @@ msgstr "How it works:"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5532,7 +5530,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5604,7 +5602,7 @@ msgstr "Latest"
 msgid "Latest report"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5718,7 +5716,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5748,8 +5746,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5797,7 +5795,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5814,7 +5812,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6859,7 +6857,7 @@ msgstr "Not Added"
 msgid "Not available"
 msgstr "Not available"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6871,7 +6869,7 @@ msgstr ""
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6995,7 +6993,7 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7124,7 +7122,7 @@ msgstr ""
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7175,8 +7173,8 @@ msgstr ""
 msgid "Open host guide"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7535,7 +7533,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7843,14 +7841,14 @@ msgstr "PNG, JPEG, or WebP. Will be cropped to a circle."
 msgid "Poor response"
 msgstr "Risposta scadente"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7858,7 +7856,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7944,7 +7942,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Preparing your experience"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8192,11 +8190,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Provide an overview of the main topics and recurring themes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8245,7 +8243,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8282,7 +8280,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Read aloud"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8337,7 +8335,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8349,7 +8347,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8683,12 +8681,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Registrazione"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9093,11 +9091,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9164,7 +9162,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9389,7 +9387,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9623,7 +9621,7 @@ msgstr "Session Name"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9688,8 +9686,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9721,7 +9719,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9783,7 +9781,7 @@ msgstr "Shortest First"
 msgid "Show"
 msgstr "Show"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9881,11 +9879,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Showing your most recent completed report."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9958,7 +9956,7 @@ msgstr ""
 msgid "Someone"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10129,7 +10127,7 @@ msgstr "Start New Conversation"
 msgid "Start over"
 msgstr "Start over"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10154,12 +10152,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10637,7 +10635,7 @@ msgstr ""
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10662,11 +10660,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "The report may start up to 5 minutes after the chosen time."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11160,7 +11158,7 @@ msgstr "Tip: Use the play button (▶) to send a test payload to your webhook an
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Title"
@@ -11430,7 +11428,7 @@ msgstr "Try asking"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11455,7 +11453,7 @@ msgstr "Turn off"
 msgid "Turn off anonymization?"
 msgstr "Turn off anonymization?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12002,7 +12000,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12994,7 +12992,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/nl-NL.po
+++ b/echo/frontend/src/locales/nl-NL.po
@@ -77,7 +77,7 @@ msgstr "\"ECHO\" binnenkort beschikbaar"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Verkennen\" binnenkort beschikbaar"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr "{0} toegevoegd vanuit je organisatie"
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -656,12 +656,12 @@ msgstr "2 tot 5."
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. Wanneer een gesprek of rapport plaatsvindt, sturen we de data automatisch naar je URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr "24 uur"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr "250 tot 1000."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr "3 dagen"
@@ -678,7 +678,7 @@ msgstr "3 dagen"
 msgid "3 months ago"
 msgstr "3 maanden geleden"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -694,12 +694,12 @@ msgstr "50 tot 250."
 msgid "6 to 15."
 msgstr "6 tot 15."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr "8 uur"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr "Een extra training is verplicht voor teams die dembrane gebruiken in sit
 msgid "An assembly."
 msgstr "Een burgerberaad."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgstr "Elke tag"
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr "Iedereen in je organisatie kan deze werkruimte vinden. Admins kunnen meteen meedoen, leden kunnen toegang aanvragen."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1623,7 +1623,7 @@ msgstr "Weet je zeker dat je je aangepaste logo wilt verwijderen? Het standaard 
 msgid "Arranged with dembrane"
 msgstr "Geregeld met dembrane"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1899,7 +1899,7 @@ msgid "Basic Settings"
 msgstr "Basis instellingen"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2057,7 +2057,7 @@ msgstr "Kun je ons meer vertellen?"
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2276,7 +2276,7 @@ msgstr "Werkruimterol wijzigen?"
 msgid "Change your own role?"
 msgstr "Je eigen rol wijzigen?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr "Wijzigingen worden automatisch opgeslagen"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Wijziging van de taal tijdens een actief gesprek kan onverwachte resultaten opleveren. Het wordt aanbevolen om een nieuw gesprek te starten na het wijzigen van de taal. Weet je zeker dat je wilt doorgaan?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2745,8 +2745,8 @@ msgstr "Gesprekken gewist"
 msgid "participant.refine.cooling.down"
 msgstr "Even afkoelen. Beschikbaar over {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2771,8 +2771,8 @@ msgstr "Gekopieerd!"
 msgid "copy"
 msgstr "kopie"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3443,7 +3443,7 @@ msgstr "dembrane B.V. {0}, alle rechten voorbehouden."
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr "dembrane kan fouten maken. Controleer antwoorden altijd even."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3878,11 +3878,11 @@ msgstr "E-mailverificatie | dembrane"
 msgid "email@work.com"
 msgstr "email@werk.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgstr "Ingeschakeld"
 msgid "Ended"
 msgstr "Afgelopen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4141,8 +4141,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr "Overschrijdt het maximum aantal stoelen. Er gelden extra kosten."
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4439,7 +4439,7 @@ msgstr "Fout bij het uploaden van het logo"
 msgid "Fair password"
 msgstr "Redelijk wachtwoord"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4592,7 +4592,7 @@ msgstr "Voor geavanceerde gebruikers: Een geheime sleutel om de authenticiteit v
 msgid "For an external organisation"
 msgstr "Voor een externe organisatie"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4656,8 +4656,6 @@ msgstr "Frans"
 msgid "friction"
 msgstr "wrijving"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4734,7 +4732,7 @@ msgstr "Samenvatting wordt gemaakt. Even wachten..."
 msgid "Generating your report..."
 msgstr "Je rapport wordt gegenereerd..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4952,7 +4950,7 @@ msgstr "Stappen verbergen"
 msgid "Hide the changes"
 msgstr "Wijzigingen verbergen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5010,7 +5008,7 @@ msgstr "Hoe het werkt:"
 msgid "How many recordings do you expect in your first year?"
 msgstr "Hoeveel opnames verwacht je in je eerste jaar?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5514,7 +5512,7 @@ msgstr "Verder bewerken"
 msgid "Keep it"
 msgstr "Behouden"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5530,7 +5528,7 @@ msgstr "Mijn abonnement behouden"
 msgid "Keep pending"
 msgstr "In behandeling houden"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5602,7 +5600,7 @@ msgstr "Laatste"
 msgid "Latest report"
 msgstr "Laatste rapport"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5716,7 +5714,7 @@ msgstr "Licenties verleend"
 msgid "Lifetime cap"
 msgstr "Levenslange limiet"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5746,8 +5744,8 @@ msgstr "Gesprekken op een rij zetten"
 msgid "Listing documentation pages"
 msgstr "Documentatiepagina's opzoeken"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5795,7 +5793,7 @@ msgstr "Live opnames, voortgang van transcriptie en fouten verschijnen hier zodr
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5812,7 +5810,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr "Live verbinding onderbroken. We halen updates nu periodiek op."
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6857,7 +6855,7 @@ msgstr "Niet toegevoegd"
 msgid "Not available"
 msgstr "Niet beschikbaar"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6869,7 +6867,7 @@ msgstr "Niet nu"
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr "Geen beheerde facturatie. Zet op beheerd om dit account op het {tier}-niveau te factureren, zonder automatische afschrijvingen via Mollie."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6993,7 +6991,7 @@ msgstr "uit"
 msgid "Off"
 msgstr "Uit"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7122,7 +7120,7 @@ msgstr "Alleen werkruimtebeheerders kunnen deze instellingen wijzigen. Vraag een
 msgid "Only you can see this workspace."
 msgstr "Alleen jij kunt deze werkruimte zien."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7173,8 +7171,8 @@ msgstr "Open voor deelname"
 msgid "Open host guide"
 msgstr "Hostgids openen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7533,7 +7531,7 @@ msgstr "Wachtwoord voldoet niet aan de vereisten."
 msgid "Passwords do not match"
 msgstr "Wachtwoorden komen niet overeen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7841,14 +7839,14 @@ msgstr "PNG, JPEG of WebP. Wordt bijgesneden tot een cirkel."
 msgid "Poor response"
 msgstr "Slecht antwoord"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7856,7 +7854,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7942,7 +7940,7 @@ msgstr "Dit canvas wordt voorbereid"
 msgid "Preparing your experience"
 msgstr "Uw ervaring voorbereiden"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8190,11 +8188,11 @@ msgstr "Naar rato voor de rest van deze factureringsperiode."
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Geef een overzicht van de belangrijkste onderwerpen en herhalende thema's"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8243,7 +8241,7 @@ msgstr "Vragen over hoe dembrane werkt, niet alleen over je data."
 msgid "Ran {0} steps at once"
 msgstr "{0} stappen tegelijk uitgevoerd"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8280,7 +8278,7 @@ msgstr "Plan heractiveren"
 msgid "Read aloud"
 msgstr "Lees hardop voor"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8335,7 +8333,7 @@ msgstr "Projectinstellingen lezen"
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8347,7 +8345,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr "De documentatie lezen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8681,12 +8679,12 @@ msgstr "Verlenging"
 msgid "Reopen"
 msgstr "Heropenen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Opname"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9091,11 +9089,11 @@ msgstr "Bezig"
 msgid "Sales invoice issued."
 msgstr "Verkoopfactuur uitgegeven."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9162,7 +9160,7 @@ msgstr "Opgeslagen als doel van dit project."
 msgid "Saving..."
 msgstr "Opslaan..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9387,7 +9385,7 @@ msgstr "transcripten te bekijken"
 msgid "See upgrade options"
 msgstr "Bekijk upgrade-opties"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9621,7 +9619,7 @@ msgstr "Sessienaam"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9686,8 +9684,8 @@ msgstr "Instellen"
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9719,7 +9717,7 @@ msgstr "Instellingen bijgewerkt"
 msgid "Setup"
 msgstr "Instellen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9781,7 +9779,7 @@ msgstr "Kortste eerst"
 msgid "Show"
 msgstr "Toon"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9879,11 +9877,11 @@ msgstr "De eerste {0} van {shownCount} resultaten worden getoond. Verfijn je zoe
 msgid "Showing your most recent completed report."
 msgstr "Uw meest recente voltooide rapport wordt getoond."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9956,7 +9954,7 @@ msgstr "Een deel van de recente audio kon niet worden getranscribeerd. De opname
 msgid "Someone"
 msgstr "Iemand"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10127,7 +10125,7 @@ msgstr "Nieuw gesprek starten"
 msgid "Start over"
 msgstr "Opnieuw beginnen"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10152,12 +10150,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr "Blijft live gedurende"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10635,7 +10633,7 @@ msgstr "De organisatie waarvoor deze uitnodiging was, is verwijderd. Er is niets
 msgid "The page this answer refers to."
 msgstr "De pagina waar dit antwoord naar verwijst."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10660,11 +10658,11 @@ msgstr "De projectcontext wordt gelezen door transcriptie, chatantwoorden en can
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "Het rapport kan tot 5 minuten na de gekozen tijd starten."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11158,7 +11156,7 @@ msgstr "Tip: Gebruik de afspeelknop (▶) om een testpayload naar je webhook te 
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tip: U kunt ook een sjabloon maken van elk chatbericht dat u verstuurt, of een bestaand sjabloon dupliceren."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Titel"
@@ -11426,7 +11424,7 @@ msgstr "Vraag bijvoorbeeld"
 msgid "Try it"
 msgstr "Probeer het"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11451,7 +11449,7 @@ msgstr "Uitschakelen"
 msgid "Turn off anonymization?"
 msgstr "Anonimisering uitschakelen?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -11998,7 +11996,7 @@ msgstr "Verifieert"
 msgid "Verifying your email address."
 msgstr "Je e-mailadres wordt geverifieerd."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr "Versie"
@@ -12990,7 +12988,7 @@ msgstr "Je abonnement is inactief. Activeer het opnieuw om leden toe te voegen."
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr "Je abonnement wordt beheerd door dembrane. Neem contact op met je accountmanager om wijzigingen te maken."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/locales/uk-UA.po
+++ b/echo/frontend/src/locales/uk-UA.po
@@ -76,7 +76,7 @@ msgstr "\"ECHO\" available soon"
 msgid "participant.modal.echo.info.title.go.deeper"
 msgstr "\"Explore\" available soon"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:711
+#: src/routes/project/popcorn/PopcornRoute.tsx:709
 msgid "\"made with dembrane\" stays on the screen."
 msgstr ""
 
@@ -312,7 +312,7 @@ msgstr ""
 
 #. placeholder {0}: counts.conversations
 #. placeholder {1}: counts.phrases
-#: src/routes/project/popcorn/PopcornRoute.tsx:97
+#: src/routes/project/popcorn/PopcornRoute.tsx:95
 msgid "{0} conversations · {1} phrases"
 msgstr ""
 
@@ -655,12 +655,12 @@ msgstr ""
 msgid "2. When a conversation or report event happens, we automatically send the data to your URL"
 msgstr "2. When a conversation or report event happens, we automatically send the data to your URL"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:370
+#: src/routes/project/popcorn/PopcornRoute.tsx:368
 #: src/routes/project/canvas/CanvasRoute.tsx:214
 msgid "24 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:684
+#: src/routes/project/popcorn/PopcornRoute.tsx:682
 msgid "24 more hours"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr ""
 msgid "250 to 1000."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:371
+#: src/routes/project/popcorn/PopcornRoute.tsx:369
 #: src/routes/project/canvas/CanvasRoute.tsx:215
 msgid "3 days"
 msgstr ""
@@ -677,7 +677,7 @@ msgstr ""
 msgid "3 months ago"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:685
+#: src/routes/project/popcorn/PopcornRoute.tsx:683
 msgid "3 more days"
 msgstr ""
 
@@ -693,12 +693,12 @@ msgstr ""
 msgid "6 to 15."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:369
+#: src/routes/project/popcorn/PopcornRoute.tsx:367
 #: src/routes/project/canvas/CanvasRoute.tsx:213
 msgid "8 hours"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:683
+#: src/routes/project/popcorn/PopcornRoute.tsx:681
 msgid "8 more hours"
 msgstr ""
 
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "An assembly."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:254
+#: src/routes/project/popcorn/PopcornRoute.tsx:252
 msgid "An early feature. It may change, and you can turn it off again in the project settings."
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Anyone in your organisation can find this workspace. Admins can join; members can request access."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:446
+#: src/routes/project/popcorn/PopcornRoute.tsx:444
 msgid "Anyone with the link can watch. No login, and no transcripts."
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgstr "Are you sure you want to remove your custom logo? The default dembrane l
 msgid "Arranged with dembrane"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:680
+#: src/routes/project/popcorn/PopcornRoute.tsx:678
 msgid "As now"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgid "Basic Settings"
 msgstr "Basic Settings"
 
 #: src/routes/project/ProjectMonitorRoute.tsx:85
-#: src/routes/project/popcorn/PopcornRoute.tsx:897
+#: src/routes/project/popcorn/PopcornRoute.tsx:905
 #: src/routes/project/library/LibraryRoute.tsx:129
 #: src/routes/project/chat/NewChatRoute.tsx:701
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:94
@@ -2059,7 +2059,7 @@ msgstr ""
 #: src/routes/project/CreateProjectRoute.tsx:403
 #: src/routes/project/report/ProjectReportRoute.tsx:288
 #: src/routes/project/report/ProjectReportRoute.tsx:1459
-#: src/routes/project/popcorn/PopcornRoute.tsx:720
+#: src/routes/project/popcorn/PopcornRoute.tsx:718
 #: src/routes/organisation/OrganisationRoute.tsx:1789
 #: src/routes/organisation/OrganisationRoute.tsx:1812
 #: src/routes/organisation/OrganisationRoute.tsx:1835
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Change your own role?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:714
+#: src/routes/project/popcorn/PopcornRoute.tsx:712
 msgid "Changemaker plan takes it off"
 msgstr ""
 
@@ -2294,7 +2294,7 @@ msgstr "Changes will be saved automatically"
 msgid "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 msgstr "Changing language during an active chat may lead to unexpected results. It's recommended to start a new chat after changing the language. Are you sure you want to continue?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:691
+#: src/routes/project/popcorn/PopcornRoute.tsx:689
 msgid "Changing the voice re-reads every conversation."
 msgstr ""
 
@@ -2747,8 +2747,8 @@ msgstr ""
 msgid "participant.refine.cooling.down"
 msgstr "Cooling down. Available in {0}"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/settings/TwoFactorSettingsCard.tsx:431
 #: src/components/project/ProjectQRCode.tsx:157
 #: src/components/conversation/CopyConversationTranscript.tsx:44
@@ -2773,8 +2773,8 @@ msgstr "Copied!"
 msgid "copy"
 msgstr "copy"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:488
-#: src/routes/project/popcorn/PopcornRoute.tsx:536
+#: src/routes/project/popcorn/PopcornRoute.tsx:486
+#: src/routes/project/popcorn/PopcornRoute.tsx:534
 #: src/components/conversation/ConversationEdit.tsx:51
 #: src/components/common/CopyRichTextIconButton.tsx:37
 #: src/components/common/CopyIconButton.tsx:8
@@ -3445,7 +3445,7 @@ msgstr ""
 msgid "dembrane can make mistakes. Please double-check responses."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:168
+#: src/routes/project/popcorn/PopcornRoute.tsx:166
 msgid "dembrane default"
 msgstr ""
 
@@ -3880,11 +3880,11 @@ msgstr ""
 msgid "email@work.com"
 msgstr "email@work.com"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:462
+#: src/routes/project/popcorn/PopcornRoute.tsx:460
 msgid "Embed"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:516
+#: src/routes/project/popcorn/PopcornRoute.tsx:514
 msgid "Embed code"
 msgstr ""
 
@@ -3957,7 +3957,7 @@ msgstr "Enabled"
 msgid "Ended"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:102
+#: src/routes/project/popcorn/PopcornRoute.tsx:100
 msgid "Ended · {read}"
 msgstr ""
 
@@ -4143,8 +4143,8 @@ msgid "Exceeds seat cap. Overage billing applies."
 msgstr ""
 
 #: src/routes/project/popcorn/PopcornRoute.tsx:925
-msgid "Exit full screen"
-msgstr ""
+#~ msgid "Exit full screen"
+#~ msgstr ""
 
 #: src/routes/project/report/ProjectReportRoute.tsx:1335
 #: src/routes/project/canvas/CanvasRoute.tsx:571
@@ -4441,7 +4441,7 @@ msgstr "Failed to upload logo"
 msgid "Fair password"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:151
+#: src/routes/project/popcorn/PopcornRoute.tsx:149
 msgid "Favour what became a decision, a need or a next step."
 msgstr ""
 
@@ -4594,7 +4594,7 @@ msgstr "For advanced users: A secret key to verify webhook authenticity. Only ne
 msgid "For an external organisation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:210
+#: src/routes/project/popcorn/PopcornRoute.tsx:208
 msgid "For example: keep the members' own words, skip anything about named staff."
 msgstr ""
 
@@ -4658,8 +4658,6 @@ msgstr "French"
 msgid "friction"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:925
-#: src/routes/project/popcorn/PopcornRoute.tsx:930
 #: src/routes/project/canvas/CanvasRoute.tsx:571
 #: src/routes/project/canvas/CanvasRoute.tsx:578
 msgid "Full screen"
@@ -4736,7 +4734,7 @@ msgstr "Generating the summary. Please wait..."
 msgid "Generating your report..."
 msgstr "Generating your report..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:143
+#: src/routes/project/popcorn/PopcornRoute.tsx:141
 msgid "Gentle on people"
 msgstr ""
 
@@ -4954,7 +4952,7 @@ msgstr ""
 msgid "Hide the changes"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Hide the sample"
 msgstr ""
 
@@ -5012,7 +5010,7 @@ msgstr "How it works:"
 msgid "How many recordings do you expect in your first year?"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:159
+#: src/routes/project/popcorn/PopcornRoute.tsx:157
 msgid "How should the phrases sound?"
 msgstr ""
 
@@ -5516,7 +5514,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:148
+#: src/routes/project/popcorn/PopcornRoute.tsx:146
 msgid "Keep it plain"
 msgstr ""
 
@@ -5532,7 +5530,7 @@ msgstr ""
 msgid "Keep pending"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:640
+#: src/routes/project/popcorn/PopcornRoute.tsx:638
 msgid "Keep reading new conversations"
 msgstr ""
 
@@ -5604,7 +5602,7 @@ msgstr "Latest"
 msgid "Latest report"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:153
+#: src/routes/project/popcorn/PopcornRoute.tsx:151
 msgid "Lean towards decisions"
 msgstr ""
 
@@ -5718,7 +5716,7 @@ msgstr ""
 msgid "Lifetime cap"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:461
+#: src/routes/project/popcorn/PopcornRoute.tsx:459
 #: src/components/report/ConversationStatusTable.tsx:65
 msgid "Link"
 msgstr "Link"
@@ -5748,8 +5746,8 @@ msgstr ""
 msgid "Listing documentation pages"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:110
-#: src/routes/project/popcorn/PopcornRoute.tsx:765
+#: src/routes/project/popcorn/PopcornRoute.tsx:108
+#: src/routes/project/popcorn/PopcornRoute.tsx:763
 #: src/routes/project/canvas/CanvasRoute.tsx:301
 #: src/components/conversation/monitorGrouping.ts:72
 #: src/components/conversation/LiveFunnelSection.tsx:265
@@ -5797,7 +5795,7 @@ msgstr ""
 msgid "live slides for the room"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:306
+#: src/routes/project/popcorn/PopcornRoute.tsx:304
 msgid "Live slides for the room, made from this project's conversations while they are still happening."
 msgstr ""
 
@@ -5814,7 +5812,7 @@ msgid "Live stream interrupted. Falling back to polling."
 msgstr ""
 
 #. placeholder {0}: format(expiry, "EEE d MMM, HH:mm")
-#: src/routes/project/popcorn/PopcornRoute.tsx:109
+#: src/routes/project/popcorn/PopcornRoute.tsx:107
 msgid "Live until {0}"
 msgstr ""
 
@@ -6859,7 +6857,7 @@ msgstr "Not Added"
 msgid "Not available"
 msgstr "Not available"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:261
+#: src/routes/project/popcorn/PopcornRoute.tsx:259
 #: src/routes/invite/AcceptInviteRoute.tsx:568
 #: src/components/pricing/PricingConfigurator.tsx:835
 #: src/components/chat/TagsUpdateSuggestionCard.tsx:216
@@ -6871,7 +6869,7 @@ msgstr ""
 msgid "Not on managed billing. Set to managed to invoice this account at the {tier} tier, with no automatic Mollie charges."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:100
+#: src/routes/project/popcorn/PopcornRoute.tsx:98
 msgid "Not reading new conversations · {read}"
 msgstr ""
 
@@ -6995,7 +6993,7 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:641
+#: src/routes/project/popcorn/PopcornRoute.tsx:639
 msgid "Off freezes the screen exactly as it is, for example while you talk it through. On picks up where it left off."
 msgstr ""
 
@@ -7124,7 +7122,7 @@ msgstr ""
 msgid "Only you can see this workspace."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:973
+#: src/routes/project/popcorn/PopcornRoute.tsx:967
 msgid "Only you see these controls: hover a tab to hide it, use the stage corner for the QR code, click a phrase to see where it came from."
 msgstr ""
 
@@ -7175,8 +7173,8 @@ msgstr ""
 msgid "Open host guide"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:492
-#: src/routes/project/popcorn/PopcornRoute.tsx:500
+#: src/routes/project/popcorn/PopcornRoute.tsx:490
+#: src/routes/project/popcorn/PopcornRoute.tsx:498
 msgid "Open in a new tab"
 msgstr ""
 
@@ -7535,7 +7533,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:521
+#: src/routes/project/popcorn/PopcornRoute.tsx:519
 msgid "Paste it into any page. It stays live."
 msgstr ""
 
@@ -7843,14 +7841,14 @@ msgstr "PNG, JPEG, or WebP. Will be cropped to a circle."
 msgid "Poor response"
 msgstr "Погана відповідь"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:242
-#: src/routes/project/popcorn/PopcornRoute.tsx:303
+#: src/routes/project/popcorn/PopcornRoute.tsx:240
+#: src/routes/project/popcorn/PopcornRoute.tsx:301
 #: src/routes/project/library/LibraryRoute.tsx:126
 #: src/features/sidebar/views/project/ProjectHomeView.tsx:113
 msgid "Popcorn"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:1040
+#: src/routes/project/popcorn/PopcornRoute.tsx:1033
 msgid "Popcorn could not be loaded. Try again in a moment."
 msgstr ""
 
@@ -7858,7 +7856,7 @@ msgstr ""
 #~ msgid "Popcorn is not available for this project. Turn on the living canvas in project settings first."
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:248
+#: src/routes/project/popcorn/PopcornRoute.tsx:246
 msgid "Popcorn shows a room its own words while it is still talking: live slides made from this project's conversations, for a big screen."
 msgstr ""
 
@@ -7944,7 +7942,7 @@ msgstr ""
 msgid "Preparing your experience"
 msgstr "Preparing your experience"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:914
+#: src/routes/project/popcorn/PopcornRoute.tsx:922
 msgid "Present"
 msgstr ""
 
@@ -8192,11 +8190,11 @@ msgstr ""
 msgid "Provide an overview of the main topics and recurring themes"
 msgstr "Provide an overview of the main topics and recurring themes"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:472
+#: src/routes/project/popcorn/PopcornRoute.tsx:470
 msgid "Public link"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:445
+#: src/routes/project/popcorn/PopcornRoute.tsx:443
 msgid "Public page"
 msgstr ""
 
@@ -8245,7 +8243,7 @@ msgstr ""
 msgid "Ran {0} steps at once"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:662
+#: src/routes/project/popcorn/PopcornRoute.tsx:660
 msgid "Rarely needed: new conversations are picked up on their own. Use it after changing the voice."
 msgstr ""
 
@@ -8282,7 +8280,7 @@ msgstr ""
 msgid "Read aloud"
 msgstr "Read aloud"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:659
+#: src/routes/project/popcorn/PopcornRoute.tsx:657
 msgid "Read everything again now"
 msgstr ""
 
@@ -8337,7 +8335,7 @@ msgstr ""
 msgid "Reading the conversations again"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:113
+#: src/routes/project/popcorn/PopcornRoute.tsx:111
 msgid "Reading the conversations now"
 msgstr ""
 
@@ -8349,7 +8347,7 @@ msgstr ""
 msgid "Reading the documentation"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:112
+#: src/routes/project/popcorn/PopcornRoute.tsx:110
 msgid "Reads new conversations every {every} minutes, last read {last}"
 msgstr ""
 
@@ -8683,12 +8681,12 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:757
+#: src/routes/project/popcorn/PopcornRoute.tsx:755
 #: src/components/feedback/AdminResponseFeedbackPanel.tsx:367
 msgid "Replay"
 msgstr "Запис"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:948
+#: src/routes/project/popcorn/PopcornRoute.tsx:941
 msgid "Replaying a saved run. The room's page and the public link keep showing the live session."
 msgstr ""
 
@@ -9093,11 +9091,11 @@ msgstr ""
 msgid "Sales invoice issued."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:344
+#: src/routes/project/popcorn/PopcornRoute.tsx:342
 msgid "Sample popcorn session"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:728
+#: src/routes/project/popcorn/PopcornRoute.tsx:726
 #: src/routes/project/canvas/CanvasRoute.tsx:255
 #: src/components/workspace/WorkspaceDataOwnershipSection.tsx:204
 #: src/components/training/TrainingRowActions.tsx:197
@@ -9164,7 +9162,7 @@ msgstr ""
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:201
+#: src/routes/project/popcorn/PopcornRoute.tsx:199
 msgid "Say it in your own words. Type, or press record and talk."
 msgstr ""
 
@@ -9389,7 +9387,7 @@ msgstr ""
 msgid "See upgrade options"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:321
+#: src/routes/project/popcorn/PopcornRoute.tsx:319
 msgid "See what the room will see, with a sample session, before your own day."
 msgstr ""
 
@@ -9623,7 +9621,7 @@ msgstr "Session Name"
 #~ msgid "Session settings"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:355
+#: src/routes/project/popcorn/PopcornRoute.tsx:353
 msgid "Session title"
 msgstr ""
 
@@ -9688,8 +9686,8 @@ msgstr ""
 
 #: src/routes/settings/UserSettingsRoute.tsx:62
 #: src/routes/project/ProjectsHome.tsx:245
-#: src/routes/project/popcorn/PopcornRoute.tsx:623
-#: src/routes/project/popcorn/PopcornRoute.tsx:923
+#: src/routes/project/popcorn/PopcornRoute.tsx:621
+#: src/routes/project/popcorn/PopcornRoute.tsx:931
 #: src/features/sidebar/views/workspace/WorkspaceSettingsView.tsx:28
 #: src/features/sidebar/views/workspace/WorkspaceHomeView.tsx:80
 #: src/features/sidebar/views/user/UserSettingsView.tsx:15
@@ -9721,7 +9719,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:439
+#: src/routes/project/popcorn/PopcornRoute.tsx:437
 msgid "Share"
 msgstr ""
 
@@ -9783,7 +9781,7 @@ msgstr "Shortest First"
 msgid "Show"
 msgstr "Show"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:697
+#: src/routes/project/popcorn/PopcornRoute.tsx:695
 msgid "Show \"made with dembrane\" on the screen"
 msgstr ""
 
@@ -9881,11 +9879,11 @@ msgstr ""
 msgid "Showing your most recent completed report."
 msgstr "Showing your most recent completed report."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:630
+#: src/routes/project/popcorn/PopcornRoute.tsx:628
 msgid "Shown at the top of the screen."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:356
+#: src/routes/project/popcorn/PopcornRoute.tsx:354
 msgid "Shown at the top of the screen. Change it any time."
 msgstr ""
 
@@ -9958,7 +9956,7 @@ msgstr ""
 msgid "Someone"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:200
+#: src/routes/project/popcorn/PopcornRoute.tsx:198
 msgid "Something else"
 msgstr ""
 
@@ -10129,7 +10127,7 @@ msgstr "Start New Conversation"
 msgid "Start over"
 msgstr "Start over"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:397
+#: src/routes/project/popcorn/PopcornRoute.tsx:395
 msgid "Start popcorn"
 msgstr ""
 
@@ -10154,12 +10152,12 @@ msgstr "Status"
 #~ msgid "Stay live"
 #~ msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:364
+#: src/routes/project/popcorn/PopcornRoute.tsx:362
 #: src/routes/project/canvas/CanvasRoute.tsx:208
 msgid "Stay live for"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:670
+#: src/routes/project/popcorn/PopcornRoute.tsx:668
 msgid "Stays live until"
 msgstr ""
 
@@ -10637,7 +10635,7 @@ msgstr ""
 msgid "The page this answer refers to."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:146
+#: src/routes/project/popcorn/PopcornRoute.tsx:144
 msgid "The plainest wording the room used. No metaphors or jokes the room did not come back to."
 msgstr ""
 
@@ -10662,11 +10660,11 @@ msgstr ""
 msgid "The report may start up to 5 minutes after the chosen time."
 msgstr "The report may start up to 5 minutes after the chosen time."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:169
+#: src/routes/project/popcorn/PopcornRoute.tsx:167
 msgid "The room's own words, the ideas that moved the conversation. Nothing added, nothing softened."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:141
+#: src/routes/project/popcorn/PopcornRoute.tsx:139
 msgid "The softer of two ways the room said a thing. Nothing that names or blames a person."
 msgstr ""
 
@@ -11160,7 +11158,7 @@ msgstr "Tip: Use the play button (▶) to send a test payload to your webhook an
 msgid "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 msgstr "Tip: You can also create a template from any chat message you send, or duplicate an existing template."
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:629
+#: src/routes/project/popcorn/PopcornRoute.tsx:627
 #: src/components/conversation/ConversationEdit.tsx:385
 msgid "Title"
 msgstr "Title"
@@ -11430,7 +11428,7 @@ msgstr "Try asking"
 msgid "Try it"
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:331
+#: src/routes/project/popcorn/PopcornRoute.tsx:329
 msgid "Try it with a sample"
 msgstr ""
 
@@ -11455,7 +11453,7 @@ msgstr "Turn off"
 msgid "Turn off anonymization?"
 msgstr "Turn off anonymization?"
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:273
+#: src/routes/project/popcorn/PopcornRoute.tsx:271
 msgid "Turn on popcorn"
 msgstr ""
 
@@ -12002,7 +12000,7 @@ msgstr ""
 msgid "Verifying your email address."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:738
+#: src/routes/project/popcorn/PopcornRoute.tsx:736
 #: src/routes/project/canvas/CanvasRoute.tsx:143
 msgid "Version"
 msgstr ""
@@ -12994,7 +12992,7 @@ msgstr ""
 msgid "Your plan is managed by dembrane. Contact your account manager to make changes."
 msgstr ""
 
-#: src/routes/project/popcorn/PopcornRoute.tsx:698
+#: src/routes/project/popcorn/PopcornRoute.tsx:696
 msgid "Your plan lets you take the mark off."
 msgstr ""
 

--- a/echo/frontend/src/routes/project/popcorn/PopcornRoute.tsx
+++ b/echo/frontend/src/routes/project/popcorn/PopcornRoute.tsx
@@ -26,8 +26,6 @@ import {
 import { useDisclosure, useDocumentTitle, useFullscreen } from "@mantine/hooks";
 import {
 	ArrowSquareOutIcon,
-	ArrowsInIcon,
-	ArrowsOutIcon,
 	CheckIcon,
 	CopyIcon,
 	PencilSimpleIcon,
@@ -35,7 +33,7 @@ import {
 	ShareNetworkIcon,
 } from "@phosphor-icons/react";
 import { addDays, addHours, format, formatDistanceToNow } from "date-fns";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router";
 import { PageContainer } from "@/components/layout/PageContainer";
 import {
@@ -817,7 +815,17 @@ function PopcornSession({
 		toggle: toggleFullscreen,
 		fullscreen,
 	} = useFullscreen();
+	const frameRef = useRef<HTMLIFrameElement | null>(null);
 	useDocumentTitle(`${popcorn.name} | dembrane`);
+
+	// Fullscreen is the wall. Tell the deck, so it drops the host affordances
+	// and shows exactly what the public page shows.
+	useEffect(() => {
+		frameRef.current?.contentWindow?.postMessage(
+			{ type: "dembrane:popcorn:presenting", value: fullscreen },
+			"*",
+		);
+	}, [fullscreen]);
 
 	const loopStatus = popcorn.loop?.status;
 	const isEnded = ["expired", "ended", "stopped"].includes(loopStatus ?? "");
@@ -922,21 +930,6 @@ function PopcornSession({
 					>
 						<Trans>Settings</Trans>
 					</Button>
-					<Tooltip label={fullscreen ? t`Exit full screen` : t`Full screen`}>
-						<ActionIcon
-							variant="outline"
-							size="lg"
-							onClick={toggleFullscreen}
-							aria-label={t`Full screen`}
-							{...testId("popcorn-fullscreen-button")}
-						>
-							{fullscreen ? (
-								<ArrowsInIcon size={18} />
-							) : (
-								<ArrowsOutIcon size={18} />
-							)}
-						</ActionIcon>
-					</Tooltip>
 				</Group>
 				<VersionStrip
 					versions={versionsQuery.data ?? []}
@@ -962,6 +955,7 @@ function PopcornSession({
 					}}
 				>
 					<iframe
+						ref={frameRef}
 						title={popcorn.name}
 						src={viewUrl}
 						className="block h-full w-full border-0"
@@ -998,7 +992,6 @@ function PopcornLoading() {
 					<Skeleton height={36} width={120} radius="xl" />
 					<Skeleton height={36} width={96} radius="md" />
 					<Skeleton height={36} width={110} radius="md" />
-					<Skeleton height={36} width={36} radius="md" />
 				</Group>
 				<Skeleton height={520} radius="md" />
 			</Stack>

--- a/echo/server/dembrane/popcorn/static/app.js
+++ b/echo/server/dembrane/popcorn/static/app.js
@@ -205,7 +205,7 @@
      the public page: the server leaves `source` out of the room's bundle. */
   function showSourceTip(item, tid, returnFocusTo) {
     const src = item.source;
-    if (!src || !src.text) return;
+    if (!src || !src.text || presenting) return;
     const href = httpUrl(src.url);
     clearTimeout(quoteHideTimer);
     tip.innerHTML = `<h2 class="sr-only" id="quote-dialog-title">Why this phrase</h2>
@@ -460,7 +460,20 @@
      a royal +; a visible optional tab grows a × on hover. The host page gets
      a message and saves the change; the deck follows on its next poll. */
   const HOST = EMBED && EMBED.mode === "host";
-  const hostMeta = () => (HOST && state.session && state.session.host) || null;
+  // While the host page is fullscreen the preview *is* the wall: no host
+  // affordances, no passages, exactly what the public page shows.
+  let presenting = false;
+  const hostMeta = () => (HOST && !presenting && state.session && state.session.host) || null;
+  if (HOST) {
+    window.addEventListener("message", (ev) => {
+      const d = ev.data;
+      if (!d || d.type !== "dembrane:popcorn:presenting") return;
+      presenting = !!d.value;
+      document.body.classList.toggle("presenting", presenting);
+      renderTabs();
+      renderQrPanel();
+    });
+  }
   function postHostSetting(patch) {
     if (!HOST || !window.parent || window.parent === window) return;
     window.parent.postMessage({ type: "dembrane:popcorn:settings", patch }, "*");

--- a/echo/server/dembrane/popcorn/static/styles.css
+++ b/echo/server/dembrane/popcorn/static/styles.css
@@ -94,13 +94,18 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 
 /* host controls in the tab row: quiet, royal, only on hover */
 .tab-wrap { position: relative; display: inline-flex; align-items: stretch; }
-/* Same box as the tab (padding and the 3px rule), so the × sits on the label's baseline. */
+/* Out of the flow, so the row measures exactly as the public deck; same
+   padding and 3px rule as the tab, so the × sits on the label's baseline. */
 .tab-hide {
+  position: absolute; left: 100%; top: 0; bottom: 0;
   appearance: none; background: none; border: none; border-bottom: 3px solid transparent;
   font: inherit; font-size: 0.85em; line-height: inherit;
-  color: var(--ink-soft); cursor: pointer; padding: 0.5em 0.35em 0.9em; margin-left: 0.05em;
+  color: var(--ink-soft); cursor: pointer; padding: 0.5em 0.35em 0.9em;
   opacity: 0; transition: opacity 120ms, color 120ms;
 }
+body.presenting .pop-sourced { cursor: default; }
+body.presenting .tail-sourced { cursor: default; }
+body.presenting .tail-sourced:hover { outline: none; }
 .tab-wrap:hover .tab-hide, .tab-hide:focus-visible { opacity: 1; }
 .tab-hide:hover { color: var(--blue); }
 .tab.tab-ghost { color: var(--ink-faint); font-weight: 300; cursor: pointer; }


### PR DESCRIPTION
Fullscreen from Present now hides the host-only controls in the deck, so the wall matches the public page. The hidden × no longer reserves width between tabs, and the separate fullscreen button is gone.