### PR TITLE
MCP: the documentation as tools, read from the published site

### DIFF
--- a/echo/docs/agent_access.md
+++ b/echo/docs/agent_access.md
@@ -12,7 +12,9 @@ An AI agent connects to dembrane as one person and sees exactly what that person
 | `/api/v2/agent/*` | OAuth access token | Same tools as REST |
 | `/api/v2/agent-access/*` | cookie session | Consent step, grants, org switch, audit |
 
-Tools: `whoami`, `list_organisations`, `list_workspaces`, `list_projects`, `get_project`, `update_project` (write scope), `list_conversations`, `get_conversation`, `get_conversations` (max 50), `list_project_webhooks`, `report_issue`, `request_tool`.
+Tools: `whoami`, `list_organisations`, `list_workspaces`, `list_projects`, `get_project`, `update_project` (write scope), `list_conversations`, `get_conversation`, `get_conversations` (max 50), `list_project_webhooks`, `report_issue`, `request_tool`, `list_docs`, `read_doc`, `search_docs`.
+
+The three docs tools read the product documentation through `dembrane/knowledge.py`: the published site (docs.dembrane.com, one markdown twin per page) in deployed environments, the repository's `docs/` folder locally, cached for an hour. Same list, line-numbered read and regex grep the in-app assistant has; public content, so no organisation and no budget charge.
 
 `report_issue` files a `support_request` through `dembrane/support_requests.py`, the one writer the dashboard's report form and the assistant's `reachOutToDembraneSupport` also use, with `source = agent_mcp`; the forwarder carries it into the same triage thread as a host's report. `request_tool` files an `agent_insight` of kind `capability_gap` through `dembrane/agent_insights.py`, the channel the assistant's `noteInsight` already uses, with `source = agent_mcp` and the wanted tool name in `suggested_capability`. A call to a tool that does not exist is recorded as an `unknown_tool` audit row with the requested name, and the error message points the agent at `request_tool`. Those three rows are the signal for which tools to add next.
 

--- a/echo/server/dembrane/agent_access/__init__.py
+++ b/echo/server/dembrane/agent_access/__init__.py
@@ -76,6 +76,9 @@ USER_SERVER = ServerDescriptor(
         "list_project_webhooks",
         "report_issue",
         "request_tool",
+        "list_docs",
+        "read_doc",
+        "search_docs",
     ],
 )
 

--- a/echo/server/dembrane/agent_access/mcp_server.py
+++ b/echo/server/dembrane/agent_access/mcp_server.py
@@ -82,7 +82,8 @@ server = DembraneMCPServer(
         "they chose. Start with whoami, then list_organisations. Ids are UUIDs; pass "
         "them between tools verbatim. Transcripts can be long: list first, then fetch "
         "the conversations you need, at most 50 at a time. If something looks wrong, "
-        "call report_issue; if a tool you need does not exist, call request_tool."
+        "call report_issue; if a tool you need does not exist, call request_tool. "
+        "Questions about how dembrane works: search_docs, then read_doc."
     ),
     auth_server_provider=provider,
     auth=auth_settings(),
@@ -315,6 +316,42 @@ async def request_tool(
             "request_tool",
             {"name": name, "chars": len(description or "")},
             lambda c: T.request_tool(c, name, description, example=example),
+        )
+    )
+
+
+@server.tool(
+    name="list_docs",
+    description="The dembrane user documentation: every page with its path and title. Public content.",
+)
+async def list_docs() -> list[dict[str, Any]]:
+    return _dump(await _run("list_docs", {}, T.list_docs))
+
+
+@server.tool(
+    name="read_doc",
+    description="Read one documentation page by path, line-numbered. Use offset to continue a long page.",
+)
+async def read_doc(path: str, offset: int = 1, limit: int = 400) -> dict[str, Any]:
+    return _dump(
+        await _run(
+            "read_doc",
+            {"path": path, "offset": offset, "limit": limit},
+            lambda c: T.read_doc(c, path, offset=offset, limit=limit),
+        )
+    )
+
+
+@server.tool(
+    name="search_docs",
+    description="Grep the documentation: a regular expression, case-insensitive, matching lines with their page and line number.",
+)
+async def search_docs(pattern: str, max_results: int = 50) -> list[dict[str, Any]]:
+    return _dump(
+        await _run(
+            "search_docs",
+            {"pattern": pattern[:200], "max_results": max_results},
+            lambda c: T.search_docs(c, pattern, max_results=max_results),
         )
     )
 

