### PR TITLE
MCP: derive the issuer from the API origin, not a base that already ends in /api

### DIFF
--- a/echo/server/dembrane/agent_access/oauth.py
+++ b/echo/server/dembrane/agent_access/oauth.py
@@ -47,8 +47,18 @@ MCP_PATH = "/api/mcp"
 CONSENT_PATH = "/settings/agents/authorize"
 
 
+def api_origin() -> str:
+    """The API host without a path. Deployments set API_BASE_URL with a
+    trailing /api (echo-next, production); local runs set the bare host.
+    MCP_PATH already carries /api, so strip one if present."""
+    base = get_settings().urls.api_base_url.rstrip("/")
+    if base.endswith("/api"):
+        base = base[: -len("/api")]
+    return base
+
+
 def issuer_url() -> str:
-    return get_settings().urls.api_base_url.rstrip("/") + MCP_PATH
+    return api_origin() + MCP_PATH
 
 
 def resource_url() -> str:

--- a/echo/server/tests/test_agent_access.py
+++ b/echo/server/tests/test_agent_access.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import time
 from typing import Any
 from datetime import datetime, timezone, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient, ASGITransport
@@ -511,3 +511,18 @@ async def test_consent_lists_guest_orgs_with_guest_role(fake: FakeStore) -> None
     ):
         memberships = await mod._my_org_memberships(_USER)
     assert memberships == [{"org_id": "org-g", "role": "guest"}]
+
+
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        ("http://localhost:8000", "http://localhost:8000/api/mcp"),
+        ("https://api.echo-next.dembrane.com/api", "https://api.echo-next.dembrane.com/api/mcp"),
+        ("https://api.dembrane.com/api/", "https://api.dembrane.com/api/mcp"),
+    ],
+)
+def test_issuer_url_never_doubles_the_api_prefix(base: str, expected: str) -> None:
+    settings = MagicMock()
+    settings.urls.api_base_url = base
+    with patch("dembrane.agent_access.oauth.get_settings", return_value=settings):
+        assert oauth.issuer_url() == expected


### PR DESCRIPTION
On echo-next the discovery document advertised /api/api/mcp because API_BASE_URL there ends in /api. The routes were right; only the advertised URLs were wrong. Regression test covers the three base shapes in use.