### PR TITLE
MCP: report_issue and request_tool through the shared writers, unknown tools audited

### DIFF
--- a/echo/directus/sync/snapshot/fields/agent_insight/source.json
+++ b/echo/directus/sync/snapshot/fields/agent_insight/source.json
@@ -1,0 +1,55 @@
+{
+  "collection": "agent_insight",
+  "field": "source",
+  "type": "string",
+  "meta": {
+    "collection": "agent_insight",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "source",
+    "group": null,
+    "hidden": false,
+    "interface": "select-dropdown",
+    "note": "assistant (in-app chat, host-reviewed) or agent_mcp (an external agent asking for a capability). Null on older rows.",
+    "options": {
+      "choices": [
+        {
+          "text": "Assistant",
+          "value": "assistant"
+        },
+        {
+          "text": "Agent MCP",
+          "value": "agent_mcp"
+        }
+      ]
+    },
+    "readonly": false,
+    "required": false,
+    "searchable": true,
+    "sort": 11,
+    "special": null,
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "source",
+    "table": "agent_insight",
+    "data_type": "character varying",
+    "default_value": null,
+    "max_length": 255,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/echo/directus/sync/snapshot/fields/support_request/source.json
+++ b/echo/directus/sync/snapshot/fields/support_request/source.json
@@ -1,0 +1,59 @@
+{
+  "collection": "support_request",
+  "field": "source",
+  "type": "string",
+  "meta": {
+    "collection": "support_request",
+    "conditions": null,
+    "display": null,
+    "display_options": null,
+    "field": "source",
+    "group": null,
+    "hidden": false,
+    "interface": "select-dropdown",
+    "note": "Where the request came from: dashboard (report issue), assistant (in-app chat), agent_mcp (an external agent over MCP). Null on rows older than this field.",
+    "options": {
+      "choices": [
+        {
+          "text": "Dashboard",
+          "value": "dashboard"
+        },
+        {
+          "text": "Assistant",
+          "value": "assistant"
+        },
+        {
+          "text": "Agent MCP",
+          "value": "agent_mcp"
+        }
+      ]
+    },
+    "readonly": false,
+    "required": false,
+    "searchable": true,
+    "sort": 31,
+    "special": null,
+    "translations": null,
+    "validation": null,
+    "validation_message": null,
+    "width": "half"
+  },
+  "schema": {
+    "name": "source",
+    "table": "support_request",
+    "data_type": "character varying",
+    "default_value": null,
+    "max_length": 255,
+    "numeric_precision": null,
+    "numeric_scale": null,
+    "is_nullable": true,
+    "is_unique": false,
+    "is_indexed": false,
+    "is_primary_key": false,
+    "is_generated": false,
+    "generation_expression": null,
+    "has_auto_increment": false,
+    "foreign_key_table": null,
+    "foreign_key_column": null
+  }
+}

--- a/echo/docs/agent_access.md
+++ b/echo/docs/agent_access.md
@@ -12,7 +12,9 @@ An AI agent connects to dembrane as one person and sees exactly what that person
 | `/api/v2/agent/*` | OAuth access token | Same tools as REST |
 | `/api/v2/agent-access/*` | cookie session | Consent step, grants, org switch, audit |
 
-Tools: `whoami`, `list_organisations`, `list_workspaces`, `list_projects`, `get_project`, `update_project` (write scope), `list_conversations`, `get_conversation`, `get_conversations` (max 50), `list_project_webhooks`.
+Tools: `whoami`, `list_organisations`, `list_workspaces`, `list_projects`, `get_project`, `update_project` (write scope), `list_conversations`, `get_conversation`, `get_conversations` (max 50), `list_project_webhooks`, `report_issue`, `request_tool`.
+
+`report_issue` and `request_tool` write `support_request` rows with `source = agent_mcp` (kind and agent details in `page_context`), so the existing forwarder carries them into the same triage thread as a host's report. A call to a tool that does not exist is recorded as an `unknown_tool` audit row with the requested name, and the error message points the agent at `request_tool`. Those three rows are the signal for which tools to add next.
 
 ## Flow
 

--- a/echo/docs/agent_access.md
+++ b/echo/docs/agent_access.md
@@ -14,7 +14,7 @@ An AI agent connects to dembrane as one person and sees exactly what that person
 
 Tools: `whoami`, `list_organisations`, `list_workspaces`, `list_projects`, `get_project`, `update_project` (write scope), `list_conversations`, `get_conversation`, `get_conversations` (max 50), `list_project_webhooks`, `report_issue`, `request_tool`.
 
-`report_issue` and `request_tool` write `support_request` rows with `source = agent_mcp` (kind and agent details in `page_context`), so the existing forwarder carries them into the same triage thread as a host's report. A call to a tool that does not exist is recorded as an `unknown_tool` audit row with the requested name, and the error message points the agent at `request_tool`. Those three rows are the signal for which tools to add next.
+`report_issue` files a `support_request` through `dembrane/support_requests.py`, the one writer the dashboard's report form and the assistant's `reachOutToDembraneSupport` also use, with `source = agent_mcp`; the forwarder carries it into the same triage thread as a host's report. `request_tool` files an `agent_insight` of kind `capability_gap` through `dembrane/agent_insights.py`, the channel the assistant's `noteInsight` already uses, with `source = agent_mcp` and the wanted tool name in `suggested_capability`. A call to a tool that does not exist is recorded as an `unknown_tool` audit row with the requested name, and the error message points the agent at `request_tool`. Those three rows are the signal for which tools to add next.
 
 ## Flow
 

--- a/echo/server/dembrane/agent_access/__init__.py
+++ b/echo/server/dembrane/agent_access/__init__.py
@@ -74,6 +74,8 @@ USER_SERVER = ServerDescriptor(
         "get_conversation",
         "get_conversations",
         "list_project_webhooks",
+        "report_issue",
+        "request_tool",
     ],
 )
 

--- a/echo/server/dembrane/agent_access/context.py
+++ b/echo/server/dembrane/agent_access/context.py
@@ -32,6 +32,7 @@ logger = getLogger("agent_access.context")
 class AgentContext:
     grant_id: str
     client_id: str
+    client_name: str
     app_user_id: str
     directus_user_id: str
     org_ids: list[str]
@@ -111,6 +112,7 @@ async def context_from_access_token(token: AgentAccessToken) -> AgentContext:
     return AgentContext(
         grant_id=grant["id"],
         client_id=str(grant.get("client_id")),
+        client_name=str(grant.get("client_name") or "agent"),
         app_user_id=str(grant["app_user_id"]),
         directus_user_id=str(grant["directus_user_id"]),
         org_ids=[str(o) for o in (grant.get("org_ids") or [])],

--- a/echo/server/dembrane/agent_access/mcp_server.py
+++ b/echo/server/dembrane/agent_access/mcp_server.py
@@ -49,13 +49,40 @@ logger = getLogger("agent_access.mcp")
 
 provider = AgentOAuthProvider()
 
-server = MCPServer(
+
+class DembraneMCPServer(MCPServer):
+    """Records the tools agents reach for and do not find. The SDK rejects an
+    unknown name before any tool code runs, so this is the only place to see
+    it; the audit row is the signal behind the tool roadmap."""
+
+    async def call_tool(self, name: str, arguments: dict[str, Any], context: Any = None) -> Any:
+        known = sorted(t.name for t in self._tool_manager.list_tools())
+        if name not in known:
+            try:
+                ctx = await _ctx()
+                await ctx.record(
+                    "unknown_tool",
+                    {"requested": name, "arguments": sorted(arguments or {})},
+                    org_id=None,
+                    status="denied",
+                )
+            except Exception:  # noqa: BLE001 — logging must not change the answer
+                logger.warning("unknown tool %s requested, audit skipped", name)
+            raise ToolError(
+                f"Unknown tool: {name}. Available: {', '.join(known)}. "
+                "If you needed something else, call request_tool with what you wanted to do."
+            )
+        return await super().call_tool(name, arguments, context)
+
+
+server = DembraneMCPServer(
     name="dembrane",
     instructions=(
         "You are connected to dembrane as one person, limited to the organisations "
         "they chose. Start with whoami, then list_organisations. Ids are UUIDs; pass "
         "them between tools verbatim. Transcripts can be long: list first, then fetch "
-        "the conversations you need, at most 50 at a time."
+        "the conversations you need, at most 50 at a time. If something looks wrong, "
+        "call report_issue; if a tool you need does not exist, call request_tool."
     ),
     auth_server_provider=provider,
     auth=auth_settings(),
@@ -244,6 +271,50 @@ async def get_conversations(conversation_ids: list[str]) -> list[dict[str, Any]]
             "get_conversations",
             {"conversation_ids": conversation_ids[: T.BATCH_MAX], "count": len(conversation_ids)},
             lambda c: T.get_conversations(c, conversation_ids),
+        )
+    )
+
+
+@server.tool(
+    name="report_issue",
+    description=(
+        "Report something wrong with dembrane to its team: a broken transcript, a tool "
+        "that errored, data that looks off. Name the project or conversation when you can."
+    ),
+)
+async def report_issue(
+    message: str, project_id: Optional[str] = None, conversation_id: Optional[str] = None
+) -> dict[str, Any]:
+    return _dump(
+        await _run(
+            "report_issue",
+            {
+                "project_id": project_id,
+                "conversation_id": conversation_id,
+                "chars": len(message or ""),
+            },
+            lambda c: T.report_issue(
+                c, message, project_id=project_id, conversation_id=conversation_id
+            ),
+        )
+    )
+
+
+@server.tool(
+    name="request_tool",
+    description=(
+        "Ask dembrane for a tool that does not exist yet. Say what you wanted to do, in your "
+        "own words, and give one example call you wish had worked."
+    ),
+)
+async def request_tool(
+    name: str, description: str, example: Optional[str] = None
+) -> dict[str, Any]:
+    return _dump(
+        await _run(
+            "request_tool",
+            {"name": name, "chars": len(description or "")},
+            lambda c: T.request_tool(c, name, description, example=example),
         )
     )
 

--- a/echo/server/dembrane/agent_access/tools.py
+++ b/echo/server/dembrane/agent_access/tools.py
@@ -10,6 +10,7 @@ names and text it needs, not raw Directus rows.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Literal, Optional
 
 from fastapi import HTTPException
@@ -98,6 +99,12 @@ class ConversationOut(ConversationSummaryOut):
     transcript_locked: bool = False
     chunk_count: int = 0
     tags: list[str] = []
+
+
+class TicketOut(BaseModel):
+    id: str
+    status: str
+    kind: Literal["issue", "tool_request"]
 
 
 class WebhookOut(BaseModel):
@@ -487,3 +494,104 @@ async def list_project_webhooks(ctx: AgentContext, project_id: str) -> list[Webh
         )
         for w in (rows if isinstance(rows, list) else [])
     ]
+
+
+# ── reporting back to dembrane ─────────────────────────────────────────────
+
+SUPPORT_SOURCE = "agent_mcp"
+MAX_TICKET_CHARS = 4000
+
+
+def _clip(text: str, limit: int = MAX_TICKET_CHARS) -> str:
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+async def _file_support_request(
+    ctx: AgentContext,
+    *,
+    kind: Literal["issue", "tool_request"],
+    message: str,
+    project_id: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> TicketOut:
+    """One support_request row, source agent_mcp. The existing forwarder
+    picks it up like any other row, so an agent's report lands in the same
+    triage thread as a host's. Never transcript content."""
+    page_context = {
+        "source": SUPPORT_SOURCE,
+        "kind": kind,
+        "client_name": ctx.client_name,
+        "client_id": ctx.client_id,
+        "grant_id": ctx.grant_id,
+        **(context or {}),
+    }
+    created = await async_directus.create_item(
+        "support_request",
+        {
+            "directus_user_id": ctx.directus_user_id,
+            "app_user_id": ctx.app_user_id,
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "message": message,
+            "page_context": json.dumps(page_context),
+            "status": "new",
+            "source": SUPPORT_SOURCE,
+        },
+    )
+    row = created.get("data") if isinstance(created, dict) and "data" in created else created
+    return TicketOut(id=str((row or {}).get("id") or ""), status="new", kind=kind)
+
+
+async def report_issue(
+    ctx: AgentContext,
+    message: str,
+    project_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+) -> TicketOut:
+    """An agent reports something wrong with dembrane: a bad transcript, a
+    tool that errored, data that looks off. Scoped to a project when the
+    agent can name one, so the team lands in the right place."""
+    if not (message or "").strip():
+        raise HTTPException(status_code=400, detail="message is required")
+    workspace_id: Optional[str] = None
+    org_id: Optional[str] = None
+    if conversation_id and not project_id:
+        access, _conv = await resolve_conversation_access(conversation_id, ctx.session)
+        project_id = access.project_id
+    if project_id:
+        access, org_id = await _project_access(ctx, project_id)
+        workspace_id = access.workspace_id
+    body = f"[{ctx.client_name} via MCP] {_clip(message)}"
+    if conversation_id:
+        body += f"\nConversation: {conversation_id}"
+    return await _file_support_request(
+        ctx,
+        kind="issue",
+        message=body,
+        project_id=project_id,
+        workspace_id=workspace_id,
+        context={"conversation_id": conversation_id, "org_id": org_id},
+    )
+
+
+async def request_tool(
+    ctx: AgentContext,
+    name: str,
+    description: str,
+    example: Optional[str] = None,
+) -> TicketOut:
+    """An agent asks for a tool that does not exist yet. The description is
+    what it wanted to do, in its own words; that is the signal we mine."""
+    if not (name or "").strip() or not (description or "").strip():
+        raise HTTPException(status_code=400, detail="name and description are required")
+    body = f"[{ctx.client_name} via MCP] Tool request: {_clip(name, 120)}\n{_clip(description)}"
+    if example:
+        body += f"\nExample: {_clip(example, 1000)}"
+    return await _file_support_request(
+        ctx,
+        kind="tool_request",
+        message=body,
+        context={"tool_name": name.strip()},
+    )

--- a/echo/server/dembrane/agent_access/tools.py
+++ b/echo/server/dembrane/agent_access/tools.py
@@ -10,7 +10,6 @@ names and text it needs, not raw Directus rows.
 
 from __future__ import annotations
 
-import json
 from typing import Any, Literal, Optional
 
 from fastapi import HTTPException
@@ -498,50 +497,12 @@ async def list_project_webhooks(ctx: AgentContext, project_id: str) -> list[Webh
 
 # ── reporting back to dembrane ─────────────────────────────────────────────
 
-SUPPORT_SOURCE = "agent_mcp"
 MAX_TICKET_CHARS = 4000
 
 
 def _clip(text: str, limit: int = MAX_TICKET_CHARS) -> str:
     text = (text or "").strip()
     return text if len(text) <= limit else text[: limit - 1] + "…"
-
-
-async def _file_support_request(
-    ctx: AgentContext,
-    *,
-    kind: Literal["issue", "tool_request"],
-    message: str,
-    project_id: Optional[str] = None,
-    workspace_id: Optional[str] = None,
-    context: Optional[dict[str, Any]] = None,
-) -> TicketOut:
-    """One support_request row, source agent_mcp. The existing forwarder
-    picks it up like any other row, so an agent's report lands in the same
-    triage thread as a host's. Never transcript content."""
-    page_context = {
-        "source": SUPPORT_SOURCE,
-        "kind": kind,
-        "client_name": ctx.client_name,
-        "client_id": ctx.client_id,
-        "grant_id": ctx.grant_id,
-        **(context or {}),
-    }
-    created = await async_directus.create_item(
-        "support_request",
-        {
-            "directus_user_id": ctx.directus_user_id,
-            "app_user_id": ctx.app_user_id,
-            "workspace_id": workspace_id,
-            "project_id": project_id,
-            "message": message,
-            "page_context": json.dumps(page_context),
-            "status": "new",
-            "source": SUPPORT_SOURCE,
-        },
-    )
-    row = created.get("data") if isinstance(created, dict) and "data" in created else created
-    return TicketOut(id=str((row or {}).get("id") or ""), status="new", kind=kind)
 
 
 async def report_issue(
@@ -551,8 +512,10 @@ async def report_issue(
     conversation_id: Optional[str] = None,
 ) -> TicketOut:
     """An agent reports something wrong with dembrane: a bad transcript, a
-    tool that errored, data that looks off. Scoped to a project when the
-    agent can name one, so the team lands in the right place."""
+    tool that errored, data that looks off. Same table and forwarder as a
+    host's report, source agent_mcp. Never transcript content."""
+    from dembrane.support_requests import SOURCE_AGENT_MCP, file_support_request
+
     if not (message or "").strip():
         raise HTTPException(status_code=400, detail="message is required")
     workspace_id: Optional[str] = None
@@ -566,14 +529,24 @@ async def report_issue(
     body = f"[{ctx.client_name} via MCP] {_clip(message)}"
     if conversation_id:
         body += f"\nConversation: {conversation_id}"
-    return await _file_support_request(
-        ctx,
-        kind="issue",
-        message=body,
-        project_id=project_id,
+    row = await file_support_request(
+        source=SOURCE_AGENT_MCP,
+        directus_user_id=ctx.directus_user_id,
+        app_user_id=ctx.app_user_id,
         workspace_id=workspace_id,
-        context={"conversation_id": conversation_id, "org_id": org_id},
+        project_id=project_id,
+        message=body,
+        page_context={
+            "source": SOURCE_AGENT_MCP,
+            "kind": "issue",
+            "client_name": ctx.client_name,
+            "client_id": ctx.client_id,
+            "grant_id": ctx.grant_id,
+            "conversation_id": conversation_id,
+            "org_id": org_id,
+        },
     )
+    return TicketOut(id=str(row.get("id") or ""), status="new", kind="issue")
 
 
 async def request_tool(
@@ -581,17 +554,28 @@ async def request_tool(
     name: str,
     description: str,
     example: Optional[str] = None,
+    project_id: Optional[str] = None,
 ) -> TicketOut:
-    """An agent asks for a tool that does not exist yet. The description is
-    what it wanted to do, in its own words; that is the signal we mine."""
+    """An agent asks for a tool that does not exist. Filed as a capability
+    gap in agent_insight, the same channel the in-app assistant uses for
+    what a host could not do, so one review surface covers both."""
+    from dembrane.agent_insights import SOURCE_AGENT_MCP, file_agent_insight
+
     if not (name or "").strip() or not (description or "").strip():
         raise HTTPException(status_code=400, detail="name and description are required")
-    body = f"[{ctx.client_name} via MCP] Tool request: {_clip(name, 120)}\n{_clip(description)}"
+    workspace_id: Optional[str] = None
+    if project_id:
+        access, _org = await _project_access(ctx, project_id)
+        workspace_id = access.workspace_id
+    content = f"[{ctx.client_name} via MCP] {_clip(description)}"
     if example:
-        body += f"\nExample: {_clip(example, 1000)}"
-    return await _file_support_request(
-        ctx,
-        kind="tool_request",
-        message=body,
-        context={"tool_name": name.strip()},
+        content += f"\nExample: {_clip(example, 1000)}"
+    row = await file_agent_insight(
+        source=SOURCE_AGENT_MCP,
+        kind="capability_gap",
+        content=content,
+        suggested_capability=name.strip()[:120],
+        workspace_id=workspace_id,
+        project_id=project_id,
     )
+    return TicketOut(id=str(row.get("id") or ""), status="new", kind="tool_request")

--- a/echo/server/dembrane/agent_insights.py
+++ b/echo/server/dembrane/agent_insights.py
@@ -1,0 +1,47 @@
+"""One writer for agent_insight rows: the product-learning channel.
+
+The in-app assistant drafts an insight for the host to review before it is
+sent; an agent over MCP files a capability gap directly, because it is the
+agent's own observation, not the host's. Both land in the same table with
+the same kinds, so one review surface serves both.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from dembrane.directus_async import async_directus
+from dembrane.support_requests import SOURCE_AGENT_MCP, SOURCE_ASSISTANT
+
+InsightKind = Literal["capability_gap", "friction", "wish", "praise"]
+
+__all__ = ["InsightKind", "SOURCE_AGENT_MCP", "SOURCE_ASSISTANT", "file_agent_insight"]
+
+
+async def file_agent_insight(
+    *,
+    source: str,
+    kind: InsightKind,
+    content: str,
+    suggested_capability: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+) -> dict[str, Any]:
+    created = await async_directus.create_item(
+        "agent_insight",
+        {
+            "source": source,
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "kind": kind,
+            "content": content.strip(),
+            "suggested_capability": (suggested_capability or "").strip() or None,
+            "status": "new",
+        },
+    )
+    row = created.get("data") if isinstance(created, dict) and "data" in created else created
+    return row if isinstance(row, dict) else {}

--- a/echo/server/dembrane/api/agentic.py
+++ b/echo/server/dembrane/api/agentic.py
@@ -22,6 +22,7 @@ from dembrane.agentic_focus import format_focus_block
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.methodologies import list_visible_methodologies
 from dembrane.project_goals import list_project_goal_revisions, get_current_project_goal_content
+from dembrane.agent_insights import file_agent_insight
 from dembrane.agentic_worker import (
     AGENT_CANCELLED_MESSAGE,
     AGENT_CANCELLED_ERROR_CODE,
@@ -50,6 +51,7 @@ from dembrane.agentic_runtime import (
     subscribe_live_events,
 )
 from dembrane.service.agentic import TERMINAL_RUN_STATUSES, AgenticRunNotFoundException
+from dembrane.support_requests import SOURCE_ASSISTANT, file_support_request
 from dembrane.api.feature_flags import require_canvas_enabled_for_project
 from dembrane.api.dependency_auth import DirectusSession, DependencyDirectusSession
 
@@ -1572,21 +1574,18 @@ async def create_support_request(
     project = await async_directus.get_item("project", project_id)
     workspace_id = project.get("workspace_id") if isinstance(project, dict) else None
 
-    created = await async_directus.create_item(
-        "support_request",
-        {
-            "workspace_id": workspace_id,
-            "project_id": project_id,
-            "directus_user_id": auth.user_id,
-            "chat_id": body.chat_id,
-            "app_user_id": body.app_user_id,
-            "message_id": body.message_id,
-            "message": body.message,
-            "page_context": body.page_context,
-            "status": "new",
-        },
+    created = await file_support_request(
+        source=SOURCE_ASSISTANT,
+        workspace_id=workspace_id,
+        project_id=project_id,
+        directus_user_id=auth.user_id,
+        chat_id=body.chat_id,
+        app_user_id=body.app_user_id,
+        message_id=body.message_id,
+        message=body.message,
+        page_context=body.page_context,
     )
-    support_request_id = created.get("id") if isinstance(created, dict) else None
+    support_request_id = created.get("id")
     return JSONResponse(
         status_code=201,
         content={"id": support_request_id, "status": "new"},
@@ -1609,21 +1608,17 @@ async def create_agent_insight(
 
     suggested_capability = _to_non_empty_string(body.suggested_capability)
     workspace_id = await _resolve_workspace_id_for_project(project_id)
-    created = await async_directus.create_item(
-        "agent_insight",
-        {
-            "workspace_id": workspace_id,
-            "project_id": project_id,
-            "chat_id": body.chat_id,
-            "message_id": body.message_id,
-            "kind": body.kind,
-            "content": content,
-            "suggested_capability": suggested_capability,
-            "status": "new",
-        },
+    created_row = await file_agent_insight(
+        source=SOURCE_ASSISTANT,
+        kind=body.kind,
+        content=content,
+        suggested_capability=suggested_capability,
+        workspace_id=workspace_id,
+        project_id=project_id,
+        chat_id=body.chat_id,
+        message_id=body.message_id,
     )
-    created_row = created.get("data") if isinstance(created, dict) else {}
-    insight_id = _to_non_empty_string((created_row or {}).get("id"))
+    insight_id = _to_non_empty_string(created_row.get("id"))
     return JSONResponse(
         status_code=201,
         content={"id": insight_id, "status": "new"},

--- a/echo/server/dembrane/api/v2/agent.py
+++ b/echo/server/dembrane/api/v2/agent.py
@@ -154,6 +154,44 @@ async def get_conversation(conversation_id: str, ctx: DependencyAgent) -> T.Conv
     )
 
 
+class IssueIn(BaseModel):
+    message: str = Field(..., min_length=1, max_length=8000)
+    project_id: Optional[str] = None
+    conversation_id: Optional[str] = None
+
+
+class ToolRequestIn(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str = Field(..., min_length=1, max_length=8000)
+    example: Optional[str] = Field(None, max_length=2000)
+
+
+@router.post("/issues", response_model=T.TicketOut)
+async def report_issue(body: IssueIn, ctx: DependencyAgent) -> T.TicketOut:
+    return await _run(
+        ctx,
+        "report_issue",
+        {
+            "project_id": body.project_id,
+            "conversation_id": body.conversation_id,
+            "chars": len(body.message),
+        },
+        lambda: T.report_issue(
+            ctx, body.message, project_id=body.project_id, conversation_id=body.conversation_id
+        ),
+    )
+
+
+@router.post("/tool-requests", response_model=T.TicketOut)
+async def request_tool(body: ToolRequestIn, ctx: DependencyAgent) -> T.TicketOut:
+    return await _run(
+        ctx,
+        "request_tool",
+        {"name": body.name, "chars": len(body.description)},
+        lambda: T.request_tool(ctx, body.name, body.description, example=body.example),
+    )
+
+
 class ConversationBatchIn(BaseModel):
     ids: list[str] = Field(..., max_length=T.BATCH_MAX)
 

--- a/echo/server/dembrane/api/v2/feedback.py
+++ b/echo/server/dembrane/api/v2/feedback.py
@@ -23,7 +23,7 @@ from dembrane.settings import get_settings
 from dembrane.inheritance import user_can_access
 from dembrane.async_helpers import run_in_thread_pool
 from dembrane.api.rate_limit import create_user_rate_limiter
-from dembrane.directus_async import async_directus
+from dembrane.support_requests import SOURCE_DASHBOARD, file_support_request
 from dembrane.api.v2.bff._access import resolve_project_access
 from dembrane.api.dependency_auth import DirectusSession, DependencyDirectusSession
 
@@ -237,26 +237,23 @@ async def create_feedback_report(
             )
 
         try:
-            created = await async_directus.create_item(
-                "support_request",
-                {
-                    "directus_user_id": auth.user_id,
-                    "workspace_id": workspace_id,
-                    "project_id": project_id,
-                    "message": build_report_message(
-                        reporter_name=reporter_name,
-                        reporter_email=reporter_email,
-                        message=message,
-                        session_replay_url=session_replay_url,
-                        attachment_links=attachment_links,
-                    ),
-                    "page_context": build_report_page_context(
-                        page_url=page_url,
-                        locale=locale,
-                        user_agent=user_agent,
-                    ),
-                    "status": "new",
-                },
+            created = await file_support_request(
+                source=SOURCE_DASHBOARD,
+                directus_user_id=auth.user_id,
+                workspace_id=workspace_id,
+                project_id=project_id,
+                message=build_report_message(
+                    reporter_name=reporter_name,
+                    reporter_email=reporter_email,
+                    message=message,
+                    session_replay_url=session_replay_url,
+                    attachment_links=attachment_links,
+                ),
+                page_context=build_report_page_context(
+                    page_url=page_url,
+                    locale=locale,
+                    user_agent=user_agent,
+                ),
             )
         except Exception as exc:
             logger.error(
@@ -272,7 +269,7 @@ async def create_feedback_report(
                 logger.warning("Could not clean up %s", key)
         raise
 
-    created_row = created.get("data") if isinstance(created, dict) else {}
+    created_row = created
     support_request_id = (created_row or {}).get("id")
     logger.info(
         "Feedback report %s stored as support_request %s (%d attachments)",

--- a/echo/server/dembrane/support_requests.py
+++ b/echo/server/dembrane/support_requests.py
@@ -1,0 +1,53 @@
+"""One writer for support_request rows, whoever files them.
+
+Three callers, one shape: the dashboard's report form, the in-app assistant's
+reachOutToDembraneSupport, and an agent connected over MCP. `source` says
+which; the forwarder carries every row to the team the same way.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from dembrane.directus_async import async_directus
+
+SOURCE_DASHBOARD = "dashboard"
+SOURCE_ASSISTANT = "assistant"
+SOURCE_AGENT_MCP = "agent_mcp"
+
+
+async def file_support_request(
+    *,
+    source: str,
+    message: str,
+    directus_user_id: Optional[str] = None,
+    app_user_id: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    message_id: Optional[str] = None,
+    page_context: str | dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create one row with status new. Returns the created row. Never put
+    transcript content in `message` or `page_context`: the forwarder sends
+    both to Slack."""
+    if isinstance(page_context, dict):
+        page_context = json.dumps(page_context)
+    created = await async_directus.create_item(
+        "support_request",
+        {
+            "source": source,
+            "directus_user_id": directus_user_id,
+            "app_user_id": app_user_id,
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "message": message,
+            "page_context": page_context,
+            "status": "new",
+        },
+    )
+    row = created.get("data") if isinstance(created, dict) and "data" in created else created
+    return row if isinstance(row, dict) else {}

--- a/echo/server/dembrane/tasks.py
+++ b/echo/server/dembrane/tasks.py
@@ -2283,6 +2283,7 @@ def build_support_request_forward_payload(
     }
     for key in (
         "page_context",
+        "source",
         "created_at",
         "chat_id",
         "project_id",
@@ -2343,6 +2344,7 @@ def task_forward_support_requests() -> None:
                         "id",
                         "message",
                         "page_context",
+                        "source",
                         "created_at",
                         "chat_id",
                         "project_id",

--- a/echo/server/tests/api/test_agentic_api.py
+++ b/echo/server/tests/api/test_agentic_api.py
@@ -2187,6 +2187,9 @@ async def test_agentic_insight_endpoint_persists_reach_back_context(monkeypatch)
 
     fake_directus = _AsyncDirectus()
     monkeypatch.setattr(agentic_api, "async_directus", fake_directus)
+    from dembrane import agent_insights as agent_insights_module
+
+    monkeypatch.setattr(agent_insights_module, "async_directus", fake_directus)
 
     async with _build_api_client(
         monkeypatch=monkeypatch,
@@ -2211,6 +2214,7 @@ async def test_agentic_insight_endpoint_persists_reach_back_context(monkeypatch)
         (
             "agent_insight",
             {
+                "source": "assistant",
                 "workspace_id": "workspace-1",
                 "project_id": "project-1",
                 "chat_id": "chat-1",

--- a/echo/server/tests/test_agent_access.py
+++ b/echo/server/tests/test_agent_access.py
@@ -535,30 +535,32 @@ def test_issuer_url_never_doubles_the_api_prefix(base: str, expected: str) -> No
 
 @pytest.mark.asyncio
 async def test_report_issue_files_a_support_request_with_agent_source(fake: FakeStore) -> None:
+    from dembrane import support_requests
     from dembrane.agent_access import tools as T
-
-    created: list[dict[str, Any]] = []
-
-    async def _create(collection: str, data: dict[str, Any]) -> dict[str, Any]:
-        created.append({"collection": collection, **data})
-        return {"data": {"id": "sr-1", **data}}
 
     access = MagicMock(workspace_id="ws-1", project_id="p1")
     with (
-        patch("dembrane.agent_access.tools.async_directus") as directus,
+        patch.object(
+            support_requests.async_directus,
+            "create_item",
+            new=AsyncMock(return_value={"data": {"id": "sr-1"}}),
+        ) as create,
         patch(
             "dembrane.agent_access.tools._project_access",
             new=AsyncMock(return_value=(access, _ORG)),
         ),
     ):
-        directus.create_item = AsyncMock(side_effect=_create)
         out = await T.report_issue(
             _ctx(), "Transcript of table 3 is empty", project_id="p1", conversation_id="c9"
         )
     assert out.id == "sr-1" and out.kind == "issue"
-    row = created[0]
-    assert row["collection"] == "support_request" and row["source"] == "agent_mcp"
-    assert row["project_id"] == "p1" and row["workspace_id"] == "ws-1" and row["status"] == "new"
+    collection, row = create.call_args.args
+    assert (
+        collection == "support_request" and row["source"] == "agent_mcp" and row["status"] == "new"
+    )
+    assert (
+        row["project_id"] == "p1" and row["workspace_id"] == "ws-1" and row["app_user_id"] == _USER
+    )
     assert row["message"].startswith("[Test agent via MCP] Transcript of table 3 is empty")
     ctx_json = json.loads(row["page_context"])
     assert (
@@ -569,21 +571,69 @@ async def test_report_issue_files_a_support_request_with_agent_source(fake: Fake
 
 
 @pytest.mark.asyncio
-async def test_request_tool_files_a_tool_request(fake: FakeStore) -> None:
+async def test_request_tool_files_a_capability_gap_insight(fake: FakeStore) -> None:
+    from dembrane import agent_insights
     from dembrane.agent_access import tools as T
 
-    with patch("dembrane.agent_access.tools.async_directus") as directus:
-        directus.create_item = AsyncMock(return_value={"data": {"id": "sr-2"}})
+    with patch.object(
+        agent_insights.async_directus,
+        "create_item",
+        new=AsyncMock(return_value={"data": {"id": "in-2"}}),
+    ) as create:
         out = await T.request_tool(
             _ctx(),
             "search_transcripts",
             "Find what a participant said about a topic",
             example="search_transcripts(project_id, 'Popcorn')",
         )
-        row = directus.create_item.call_args.args[1]
-    assert out.kind == "tool_request" and row["source"] == "agent_mcp" and row["project_id"] is None
-    assert "Tool request: search_transcripts" in row["message"] and "Example:" in row["message"]
-    assert json.loads(row["page_context"])["tool_name"] == "search_transcripts"
+    assert out.kind == "tool_request" and out.id == "in-2"
+    collection, row = create.call_args.args
+    assert (
+        collection == "agent_insight"
+        and row["source"] == "agent_mcp"
+        and row["kind"] == "capability_gap"
+    )
+    assert row["suggested_capability"] == "search_transcripts" and row["project_id"] is None
+    assert (
+        row["content"].startswith("[Test agent via MCP] Find what") and "Example:" in row["content"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_writers_stamp_the_source() -> None:
+    from dembrane import agent_insights, support_requests
+
+    with patch.object(
+        support_requests.async_directus,
+        "create_item",
+        new=AsyncMock(return_value={"data": {"id": "a"}}),
+    ) as c1:
+        await support_requests.file_support_request(
+            source=support_requests.SOURCE_DASHBOARD, message="m", page_context={"k": 1}
+        )
+    row = c1.call_args.args[1]
+    assert (
+        row["source"] == "dashboard"
+        and json.loads(row["page_context"]) == {"k": 1}
+        and row["status"] == "new"
+    )
+    with patch.object(
+        agent_insights.async_directus,
+        "create_item",
+        new=AsyncMock(return_value={"data": {"id": "b"}}),
+    ) as c2:
+        await agent_insights.file_agent_insight(
+            source=agent_insights.SOURCE_ASSISTANT,
+            kind="wish",
+            content="  x  ",
+            suggested_capability=" ",
+        )
+    row = c2.call_args.args[1]
+    assert (
+        row["source"] == "assistant"
+        and row["content"] == "x"
+        and row["suggested_capability"] is None
+    )
 
 
 @pytest.mark.asyncio

--- a/echo/server/tests/test_agent_access.py
+++ b/echo/server/tests/test_agent_access.py
@@ -4,6 +4,7 @@ the end-to-end flow against a real stack lives outside the unit suite."""
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any
 from datetime import datetime, timezone, timedelta
@@ -297,6 +298,7 @@ def _ctx(scopes: list[str] | None = None, org_ids: list[str] | None = None) -> A
     return AgentContext(
         grant_id="grant-1",
         client_id="client-1",
+        client_name="Test agent",
         app_user_id=_USER,
         directus_user_id=_DIRECTUS_USER,
         org_ids=org_ids if org_ids is not None else [_ORG],
@@ -526,3 +528,95 @@ def test_issuer_url_never_doubles_the_api_prefix(base: str, expected: str) -> No
     settings.urls.api_base_url = base
     with patch("dembrane.agent_access.oauth.get_settings", return_value=settings):
         assert oauth.issuer_url() == expected
+
+
+# ── reporting back ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_report_issue_files_a_support_request_with_agent_source(fake: FakeStore) -> None:
+    from dembrane.agent_access import tools as T
+
+    created: list[dict[str, Any]] = []
+
+    async def _create(collection: str, data: dict[str, Any]) -> dict[str, Any]:
+        created.append({"collection": collection, **data})
+        return {"data": {"id": "sr-1", **data}}
+
+    access = MagicMock(workspace_id="ws-1", project_id="p1")
+    with (
+        patch("dembrane.agent_access.tools.async_directus") as directus,
+        patch(
+            "dembrane.agent_access.tools._project_access",
+            new=AsyncMock(return_value=(access, _ORG)),
+        ),
+    ):
+        directus.create_item = AsyncMock(side_effect=_create)
+        out = await T.report_issue(
+            _ctx(), "Transcript of table 3 is empty", project_id="p1", conversation_id="c9"
+        )
+    assert out.id == "sr-1" and out.kind == "issue"
+    row = created[0]
+    assert row["collection"] == "support_request" and row["source"] == "agent_mcp"
+    assert row["project_id"] == "p1" and row["workspace_id"] == "ws-1" and row["status"] == "new"
+    assert row["message"].startswith("[Test agent via MCP] Transcript of table 3 is empty")
+    ctx_json = json.loads(row["page_context"])
+    assert (
+        ctx_json["kind"] == "issue"
+        and ctx_json["conversation_id"] == "c9"
+        and ctx_json["grant_id"] == "grant-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_tool_files_a_tool_request(fake: FakeStore) -> None:
+    from dembrane.agent_access import tools as T
+
+    with patch("dembrane.agent_access.tools.async_directus") as directus:
+        directus.create_item = AsyncMock(return_value={"data": {"id": "sr-2"}})
+        out = await T.request_tool(
+            _ctx(),
+            "search_transcripts",
+            "Find what a participant said about a topic",
+            example="search_transcripts(project_id, 'Popcorn')",
+        )
+        row = directus.create_item.call_args.args[1]
+    assert out.kind == "tool_request" and row["source"] == "agent_mcp" and row["project_id"] is None
+    assert "Tool request: search_transcripts" in row["message"] and "Example:" in row["message"]
+    assert json.loads(row["page_context"])["tool_name"] == "search_transcripts"
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_is_audited_and_answered_with_a_hint(fake: FakeStore) -> None:
+    from mcp.server.mcpserver.exceptions import ToolError
+    from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+    from mcp.server.auth.middleware.auth_context import auth_context_var
+
+    from dembrane.agent_access.oauth import AgentAccessToken
+    from dembrane.agent_access.mcp_server import server
+
+    fake.grants["grant-1"] = {
+        "id": "grant-1",
+        "client_id": "client-1",
+        "client_name": "Test agent",
+        "app_user_id": _USER,
+        "directus_user_id": _DIRECTUS_USER,
+        "org_ids": [_ORG],
+        "scopes": [SCOPE_READ],
+        "revoked_at": None,
+        "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+    }
+    token = AgentAccessToken(
+        token="t", client_id="client-1", scopes=[SCOPE_READ], grant_id="grant-1", pair_id="pair"
+    )
+    reset = auth_context_var.set(AuthenticatedUser(token))
+    try:
+        with pytest.raises(ToolError) as exc:
+            await server.call_tool("grep", {"query": "Popcorn"})
+    finally:
+        auth_context_var.reset(reset)
+    assert "request_tool" in str(exc.value) and "Unknown tool: grep" in str(exc.value)
+    assert fake.audit[-1]["tool"] == "unknown_tool" and fake.audit[-1]["params"] == {
+        "requested": "grep",
+        "arguments": ["query"],
+    }

--- a/echo/server/tests/test_feedback_reports.py
+++ b/echo/server/tests/test_feedback_reports.py
@@ -105,7 +105,7 @@ async def test_happy_path_writes_support_request_and_stores_s3():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like") as save_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png()])
@@ -143,7 +143,7 @@ async def test_verified_scope_ids_are_persisted():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
         _scope_patch(),
     ):
         async with _client(_build_app()) as c:
@@ -167,7 +167,7 @@ async def test_unverified_scope_ids_are_dropped():
                 "dembrane.api.v2.feedback.get_directus_user_profile",
                 new=AsyncMock(return_value=_PROFILE),
             ),
-            patch("dembrane.api.v2.feedback.async_directus", new=directus),
+            patch("dembrane.support_requests.async_directus", new=directus),
             scope,
         ):
             async with _client(_build_app()) as c:
@@ -191,7 +191,7 @@ async def test_no_attachments_omits_attachment_block():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form())
@@ -209,7 +209,7 @@ async def test_untrusted_replay_url_is_dropped():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -229,7 +229,7 @@ async def test_non_http_page_url_is_dropped():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -251,7 +251,7 @@ async def test_rejects_wrong_mime():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -272,7 +272,7 @@ async def test_rejects_too_many_files():
             "dembrane.api.v2.feedback.get_directus_user_profile",
             new=AsyncMock(return_value=_PROFILE),
         ),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -288,7 +288,7 @@ async def test_rejects_empty_message():
     with (
         patch("dembrane.api.v2.feedback.get_settings", return_value=settings),
         patch("dembrane.api.v2.feedback._RATE_LIMITER", new=AsyncMock()),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(message="  "))
@@ -300,7 +300,7 @@ async def test_rejects_oversize_message():
     with (
         patch("dembrane.api.v2.feedback.get_settings", return_value=settings),
         patch("dembrane.api.v2.feedback._RATE_LIMITER", new=AsyncMock()),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(message="x" * 5001))
@@ -319,7 +319,7 @@ async def test_directus_failure_cleans_up_s3_and_returns_502():
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like"),
         patch("dembrane.api.v2.feedback.delete_from_s3") as delete_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png()])
@@ -337,7 +337,7 @@ async def test_filename_with_spaces_is_allow_listed():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like") as save_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -364,7 +364,7 @@ async def test_dot_runs_are_collapsed_not_rejected():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like") as save_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png("a..b.png")])
@@ -400,7 +400,7 @@ async def test_attachment_link_has_one_api_segment_either_way():
                 new=AsyncMock(return_value=_PROFILE),
             ),
             patch("dembrane.api.v2.feedback.save_to_s3_from_file_like"),
-            patch("dembrane.api.v2.feedback.async_directus", new=directus),
+            patch("dembrane.support_requests.async_directus", new=directus),
         ):
             async with _client(_build_app()) as c:
                 resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png()])
