### PR TITLE
docs: align button spec with the shipped styles

### DIFF
--- a/echo/brand/STYLE_GUIDE.md
+++ b/echo/brand/STYLE_GUIDE.md
@@ -162,27 +162,32 @@ Keep it simple. One or two font weights max. Let whitespace do the work.
 
 ## Buttons
 
+Only the primary button is pill-shaped. That shape is what marks the primary action on a screen, so secondary and tertiary keep standard corners.
+
 ### Primary
 
-- Default: Royal Blue background, white text, rounded corners
+- Default: Royal Blue background, white text, pill shape (fully rounded)
 - Hover: Graphite background
 - Click: Graphite background
+- Loading: Graphite background, white spinner
 
 ### Secondary
 
-- Default: Transparent with Royal Blue border, Royal Blue text
+- Default: Transparent with Royal Blue border, Royal Blue text, standard corners
 - Hover: 10% Royal Blue opacity fill
 - Click: 20% Royal Blue opacity fill
 
 ### Tertiary
 
-- Default: Text only, Royal Blue, no border
+- Default: Text only, Royal Blue, no border, standard corners
 - Hover: 10% Royal Blue opacity background
 - Click: 20% Royal Blue opacity background
 
 ### Disabled
 
-- Parchment background (darker), Graphite text at 50% opacity
+- Default: Gray background, Graphite text at full opacity. Disabled labels stay readable, never dimmed
+- Hover: 1px Golden Pollen border
+- Click: 1px Cotton Candy border
 
 ### Copy patterns
 

--- a/echo/docs/style-guides/frontend_button_design_system.md
+++ b/echo/docs/style-guides/frontend_button_design_system.md
@@ -71,7 +71,7 @@ This document describes the button design system implemented in the ECHO fronten
 
 ## Brand Colors
 
-All brand colors are defined in [`src/colors.ts`](../src/colors.ts) as the single source of truth.
+All brand colors are defined in [`frontend/src/colors.ts`](../../frontend/src/colors.ts) as the single source of truth.
 
 ### Available Colors
 
@@ -116,10 +116,10 @@ import { baseColors } from "@/colors";
 
 ### File Structure
 
-- **[`src/colors.ts`](../src/colors.ts)**: Single source of truth for all brand colors
-- **[`src/theme.tsx`](../src/theme.tsx)**: Mantine theme configuration with button defaults
-- **[`src/styles/button.module.css`](../src/styles/button.module.css)**: Custom button variant styles
-- **[`tailwind.config.js`](../../tailwind.config.js)**: Tailwind configuration with brand colors
+- **[`frontend/src/colors.ts`](../../frontend/src/colors.ts)**: Single source of truth for all brand colors
+- **[`frontend/src/theme.tsx`](../../frontend/src/theme.tsx)**: Mantine theme configuration with button defaults
+- **[`frontend/src/styles/button.module.css`](../../frontend/src/styles/button.module.css)**: Custom button variant styles
+- **[`frontend/tailwind.config.js`](../../frontend/tailwind.config.js)**: Tailwind configuration with brand colors
 
 ### How It Works
 
@@ -192,6 +192,6 @@ Test button states in development:
 ## Questions?
 
 For questions about the design system, refer to:
-- [Frontend Style Guides](../../docs/style-guides/)
-- [AGENTS.md](../AGENTS.md) for general frontend patterns
-- [COPY_GUIDE.md](../COPY_GUIDE.md) for button text guidelines
+- [Frontend style guides](./) for the other frontend conventions
+- [frontend/AGENTS.md](../../frontend/AGENTS.md) for general frontend patterns
+- [brand/STYLE_GUIDE.md](../../brand/STYLE_GUIDE.md) for button text guidelines


### PR DESCRIPTION
The button rules live in four places. Two of them had drifted from what the frontend actually ships.

## What was wrong

**Shape.** `brand/STYLE_GUIDE.md` described the primary button as "rounded corners". `button.module.css` gives `variant="filled"` a `border-radius: 9999px` pill, and explicitly keeps `outline` and `subtle` on standard corners. The pill is the signal that marks the primary action, so the guide now says so.

**Disabled state.** The guide specified a Parchment background with Graphite text at 50% opacity. The code uses a gray fill with Graphite text at full opacity (`opacity: 1` is set deliberately so the label stays readable), plus a 1px Golden Pollen border on hover and Cotton Candy on click. The guide now matches.

**Dead links.** Every relative link in `docs/style-guides/frontend_button_design_system.md` was broken, left over from when the file sat in `frontend/docs/`. They pointed at `../src/colors.ts` and friends, and one pointed at a `COPY_GUIDE.md` that does not exist. All of them now resolve, and the copy guidance points at `brand/STYLE_GUIDE.md` where it actually lives.

## What was left alone

`frontend_button_design_system.md` calls `#4169E1` "Institution Blue" while everything else calls it Royal Blue. Same hex, deliberately left as is.

Docs only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)