### PR TITLE
Popcorn heals a lost read within one cadence, and an empty stage says the read found nothing

### DIFF
--- a/echo/server/dembrane/popcorn/static/app.js
+++ b/echo/server/dembrane/popcorn/static/app.js
@@ -745,8 +745,13 @@
       // In dembrane the deck reads transcripts that already exist; it never
       // records. Say what is actually happening so a host does not think a
       // microphone is open.
+      const transcripts = (state.session?.transcripts || []).length;
+      const read = [...state.popcorn.values()].filter((p) => p.done).length;
+      // A finished read that found nothing must say so, or a host takes an
+      // empty stage for a broken one.
       const msg = !state.session ? "drop your session's JSON files anywhere on this page"
-        : EMBED && !(state.session.transcripts || []).length ? "waiting for the first conversation"
+        : EMBED && !transcripts ? "waiting for the first conversation"
+        : EMBED && read >= transcripts ? `read ${transcripts} conversation${transcripts === 1 ? "" : "s"}, nothing worth a popcorn yet`
         : EMBED ? "reading the conversations…"
         : "listening…";
       if (!waiting) stageEl.innerHTML = `<p class="popcorn-waiting"><span class="live-dot"></span>&nbsp; ${msg}</p>`;

--- a/echo/server/dembrane/popcorn/ticks.py
+++ b/echo/server/dembrane/popcorn/ticks.py
@@ -64,7 +64,7 @@ MAX_CHARS_PER_CONVERSATION = 150_000
 MAX_ANALYSIS_CHARS = 600_000
 RUN_LOCK_SECONDS = 5 * 60
 MANUAL_LOCK_WAIT_SECONDS = 180
-STALE_TICK_SECONDS = 180
+STALE_TICK_SECONDS = 90
 ANALYSIS_KINDS = ("tensions", "stakeholders")
 ANALYSIS_SHAPERS = {"tensions": shape_tensions, "stakeholders": shape_stakeholders}
 
@@ -500,6 +500,11 @@ async def run_popcorn_tick(loop_id: str, tick_kind: str = "scheduled") -> dict[s
         if not report_id or not project_id or not acting_user_id:
             raise RuntimeError("Popcorn loop is missing required ids")
 
+        # The next read is booked before this one starts, so a worker that dies
+        # mid-read (a pod scaled away, a crash) costs the room one cadence and
+        # never the chain. The booking is refreshed again when this read ends.
+        await _enqueue_next_if_due(loop)
+
         state = normalize_state(loop.get("popcorn_state"))
         config = await get_latest_config(report_id)
         settings = normalize_settings(
@@ -662,7 +667,7 @@ async def reconcile_missing_popcorn_tick_tasks() -> int:
         },
     )
     covered: set[str] = set()
-    for task in (existing or []):
+    for task in existing or []:
         if not isinstance(task, dict):
             continue
         loop_id = str((task.get("payload") or {}).get("loop_id") or "")
@@ -696,7 +701,9 @@ async def reconcile_missing_popcorn_tick_tasks() -> int:
                             },
                         )
                     except Exception as exc:
-                        logger.warning("Failed to mark stranded task %s as failed: %s", task_id, exc)
+                        logger.warning(
+                            "Failed to mark stranded task %s as failed: %s", task_id, exc
+                        )
 
     enqueued = 0
     for loop in popcorn_loops:

--- a/echo/server/dembrane/scheduler.py
+++ b/echo/server/dembrane/scheduler.py
@@ -74,7 +74,8 @@ scheduler.add_job(
 
 scheduler.add_job(
     func="dembrane.tasks:task_reconcile_popcorn_tick_tasks.send",
-    trigger=CronTrigger(minute="*/5"),
+    # Every minute, not five: a live room notices a missed 2-minute read.
+    trigger=CronTrigger(minute="*"),
     id="task_reconcile_popcorn_tick_tasks",
     name="Backfill scheduled_task rows for active popcorn loops (reconciler)",
     replace_existing=True,

--- a/echo/server/tests/test_popcorn_ticks.py
+++ b/echo/server/tests/test_popcorn_ticks.py
@@ -237,7 +237,8 @@ def test_first_tick_pops_every_transcript_then_analyses(fake: _FakeDirectus, mon
     runs = fake.created["agent_loop_run"]
     assert runs[-1]["status"] == "ok"
     assert "2 of 2 conversations re-read" in runs[-1]["detail"]
-    assert fake.enqueued == [("loop1", "scheduled")]  # type: ignore[attr-defined]
+    # Booked once when the read starts and again when it ends.
+    assert fake.enqueued == [("loop1", "scheduled"), ("loop1", "scheduled")]  # type: ignore[attr-defined]
 
 
 def test_second_tick_only_rereads_changed_conversations(fake: _FakeDirectus, monkeypatch) -> None:


### PR DESCRIPTION
A worker killed mid-read (Argo scaled one away on 5 Sep) left the loop with no next tick until the 5-minute reconciler noticed. The next read is now booked before a read starts, the reconciler runs every minute with a 90s threshold, and a finished read with zero phrases tells the room so instead of showing a blank stage.