@@ -423,7 +423,7 @@ async def test_upload_carries_the_validated_content_type():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like") as save_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png()])
@@ -442,7 +442,7 @@ async def test_oversize_attachment_is_rejected_before_any_upload():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like") as save_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post("/v2/feedback/reports", data=_form(), files=[_png(size=oversize)])
@@ -464,7 +464,7 @@ async def test_rate_limit_is_not_spent_on_an_invalid_request():
             new=AsyncMock(return_value=_PROFILE),
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like"),
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             bad = await c.post(
@@ -495,7 +495,7 @@ async def test_unsanitizable_filename_returns_400_and_cleans_up():
         ),
         patch("dembrane.api.v2.feedback.save_to_s3_from_file_like"),
         patch("dembrane.api.v2.feedback.delete_from_s3") as delete_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             resp = await c.post(
@@ -522,7 +522,7 @@ async def test_unexpected_upload_error_cleans_up_earlier_object():
             side_effect=[None, RuntimeError("s3 down")],
         ),
         patch("dembrane.api.v2.feedback.delete_from_s3") as delete_mock,
-        patch("dembrane.api.v2.feedback.async_directus", new=directus),
+        patch("dembrane.support_requests.async_directus", new=directus),
     ):
         async with _client(_build_app()) as c:
             with pytest.raises(RuntimeError):


### PR DESCRIPTION
Agents can report a problem or ask for a tool they miss. report_issue goes through the one support_request writer the dashboard form and the assistant now also use, with source agent_mcp, so it reaches the same triage thread; request_tool files a capability gap in agent_insight, the channel the assistant's noteInsight already uses. Calls to tools that do not exist are audited with the requested name. Two new Directus fields, source on support_request and agent_insight, are in the snapshot.