--- a/echo/server/dembrane/agent_access/tools.py
+++ b/echo/server/dembrane/agent_access/tools.py
@@ -579,3 +579,42 @@ async def request_tool(
         project_id=project_id,
     )
     return TicketOut(id=str(row.get("id") or ""), status="new", kind="tool_request")
+
+
+# ── documentation ──────────────────────────────────────────────────────────
+
+
+class DocOut(BaseModel):
+    path: str
+    title: str
+
+
+class DocReadOut(BaseModel):
+    path: str
+    text: str
+
+
+class DocHitOut(BaseModel):
+    path: str
+    line: int
+    text: str
+
+
+async def list_docs(ctx: AgentContext) -> list[DocOut]:  # noqa: ARG001 — same signature as every tool
+    from dembrane import knowledge
+
+    return [DocOut(**d) for d in await knowledge.list_docs()]
+
+
+async def read_doc(ctx: AgentContext, path: str, offset: int = 1, limit: int = 400) -> DocReadOut:  # noqa: ARG001
+    from dembrane import knowledge
+
+    return DocReadOut(path=path, text=await knowledge.read_doc(path, offset=offset, limit=limit))
+
+
+async def search_docs(ctx: AgentContext, pattern: str, max_results: int = 50) -> list[DocHitOut]:  # noqa: ARG001
+    from dembrane import knowledge
+
+    if not (pattern or "").strip():
+        raise HTTPException(status_code=400, detail="pattern is required")
+    return [DocHitOut(**h) for h in await knowledge.grep_docs(pattern, max_results=max_results)]

--- a/echo/server/dembrane/api/v2/agent.py
+++ b/echo/server/dembrane/api/v2/agent.py
@@ -154,6 +154,40 @@ async def get_conversation(conversation_id: str, ctx: DependencyAgent) -> T.Conv
     )
 
 
+@router.get("/docs", response_model=list[T.DocOut])
+async def list_docs(ctx: DependencyAgent) -> list[T.DocOut]:
+    return await _run(ctx, "list_docs", {}, lambda: T.list_docs(ctx))
+
+
+@router.get("/docs/read", response_model=T.DocReadOut)
+async def read_doc(
+    ctx: DependencyAgent,
+    path: str = Query(...),
+    offset: int = Query(1, ge=1),
+    limit: int = Query(400, ge=1, le=400),
+) -> T.DocReadOut:
+    return await _run(
+        ctx,
+        "read_doc",
+        {"path": path, "offset": offset, "limit": limit},
+        lambda: T.read_doc(ctx, path, offset=offset, limit=limit),
+    )
+
+
+@router.get("/docs/search", response_model=list[T.DocHitOut])
+async def search_docs(
+    ctx: DependencyAgent,
+    pattern: str = Query(..., min_length=1),
+    max_results: int = Query(50, ge=1, le=50),
+) -> list[T.DocHitOut]:
+    return await _run(
+        ctx,
+        "search_docs",
+        {"pattern": pattern[:200], "max_results": max_results},
+        lambda: T.search_docs(ctx, pattern, max_results=max_results),
+    )
+
+
 class IssueIn(BaseModel):
     message: str = Field(..., min_length=1, max_length=8000)
     project_id: Optional[str] = None

--- a/echo/server/dembrane/knowledge.py
+++ b/echo/server/dembrane/knowledge.py
@@ -1,0 +1,153 @@
+"""The product documentation as a small read-only file system.
+
+Same corpus, same three verbs the in-app assistant has (list, line-numbered
+read, regex grep), served from the server so an agent over MCP reads what a
+host reads. Deployed environments fetch the published site (docs.dembrane.com
+lists every page in llms.txt and serves a markdown twin per page); local
+runs read the repository's docs folder. The corpus is cached for an hour.
+"""
+
+from __future__ import annotations
+
+import re
+import json
+import time
+import asyncio
+import hashlib
+from typing import Any, Optional
+from logging import getLogger
+from pathlib import Path
+
+import httpx
+
+from dembrane.redis_async import get_redis_client
+from dembrane.agentic_client import docs_base_url_for_env
+
+logger = getLogger("dembrane.knowledge")
+
+MAX_READ_LINES = 400
+MAX_GREP_RESULTS = 50
+CORPUS_TTL_SECONDS = 3600
+_FETCH_CONCURRENCY = 8
+
+_memo: dict[str, tuple[float, dict[str, str]]] = {}
+_lock = asyncio.Lock()
+
+
+def _repo_docs_dir() -> Optional[Path]:
+    # server/dembrane/knowledge.py → repo root is three levels up; docs/ lives there.
+    candidate = Path(__file__).resolve().parents[3] / "docs"
+    return candidate if candidate.is_dir() else None
+
+
+def _disk_corpus(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for p in sorted(root.rglob("*.md")):
+        rel = p.relative_to(root).as_posix()
+        # Published set only: no authoring notes, no translation twins.
+        if rel.startswith("_authoring/") or re.search(r"\.[a-z]{2}-[A-Z]{2}\.md$", rel):
+            continue
+        out[rel] = p.read_text(encoding="utf-8", errors="replace")
+    return out
+
+
+async def _published_corpus(base: str) -> dict[str, str]:
+    async with httpx.AsyncClient(timeout=20) as client:
+        index = (await client.get(f"{base}/llms.txt")).text
+        paths = re.findall(rf"\({re.escape(base)}/([^)\s]+\.md)\)", index)
+        sem = asyncio.Semaphore(_FETCH_CONCURRENCY)
+
+        async def fetch(path: str) -> tuple[str, str]:
+            async with sem:
+                r = await client.get(f"{base}/{path}")
+                return path, (r.text if r.status_code == 200 else "")
+
+        pages = await asyncio.gather(*(fetch(p) for p in dict.fromkeys(paths)))
+    return {p: t for p, t in pages if t}
+
+
+async def corpus() -> dict[str, str]:
+    """{path: markdown}. Memoised per process, shared through Redis, so a
+    grep never costs 91 HTTP calls twice in an hour."""
+    base = docs_base_url_for_env().rstrip("/")
+    key = "disk" if not base else hashlib.sha1(base.encode()).hexdigest()[:12]
+    hit = _memo.get(key)
+    if hit and time.time() - hit[0] < CORPUS_TTL_SECONDS:
+        return hit[1]
+    async with _lock:
+        hit = _memo.get(key)
+        if hit and time.time() - hit[0] < CORPUS_TTL_SECONDS:
+            return hit[1]
+        data: dict[str, str] = {}
+        if not base:
+            root = _repo_docs_dir()
+            data = _disk_corpus(root) if root else {}
+        else:
+            redis_key = f"dembrane:knowledge:{key}"
+            try:
+                client = await get_redis_client()
+                raw = await client.get(redis_key)
+                if raw:
+                    data = json.loads(raw)
+            except Exception as exc:  # noqa: BLE001 — cache miss is not an error
+                logger.debug("knowledge cache read failed: %s", exc)
+            if not data:
+                try:
+                    data = await _published_corpus(base)
+                except Exception as exc:  # noqa: BLE001 — degrade to empty, never raise
+                    logger.warning("knowledge corpus fetch failed from %s: %s", base, exc)
+                    data = {}
+                if data:
+                    try:
+                        client = await get_redis_client()
+                        await client.set(redis_key, json.dumps(data), ex=CORPUS_TTL_SECONDS)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("knowledge cache write failed: %s", exc)
+        _memo[key] = (time.time(), data)
+        return data
+
+
+def _title(text: str, path: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return path
+
+
+async def list_docs() -> list[dict[str, str]]:
+    data = await corpus()
+    return [{"path": p, "title": _title(t, p)} for p, t in sorted(data.items())]
+
+
+async def read_doc(path: str, offset: int = 1, limit: int = MAX_READ_LINES) -> str:
+    data = await corpus()
+    text = data.get(path.strip().lstrip("/"))
+    if text is None:
+        return f"Not found: {path}. Use list_docs to see available paths."
+    lines = text.splitlines()
+    start = max(offset, 1)
+    end = min(start - 1 + max(1, min(limit, MAX_READ_LINES)), len(lines))
+    numbered = [f"{i}: {lines[i - 1]}" for i in range(start, end + 1)]
+    suffix = (
+        ""
+        if end >= len(lines)
+        else f"\n... ({len(lines) - end} more lines; call read_doc with offset={end + 1})"
+    )
+    return "\n".join(numbered) + suffix
+
+
+async def grep_docs(pattern: str, max_results: int = MAX_GREP_RESULTS) -> list[dict[str, Any]]:
+    data = await corpus()
+    try:
+        compiled = re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        compiled = re.compile(re.escape(pattern), re.IGNORECASE)
+    cap = max(1, min(max_results, MAX_GREP_RESULTS))
+    results: list[dict[str, Any]] = []
+    for path, text in sorted(data.items()):
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if compiled.search(line):
+                results.append({"path": path, "line": lineno, "text": line.strip()[:300]})
+                if len(results) >= cap:
+                    return results
+    return results

--- a/echo/server/tests/test_agent_access.py
+++ b/echo/server/tests/test_agent_access.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any
+from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -670,3 +671,59 @@ async def test_unknown_tool_is_audited_and_answered_with_a_hint(fake: FakeStore)
         "requested": "grep",
         "arguments": ["query"],
     }
+
+
+# ── documentation ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def docs_corpus() -> Any:
+    data = {
+        "users/host/index.md": "# For hosts\n\nCreate projects.\nRead transcripts here.\n",
+        "users/participant/index.md": "# For participants\n\nSomeone invited you.\nYour transcript is yours.\n",
+    }
+    with patch("dembrane.knowledge.corpus", new=AsyncMock(return_value=data)):
+        yield data
+
+
+@pytest.mark.asyncio
+async def test_docs_list_read_and_grep_follow_the_assistant_semantics(
+    docs_corpus: dict[str, str],
+) -> None:
+    from dembrane import knowledge
+
+    assert await knowledge.list_docs() == [
+        {"path": "users/host/index.md", "title": "For hosts"},
+        {"path": "users/participant/index.md", "title": "For participants"},
+    ]
+    text = await knowledge.read_doc("users/host/index.md", offset=1, limit=2)
+    assert text.startswith("1: # For hosts\n2: ") and "call read_doc with offset=3" in text
+    assert (await knowledge.read_doc("nope.md")).startswith("Not found: nope.md")
+    hits = await knowledge.grep_docs("transcript", max_results=10)
+    assert [(h["path"], h["line"]) for h in hits] == [
+        ("users/host/index.md", 4),
+        ("users/participant/index.md", 4),
+    ]
+    assert await knowledge.grep_docs("[unclosed", max_results=10) == []
+
+
+def test_disk_corpus_skips_authoring_and_translation_twins(tmp_path: Path) -> None:
+    from dembrane import knowledge
+
+    (tmp_path / "a.md").write_text("# A", encoding="utf-8")
+    (tmp_path / "a.nl-NL.md").write_text("# A nl", encoding="utf-8")
+    (tmp_path / "_authoring").mkdir()
+    (tmp_path / "_authoring" / "notes.md").write_text("# notes", encoding="utf-8")
+    assert list(knowledge._disk_corpus(tmp_path)) == ["a.md"]
+
+
+@pytest.mark.asyncio
+async def test_docs_tools_are_audited_and_need_no_org(
+    fake: FakeStore, docs_corpus: dict[str, str]
+) -> None:
+    app = _rest_app(_ctx(org_ids=[]))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+        r = await ac.get("/v2/agent/docs/search", params={"pattern": "invited"})
+    assert r.status_code == 200 and r.json()[0]["path"] == "users/participant/index.md"
+    assert fake.audit[-1]["tool"] == "search_docs" and fake.audit[-1]["status"] == "ok"
+    assert fake.usage == {}


### PR DESCRIPTION
list_docs, read_doc and search_docs read the published docs site (one markdown twin per page, cached an hour) with the same list, line-numbered read and regex grep the in-app assistant has. Public content, so no organisation check and no budget charge; every call is still audited.